### PR TITLE
fix: coverage hook uses test:coverage script for turbo compatibility

### DIFF
--- a/ai-sdlc-plugin/hooks/deferred-coverage-check.js
+++ b/ai-sdlc-plugin/hooks/deferred-coverage-check.js
@@ -37,9 +37,30 @@ const projectDir =
   })();
 
 // ── Detect package manager and coverage command ──────────────────────
+// Prefer the dedicated test:coverage script (works with turbo, nx, etc.).
+// Fall back to passing --coverage via -- passthrough only if no dedicated script exists.
 
 let coverageCmd;
-if (existsSync(join(projectDir, 'pnpm-lock.yaml'))) {
+
+function hasScript(scriptName) {
+  try {
+    const pkg = JSON.parse(readFileSync(join(projectDir, 'package.json'), 'utf-8'));
+    return !!(pkg.scripts && pkg.scripts[scriptName]);
+  } catch {
+    return false;
+  }
+}
+
+if (hasScript('test:coverage')) {
+  // Dedicated coverage script — works with any task runner (turbo, nx, pnpm, etc.)
+  if (existsSync(join(projectDir, 'pnpm-lock.yaml'))) {
+    coverageCmd = 'pnpm test:coverage';
+  } else if (existsSync(join(projectDir, 'yarn.lock'))) {
+    coverageCmd = 'yarn test:coverage';
+  } else {
+    coverageCmd = 'npm run test:coverage';
+  }
+} else if (existsSync(join(projectDir, 'pnpm-lock.yaml'))) {
   coverageCmd = 'pnpm test -- --coverage --reporter=json';
 } else if (existsSync(join(projectDir, 'yarn.lock'))) {
   coverageCmd = 'yarn test --coverage --json';


### PR DESCRIPTION
## Summary

- Fixes the deferred-coverage-check hook that blocked users with turborepo: `pnpm test -- --coverage` fails because turbo doesn't accept `--coverage` as a direct argument
- Now prefers the dedicated `test:coverage` script from package.json (works with any task runner), falling back to `-- --coverage` passthrough only when no dedicated script exists

## Test plan

- [x] Users with turborepo no longer see "unexpected argument '--coverage'" on Stop hook
- [x] Projects with `test:coverage` script use it directly
- [x] Projects without `test:coverage` fall back to existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)