### PR TITLE
fix: Export loadConfigAsync and startWatch from orchestrator barrel file (#9)

### DIFF
--- a/dogfood/src/orchestrator/barrel-exports.test.ts
+++ b/dogfood/src/orchestrator/barrel-exports.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import * as barrel from './index.js';
+
+describe('orchestrator barrel exports', () => {
+  it('exports loadConfigAsync', () => {
+    expect(barrel.loadConfigAsync).toBeTypeOf('function');
+  });
+
+  it('exports startWatch', () => {
+    expect(barrel.startWatch).toBeTypeOf('function');
+  });
+
+  it('exports parsePipelineManifest', () => {
+    expect(barrel.parsePipelineManifest).toBeTypeOf('function');
+  });
+
+  it('exports buildPipelineDistribution', () => {
+    expect(barrel.buildPipelineDistribution).toBeTypeOf('function');
+  });
+
+  it('continues to export loadConfig', () => {
+    expect(barrel.loadConfig).toBeTypeOf('function');
+  });
+});

--- a/dogfood/src/orchestrator/index.ts
+++ b/dogfood/src/orchestrator/index.ts
@@ -1,4 +1,4 @@
-export { loadConfig, type AiSdlcConfig } from './load-config.js';
+export { loadConfig, loadConfigAsync, type AiSdlcConfig } from './load-config.js';
 export { validateIssue, validateIssueWithExtensions, parseComplexity } from './validate-issue.js';
 export {
   executePipeline,
@@ -92,8 +92,16 @@ export {
   AdapterBindingBuilder,
   parseBuilderManifest,
   validateBuilderManifest,
+  parsePipelineManifest,
+  buildPipelineDistribution,
   API_VERSION,
+  type BuilderManifest,
+  type BuildDistributionOptions,
+  type DistributionBuildResult,
 } from './builders.js';
+
+// Watch mode
+export { startWatch, type WatchOptions, type WatchHandle } from './watch.js';
 
 // Agent orchestration
 export {


### PR DESCRIPTION
## Summary

Here's a summary of the changes made:

**File modified: `dogfood/src/orchestrator/index.ts`**
- Added `loadConfigAsync` to the existing `./load-config.js` export line (line 1)
- Added `parsePipelineManifest`, `buildPipelineDistribution`, and their associated types (`BuilderManifest`, `BuildDistributionOptions`, `DistributionBuildResult`) to the `./builders.js` export block (lines 95-100)
- Added a new "Watch mode" section exporting `startWatch`, `WatchOptions`, and `WatchHandle` from `./watch.js` (lines 103-104)

**File created: `dogfood/src/orchestrator/barrel-exports.test.ts`**
- Tests that `loadConfigAsync`, `startWatch`, `parsePipelineManifest`, `buildPipelineDistribution`, and `loadConfig` are all exported as functions from the barrel file

All 354 tests pass, lint is clean, format is clean, and the build succeeds with no type errors.

## Changes

- `dogfood/src/orchestrator/index.ts`
- `dogfood/src/orchestrator/barrel-exports.test.ts`

Closes #9

---
*This PR was generated by [AI-SDLC](https://github.com/ai-sdlc-framework/ai-sdlc) dogfood pipeline.*


## Provenance

- **Model**: claude-opus-4-6
- **Tool**: claude-code
- **Prompt Hash**: `81fd8ada2c038409`
- **Timestamp**: 2026-02-09T22:21:59.641Z
- **Review Status**: pending

<!-- provenance-annotations
ai-sdlc.io/provenance-model: claude-opus-4-6
ai-sdlc.io/provenance-tool: claude-code
ai-sdlc.io/provenance-promptHash: 81fd8ada2c038409
ai-sdlc.io/provenance-timestamp: 2026-02-09T22:21:59.641Z
ai-sdlc.io/provenance-reviewDecision: pending
-->