### PR TITLE
fix: Add PriorityScore type export to SDK TypeScript barrel (#29)

### DIFF
--- a/orchestrator/src/priority.ts
+++ b/orchestrator/src/priority.ts
@@ -11,91 +11,11 @@
  * RFC reference: PPA section (priority scoring).
  */
 
-// ── Types ───────────────────────────────────────────────────────────
+import type { PriorityScore, PriorityInput, PriorityConfig } from '@ai-sdlc/reference';
 
-export interface PriorityScore {
-  composite: number;
-  dimensions: {
-    soulAlignment: number; // Sα  [0, 1]
-    demandPressure: number; // Dπ  [0, 1.5]
-    marketForce: number; // Mφ  [0.5, 3.0] (bounded, not [0.025, 45])
-    executionReality: number; // Eρ  [0, 1]
-    entropyTax: number; // Eτ  [0, 1]
-    humanCurve: number; // HC  [-1, 1]
-    calibration: number; // Cκ  [0.7, 1.3]
-  };
-  confidence: number; // [0, 1]
-  timestamp: string;
-  /** Present when the score was produced via override. */
-  override?: { reason: string; expiry?: string };
-}
+// ── Re-export types ─────────────────────────────────────────────────
 
-export interface PriorityInput {
-  /** Work item identifier */
-  itemId: string;
-  /** Work item title and description for semantic analysis */
-  title: string;
-  description: string;
-  /** Labels/tags on the work item */
-  labels?: string[];
-
-  // Soul Alignment inputs
-  /** Pre-computed soul alignment score, or undefined to skip */
-  soulAlignment?: number;
-
-  // Demand Pressure inputs
-  /** Number of customer requests for this feature */
-  customerRequestCount?: number;
-  /** Recency-weighted demand signal [0, 1] */
-  demandSignal?: number;
-  /** Bug severity if this is a bug (1-5, 5=critical) */
-  bugSeverity?: number;
-  /** Builder conviction / roadmap priority [0, 1] */
-  builderConviction?: number;
-
-  // Market Force inputs
-  /** Technology inflection relevance [0, 1] */
-  techInflection?: number;
-  /** Competitive pressure relevance [0, 1] */
-  competitivePressure?: number;
-  /** Regulatory urgency [0, 1] */
-  regulatoryUrgency?: number;
-
-  // Execution Reality inputs (from AI-SDLC)
-  /** Task complexity from parseComplexity() (1-10) */
-  complexity?: number;
-  /** Budget utilization percent from CostTracker */
-  budgetUtilization?: number;
-  /** Are dependencies clear? [0, 1] */
-  dependencyClearance?: number;
-
-  // Entropy Tax inputs
-  /** Competitive drift score [0, 1] */
-  competitiveDrift?: number;
-  /** Market divergence [0, 1] */
-  marketDivergence?: number;
-
-  // Human Curve inputs
-  /** Explicit priority from backlog tool [0, 1] */
-  explicitPriority?: number;
-  /** Team consensus signal (votes, watchers) [0, 1] */
-  teamConsensus?: number;
-  /** Meeting decision weight [0, 1] */
-  meetingDecision?: number;
-  /** Override flag — if true, bypasses algorithm */
-  override?: boolean;
-  /** Override reason (required when override=true) */
-  overrideReason?: string;
-  /** Override expiry ISO timestamp */
-  overrideExpiry?: string;
-}
-
-export interface PriorityConfig {
-  /** Weights for human curve sub-components */
-  humanCurveWeights?: { explicit?: number; consensus?: number; decision?: number };
-  /** Calibration coefficient (default 1.0) */
-  calibrationCoefficient?: number;
-}
+export type { PriorityScore, PriorityInput, PriorityConfig };
 
 // ── Constants ───────────────────────────────────────────────────────
 

--- a/reference/src/core/types.ts
+++ b/reference/src/core/types.ts
@@ -147,6 +147,53 @@ export interface PriorityPolicy {
   adapters?: PriorityAdaptersConfig;
 }
 
+export interface PriorityScore {
+  composite: number;
+  dimensions: {
+    soulAlignment: number;
+    demandPressure: number;
+    marketForce: number;
+    executionReality: number;
+    entropyTax: number;
+    humanCurve: number;
+    calibration: number;
+  };
+  confidence: number;
+  timestamp: string;
+  override?: { reason: string; expiry?: string };
+}
+
+export interface PriorityInput {
+  itemId: string;
+  title: string;
+  description: string;
+  labels?: string[];
+  soulAlignment?: number;
+  customerRequestCount?: number;
+  demandSignal?: number;
+  bugSeverity?: number;
+  builderConviction?: number;
+  techInflection?: number;
+  competitivePressure?: number;
+  regulatoryUrgency?: number;
+  complexity?: number;
+  budgetUtilization?: number;
+  dependencyClearance?: number;
+  competitiveDrift?: number;
+  marketDivergence?: number;
+  explicitPriority?: number;
+  teamConsensus?: number;
+  meetingDecision?: number;
+  override?: boolean;
+  overrideReason?: string;
+  overrideExpiry?: string;
+}
+
+export interface PriorityConfig {
+  humanCurveWeights?: { explicit?: number; consensus?: number; decision?: number };
+  calibrationCoefficient?: number;
+}
+
 export interface ModelRule {
   complexity: [number, number];
   model: string;

--- a/sdk-typescript/src/core.ts
+++ b/sdk-typescript/src/core.ts
@@ -39,6 +39,9 @@ export {
   type PriorityDimensionsConfig,
   type PriorityCalibrationConfig,
   type PriorityAdaptersConfig,
+  type PriorityScore,
+  type PriorityInput,
+  type PriorityConfig,
   API_VERSION,
 
   // Validation

--- a/sdk-typescript/src/exports.test.ts
+++ b/sdk-typescript/src/exports.test.ts
@@ -15,6 +15,10 @@ describe('SDK subpath exports', () => {
     expect(mod.exceedsSeverity).toBeTypeOf('function');
     expect(mod.createProvenance).toBeTypeOf('function');
     expect(mod.PROVENANCE_ANNOTATION_PREFIX).toBeTypeOf('string');
+
+    // Verify PriorityScore, PriorityInput, PriorityConfig types are exported
+    // Type-only exports can't be verified at runtime, but we can check the module imports
+    expect(mod).toBeDefined();
   });
 
   it('builders exports all 5 resource builders + distribution', async () => {

--- a/sdk-typescript/src/type-check.test.ts
+++ b/sdk-typescript/src/type-check.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import type { PriorityScore, PriorityInput, PriorityConfig } from './core.js';
+
+/**
+ * Type-checking test to verify PriorityScore, PriorityInput, and PriorityConfig
+ * are properly exported from @ai-sdlc/sdk/core
+ */
+describe('Priority types from core', () => {
+  it('PriorityScore type is available', () => {
+    const score: PriorityScore = {
+      composite: 1.5,
+      dimensions: {
+        soulAlignment: 0.9,
+        demandPressure: 1.2,
+        marketForce: 1.5,
+        executionReality: 0.8,
+        entropyTax: 0.1,
+        humanCurve: 0.5,
+        calibration: 1.0,
+      },
+      confidence: 0.85,
+      timestamp: '2024-01-01T00:00:00Z',
+    };
+    expect(score.composite).toBe(1.5);
+  });
+
+  it('PriorityInput type is available', () => {
+    const input: PriorityInput = {
+      itemId: 'test-1',
+      title: 'Test Issue',
+      description: 'Test description',
+      complexity: 5,
+    };
+    expect(input.itemId).toBe('test-1');
+  });
+
+  it('PriorityConfig type is available', () => {
+    const config: PriorityConfig = {
+      calibrationCoefficient: 1.1,
+      humanCurveWeights: {
+        explicit: 0.5,
+        consensus: 0.3,
+        decision: 0.2,
+      },
+    };
+    expect(config.calibrationCoefficient).toBe(1.1);
+  });
+});


### PR DESCRIPTION
## Summary

Excellent! Let me create a comprehensive summary of the changes:

## Summary

I've successfully fixed issue #29 by adding the `PriorityScore`, `PriorityInput`, and `PriorityConfig` type exports to the SDK TypeScript barrel.

### Changes Made (5 files):

1. **reference/src/core/types.ts**: Added the three runtime type definitions alongside the existing `PriorityPolicy` type
2. **sdk-typescript/src/core.ts**: Added re-exports for `PriorityScore`, `PriorityInput`, and `PriorityConfig`
3. **orchestrator/src/priority.ts**: Updated to import these types from `@ai-sdlc/reference` instead of defining them locally (avoiding duplication)
4. **sdk-typescript/src/exports.test.ts**: Updated with a comment about type exports
5. **sdk-typescript/src/type-check.test.ts**: Added new test file to verify the types can be imported and used

### Acceptance Criteria - All Met ✓

- ✅ `PriorityScore` is re-exported from `@ai-sdlc/sdk/core`
- ✅ `PriorityInput` is re-exported from `@ai-sdlc/sdk/core`
- ✅ `PriorityConfig` is re-exported from `@ai-sdlc/sdk/core`
- ✅ Existing exports test continues to pass

### Test Results

- **Reference package**: 980 tests passed
- **SDK package**: 15 tests passed (including 3 new type-checking tests)
- **Orchestrator priority tests**: 41 tests passed
- **Files changed**: 5 (well within the 15 file limit)

The types are now properly available for SDK consumers to use when calling `computePriority()` from the orchestrator package.

## Changes

- `orchestrator/src/priority.ts`
- `reference/src/core/types.ts`
- `sdk-typescript/src/core.ts`
- `sdk-typescript/src/exports.test.ts`
- `sdk-typescript/src/type-check.test.ts`

Closes #29

---
*This PR was generated by [AI-SDLC](https://github.com/ai-sdlc-framework/ai-sdlc).*


## Provenance

- **Model**: claude-sonnet-4-5-20250929
- **Tool**: claude-code
- **Prompt Hash**: `67163031e06d91c3`
- **Timestamp**: 2026-03-25T16:32:45.620Z
- **Review Status**: pending

<!-- provenance-annotations
ai-sdlc.io/provenance-model: claude-sonnet-4-5-20250929
ai-sdlc.io/provenance-tool: claude-code
ai-sdlc.io/provenance-promptHash: 67163031e06d91c3
ai-sdlc.io/provenance-timestamp: 2026-03-25T16:32:45.620Z
ai-sdlc.io/provenance-reviewDecision: pending
-->