### PR TITLE
fix: Add exports field to dogfood package.json for runner subpath (#5)

### DIFF
--- a/dogfood/package.json
+++ b/dogfood/package.json
@@ -11,6 +11,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./runner": {
+      "types": "./dist/runner/index.d.ts",
+      "import": "./dist/runner/index.js"
     }
   },
   "scripts": {

--- a/dogfood/src/runner/exports.test.ts
+++ b/dogfood/src/runner/exports.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const PKG_ROOT = resolve(import.meta.dirname, '../..');
+const pkg = JSON.parse(readFileSync(resolve(PKG_ROOT, 'package.json'), 'utf-8'));
+
+describe('package.json exports', () => {
+  it('has a root "." export with types and import', () => {
+    expect(pkg.exports['.']).toEqual({
+      types: './dist/index.d.ts',
+      import: './dist/index.js',
+    });
+  });
+
+  it('has a "./runner" subpath export with types and import', () => {
+    expect(pkg.exports['./runner']).toEqual({
+      types: './dist/runner/index.d.ts',
+      import: './dist/runner/index.js',
+    });
+  });
+
+  it('dist files referenced by "./runner" export exist', () => {
+    const runnerExport = pkg.exports['./runner'];
+    expect(existsSync(resolve(PKG_ROOT, runnerExport.types))).toBe(true);
+    expect(existsSync(resolve(PKG_ROOT, runnerExport.import))).toBe(true);
+  });
+
+  it('runner subpath re-exports expected symbols', async () => {
+    const runner = await import(resolve(PKG_ROOT, pkg.exports['./runner'].import));
+    expect(runner.GitHubActionsRunner).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

All tasks are complete. Here's a summary of the changes:

**Files changed (2):**

1. **`dogfood/package.json`** — Added a `"./runner"` subpath export pointing to `dist/runner/index.js` (import) and `dist/runner/index.d.ts` (types). This enables consumers to do:
   ```ts
   import { AgentRunner } from '@ai-sdlc/dogfood/runner';
   ```

2. **`dogfood/src/runner/exports.test.ts`** (new) — Added 4 tests verifying:
   - The root `"."` export is configured correctly
   - The `"./runner"` subpath export has correct `types` and `import` entries
   - The dist files referenced by the `"./runner"` export exist on disk
   - The runner subpath re-exports the expected `GitHubActionsRunner` symbol

**Verification:**
- `pnpm build` completes cleanly across all workspace packages
- All 24 tests pass (20 existing + 4 new)


## Changes

- `dogfood/package.json`
- `dogfood/src/runner/exports.test.ts`

Closes #5

---
*This PR was generated by [AI-SDLC](https://github.com/ai-sdlc-framework/ai-sdlc) dogfood pipeline.*