### PR TITLE
feat: add marketplace.json for plugin installation from GitHub

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "ai-sdlc",
+  "owner": {
+    "name": "AI-SDLC Framework",
+    "url": "https://ai-sdlc.io"
+  },
+  "plugins": [
+    {
+      "name": "ai-sdlc",
+      "source": "./ai-sdlc-plugin",
+      "description": "AI-SDLC governance framework for Claude Code — action enforcement, telemetry, quality gates, review agents, and MCP tools",
+      "version": "0.7.0"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -174,7 +174,14 @@ Promotion requires meeting quantitative criteria (PR approval rate, rollback rat
 Install the AI-SDLC governance plugin for zero-config enforcement in Claude Code:
 
 ```bash
-claude --plugin-dir ./ai-sdlc-plugin
+# Add the AI-SDLC marketplace
+/plugin marketplace add --source github --repo ai-sdlc-framework/ai-sdlc
+
+# Install the plugin
+/plugin install ai-sdlc@ai-sdlc
+
+# Reload to activate
+/reload-plugins
 ```
 
 The plugin provides:


### PR DESCRIPTION
## Summary

Adds `.claude-plugin/marketplace.json` at the repo root so users can install the AI-SDLC plugin directly from GitHub:

```
/plugin marketplace add --source github --repo ai-sdlc-framework/ai-sdlc
/plugin install ai-sdlc@ai-sdlc
/reload-plugins
```

Updates README install instructions from `claude --plugin-dir` (dev-only) to the marketplace commands (user-facing).

## Test plan
- [ ] Run `/plugin marketplace add --source github --repo ai-sdlc-framework/ai-sdlc` in Claude Code
- [ ] Run `/plugin install ai-sdlc@ai-sdlc` and verify plugin loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)