### PR TITLE
feat: harden plugin hooks for coverage, turbo, and .env

### DIFF
--- a/ai-sdlc-plugin/hooks/deferred-coverage-check.js
+++ b/ai-sdlc-plugin/hooks/deferred-coverage-check.js
@@ -6,7 +6,7 @@
  * which wakes the model via Claude Code's asyncRewake mechanism.
  *
  * Exit codes:
- *   0 = coverage OK or no coverage tool available
+ *   0 = coverage OK, no coverage tool available, or skipped
  *   2 = coverage below threshold (blocking — wakes the model)
  */
 
@@ -36,23 +36,71 @@ const projectDir =
     }
   })();
 
-// ── Detect package manager and coverage command ──────────────────────
-// Prefer the dedicated test:coverage script (works with turbo, nx, etc.).
-// Fall back to passing --coverage via -- passthrough only if no dedicated script exists.
+// ── Helpers ──────────────────────────────────────────────────────────
 
-let coverageCmd;
-
-function hasScript(scriptName) {
+function readPkg() {
   try {
-    const pkg = JSON.parse(readFileSync(join(projectDir, 'package.json'), 'utf-8'));
-    return !!(pkg.scripts && pkg.scripts[scriptName]);
+    return JSON.parse(readFileSync(join(projectDir, 'package.json'), 'utf-8'));
   } catch {
-    return false;
+    return {};
   }
 }
 
+function hasScript(name) {
+  const pkg = readPkg();
+  return !!(pkg.scripts && pkg.scripts[name]);
+}
+
+function hasDep(name) {
+  const pkg = readPkg();
+  return !!(pkg.dependencies?.[name] || pkg.devDependencies?.[name]);
+}
+
+function usesTaskRunner() {
+  return existsSync(join(projectDir, 'turbo.json')) || existsSync(join(projectDir, 'nx.json'));
+}
+
+// ── Load coverage config (.ai-sdlc/coverage-config.yaml) ────────────
+
+let coverageConfig = {};
+try {
+  const configPath = join(projectDir, '.ai-sdlc', 'coverage-config.yaml');
+  if (existsSync(configPath)) {
+    const raw = readFileSync(configPath, 'utf-8');
+    // Lightweight YAML parse for simple key: value and list fields
+    const excludeMatch = raw.match(/excludeWorkspaces:\s*\n((?:\s+-\s+.+\n?)+)/);
+    if (excludeMatch) {
+      coverageConfig.excludeWorkspaces = excludeMatch[1]
+        .split('\n')
+        .map((l) => l.replace(/^\s+-\s+/, '').trim())
+        .filter(Boolean);
+    }
+    const timeoutMatch = raw.match(/maxDurationMs:\s*(\d+)/);
+    if (timeoutMatch) {
+      coverageConfig.maxDurationMs = parseInt(timeoutMatch[1], 10);
+    }
+  }
+} catch {
+  // Non-critical — use defaults
+}
+
+const maxDurationMs = coverageConfig.maxDurationMs || 120000;
+const excludeWorkspaces = coverageConfig.excludeWorkspaces || [];
+
+// ── Check if coverage provider is available ─────────────────────────
+
+if (hasDep('vitest') && !hasDep('@vitest/coverage-v8') && !hasDep('@vitest/coverage-istanbul')) {
+  // Coverage provider not installed — skip gracefully
+  process.exit(0);
+}
+
+// ── Detect coverage command ─────────────────────────────────────────
+// Priority: dedicated test:coverage > -- passthrough with turbo awareness
+
+let coverageCmd;
+
 if (hasScript('test:coverage')) {
-  // Dedicated coverage script — works with any task runner (turbo, nx, pnpm, etc.)
+  // Dedicated script — works with any task runner
   if (existsSync(join(projectDir, 'pnpm-lock.yaml'))) {
     coverageCmd = 'pnpm test:coverage';
   } else if (existsSync(join(projectDir, 'yarn.lock'))) {
@@ -60,18 +108,29 @@ if (hasScript('test:coverage')) {
   } else {
     coverageCmd = 'npm run test:coverage';
   }
+} else if (usesTaskRunner()) {
+  // Turbo/nx detected but no test:coverage script — skip rather than fail.
+  // Can't safely pass --coverage through a task runner.
+  process.exit(0);
 } else if (existsSync(join(projectDir, 'pnpm-lock.yaml'))) {
-  coverageCmd = 'pnpm test -- --coverage --reporter=json';
+  coverageCmd = 'pnpm test -- --coverage';
 } else if (existsSync(join(projectDir, 'yarn.lock'))) {
-  coverageCmd = 'yarn test --coverage --json';
+  coverageCmd = 'yarn test --coverage';
 } else if (existsSync(join(projectDir, 'package-lock.json'))) {
-  coverageCmd = 'npm test -- --coverage --json';
+  coverageCmd = 'npm test -- --coverage';
 } else {
-  // No recognized package manager — skip
   process.exit(0);
 }
 
-// ── Check if any code was modified in this session ───────────────────
+// ── Apply workspace exclusions ──────────────────────────────────────
+
+if (excludeWorkspaces.length > 0 && coverageCmd.startsWith('pnpm')) {
+  // For pnpm workspaces, add --filter to exclude listed packages
+  const filters = excludeWorkspaces.map((ws) => `--filter '!${ws}'`).join(' ');
+  coverageCmd = coverageCmd.replace('pnpm ', `pnpm ${filters} `);
+}
+
+// ── Check if any source code was modified ───────────────────────────
 
 try {
   const diff = execSync('git diff --name-only HEAD~1 2>/dev/null || echo ""', {
@@ -80,11 +139,9 @@ try {
   }).trim();
 
   if (!diff) {
-    // No changes to check coverage for
     process.exit(0);
   }
 
-  // Only check if source files were modified (not just config/docs)
   const sourceFiles = diff
     .split('\n')
     .filter(
@@ -95,7 +152,6 @@ try {
     process.exit(0);
   }
 } catch {
-  // Can't detect changes — skip
   process.exit(0);
 }
 
@@ -105,60 +161,83 @@ try {
   execSync(coverageCmd, {
     cwd: projectDir,
     encoding: 'utf-8',
-    timeout: 120000, // 2 min max
+    timeout: maxDurationMs,
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
-  // Tests passed — coverage is acceptable
   process.exit(0);
 } catch (err) {
-  // Tests failed or coverage below threshold
   const stderr = err.stderr || '';
   const stdout = err.stdout || '';
   const combined = stderr + stdout;
 
   // ── Missing coverage provider — skip gracefully ────────────
-  // If @vitest/coverage-v8 (or c8, istanbul, etc.) isn't installed,
-  // the coverage command fails with a "cannot find" error. This is
-  // the user's project config, not an agent failure — don't block.
   const missingProviderPatterns = [
     /Cannot find package '@vitest\/coverage/i,
     /Cannot find module '@vitest\/coverage/i,
     /Failed to load coverage provider/i,
+    /Failed to load url.*@vitest\/coverage/i,
     /coverage provider.*not found/i,
     /ERR_MODULE_NOT_FOUND.*coverage/i,
     /unexpected argument ['"]?--coverage/i,
   ];
 
   if (missingProviderPatterns.some((p) => p.test(combined))) {
-    // Coverage tooling not available in this project — skip silently
     process.exit(0);
   }
 
-  // ── Parse coverage results if available ────────────────────
+  // ── Timeout — exit gracefully with advisory ────────────────
+  if (err.killed || (err.signal && err.signal === 'SIGTERM')) {
+    process.exit(0);
+  }
+
+  // ── Parse coverage results ─────────────────────────────────
   const coverageMatch = stdout.match(/All files\s*\|\s*([\d.]+)/);
   const threshold = 80;
 
   if (coverageMatch) {
     const coverage = parseFloat(coverageMatch[1]);
     if (coverage < threshold) {
+      // Identify which packages are below threshold
+      const packageMatch = stdout.match(/^(\S+)\s*\|\s*([\d.]+)/gm);
+      const lowPackages = [];
+      if (packageMatch) {
+        for (const line of packageMatch) {
+          const m = line.match(/^(\S+)\s*\|\s*([\d.]+)/);
+          if (m && parseFloat(m[2]) < threshold) {
+            lowPackages.push(`${m[1]} (${m[2]}%)`);
+          }
+        }
+      }
+
+      const detail = lowPackages.length > 0 ? ` Low coverage in: ${lowPackages.join(', ')}.` : '';
       process.stderr.write(
-        `AI-SDLC Coverage Check: Overall coverage is ${coverage}% (threshold: ${threshold}%).\n` +
-          `Please add tests to improve coverage before stopping.\n`,
+        `AI-SDLC Coverage: ${coverage}% overall (threshold: ${threshold}%).${detail} Please add tests.\n`,
       );
       process.exit(2);
     }
-    // Coverage above threshold — pass
     process.exit(0);
   }
 
-  // ── Test failures (not coverage-related) — report ──────────
+  // ── Test failures — one-line actionable message ────────────
   if (err.status !== 0) {
-    process.stderr.write(
-      `AI-SDLC Coverage Check: Test suite failed.\n` +
-        `${stderr.slice(0, 500)}\n` +
-        `Please fix failing tests before stopping.\n`,
-    );
+    // Try to extract the failing package/test name
+    const failedSuite = combined.match(/FAIL\s+(\S+)/);
+    const failedPkg = combined.match(/ERR_PNPM.*?(\S+@\S+)/);
+    const failCount = combined.match(/(\d+)\s+failed/);
+
+    let summary = 'AI-SDLC Coverage: Tests failed.';
+    if (failedPkg) {
+      summary = `AI-SDLC Coverage: Tests failed in ${failedPkg[1]}.`;
+    } else if (failedSuite) {
+      summary = `AI-SDLC Coverage: Test failed: ${failedSuite[1]}.`;
+    }
+    if (failCount) {
+      summary += ` ${failCount[1]} test(s) failing.`;
+    }
+    summary += ' Please fix before stopping.\n';
+
+    process.stderr.write(summary);
     process.exit(2);
   }
 

--- a/ai-sdlc-plugin/hooks/session-start.js
+++ b/ai-sdlc-plugin/hooks/session-start.js
@@ -57,6 +57,65 @@ const requireTests = extractField(yaml, 'requireTests') || 'true';
 const blockedActions = parseListField(yaml, 'blockedActions');
 const blockedPaths = parseListField(yaml, 'blockedPaths');
 
+// ── Detect missing dev tools ─────────────────────────────────────────
+
+const warnings = [];
+
+// Check for vitest without coverage provider
+try {
+  const pkgPath = join(projectDir, 'package.json');
+  if (existsSync(pkgPath)) {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+    if (
+      allDeps['vitest'] &&
+      !allDeps['@vitest/coverage-v8'] &&
+      !allDeps['@vitest/coverage-istanbul']
+    ) {
+      warnings.push(
+        '⚠ vitest detected without coverage provider. Run: `pnpm add -D -w @vitest/coverage-v8`',
+      );
+    }
+  }
+} catch {
+  // Non-critical — skip
+}
+
+// Check for .env issues (AISDLC-36)
+try {
+  const envFiles = ['.env', '.env.local'].map((f) => join(projectDir, f)).filter(existsSync);
+  for (const envFile of envFiles) {
+    const lines = readFileSync(envFile, 'utf-8').split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (!line || line.startsWith('#')) continue;
+      // Spaces in key
+      if (/^[A-Za-z_]+ [A-Za-z_]/.test(line) && line.includes('=')) {
+        warnings.push(`⚠ ${envFile}:${i + 1}: key contains spaces — will cause parse errors`);
+        break;
+      }
+      // Unbalanced quotes
+      const afterEq = line.split('=').slice(1).join('=');
+      if (
+        (afterEq.startsWith('"') && !afterEq.endsWith('"')) ||
+        (afterEq.startsWith("'") && !afterEq.endsWith("'"))
+      ) {
+        warnings.push(`⚠ ${envFile}:${i + 1}: unbalanced quotes — will cause parse errors`);
+        break;
+      }
+      // Leading bullet
+      if (/^[-*]\s/.test(line)) {
+        warnings.push(
+          `⚠ ${envFile}:${i + 1}: looks like a list item, not an env var — add # to comment out`,
+        );
+        break;
+      }
+    }
+  }
+} catch {
+  // Non-critical — skip
+}
+
 // ── Load review policy if present ────────────────────────────────────
 
 let reviewPolicySummary = '';
@@ -96,6 +155,10 @@ Before EVERY commit, run these and fix any failures:
 **NEVER merge PRs. Only humans merge.**
 **NEVER close issues or PRs.**
 **NEVER force push.**${reviewPolicySummary}`;
+
+if (warnings.length > 0) {
+  context += `\n\n### Setup Warnings\n${warnings.join('\n')}`;
+}
 
 // ── Output ───────────────────────────────────────────────────────────
 

--- a/ai-sdlc-plugin/plugin.json
+++ b/ai-sdlc-plugin/plugin.json
@@ -61,7 +61,11 @@
             "model": "claude-haiku-4-5-20251001",
             "timeout": 45,
             "statusMessage": "Running governance quality gates..."
-          },
+          }
+        ]
+      },
+      {
+        "hooks": [
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/deferred-coverage-check.sh\"",


### PR DESCRIPTION
## Summary

Six friction-point fixes for the AI-SDLC plugin, all reported from real user sessions:

- **AISDLC-31**: Session-start detects vitest without `@vitest/coverage-v8` and emits remediation advice. Coverage hook also pre-checks before running.
- **AISDLC-32**: Coverage hook detects `turbo.json`/`nx.json` and skips gracefully when no `test:coverage` script exists (can't safely pass `--coverage` through turbo).
- **AISDLC-33**: Moved coverage hook into its own Stop entry in `plugin.json` so `asyncRewake` runs independently of synchronous quality gate hooks.
- **AISDLC-34**: Coverage hook reads `.ai-sdlc/coverage-config.yaml` for `excludeWorkspaces` (skip named packages) and `maxDurationMs` (graceful timeout).
- **AISDLC-35**: Error messages are one-line actionable summaries instead of raw stderr dumps.
- **AISDLC-36**: Session-start scans `.env`/`.env.local` for spaces in keys, unbalanced quotes, and leading bullets. Emits advisory warnings.

## Test plan

- [x] Project without `@vitest/coverage-v8` — session-start warns, coverage hook skips
- [x] Project with turbo.json and no `test:coverage` script — coverage hook skips
- [x] Coverage hook in its own Stop entry — asyncRewake independent of quality gate
- [x] `.ai-sdlc/coverage-config.yaml` with `excludeWorkspaces` — listed packages skipped
- [x] Coverage failure produces one-line message with package name and threshold
- [x] `.env` with spaces in keys — session-start emits advisory warning
- [x] All existing tests pass (3,551)

🤖 Generated with [Claude Code](https://claude.com/claude-code)