### PR TITLE
fix: correct plugin marketplace add syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Install the AI-SDLC governance plugin for zero-config enforcement in Claude Code
 
 ```bash
 # Add the AI-SDLC marketplace
-/plugin marketplace add --source github --repo ai-sdlc-framework/ai-sdlc
+/plugin marketplace add ai-sdlc-framework/ai-sdlc
 
 # Install the plugin
 /plugin install ai-sdlc@ai-sdlc


### PR DESCRIPTION
## Summary

Fixes the install command from:
```
/plugin marketplace add --source github --repo ai-sdlc-framework/ai-sdlc
```

To:
```
/plugin marketplace add ai-sdlc-framework/ai-sdlc
```

The CLI takes `owner/repo` directly, not `--source`/`--repo` flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)