### PR TITLE
feat: rewrite plugin skills to call orchestrator (triage + review + fix-pr + status)

### DIFF
--- a/ai-sdlc-plugin/commands/fix-pr.md
+++ b/ai-sdlc-plugin/commands/fix-pr.md
@@ -1,79 +1,114 @@
 ---
 name: fix-pr
-description: Automatically fix CI failures, review findings, and coverage issues on a PR
+description: Fix CI failures and review findings on a PR by chaining cli-fix-ci + cli-fix-review
 argument-hint: <pr-number>
+allowed-tools: Read, Grep, Glob, Bash
 ---
 
-Fix all issues on PR #$ARGUMENTS. Follow these steps exactly:
+Fix PR #$ARGUMENTS by chaining `@ai-sdlc/orchestrator`'s `executeFixCI()`
+and `executeFixReview()` in priority order. Both already implement
+retry tracking via `RETRY_MARKER` comments (capped at
+`MAX_FIX_ATTEMPTS = 3` and `MAX_REVIEW_FIX_ATTEMPTS = 2`), branch-name
+sanitization, and PR-number validation — this skill's job is to wire
+them up, not reimplement the recipe.
 
-## Step 1: Gather PR context
+## Step 1 — Gather PR context
 
-Run these commands to collect all failure information:
-
-```bash
-# Get PR details
-gh pr view $ARGUMENTS --repo ai-sdlc-framework/ai-sdlc --json title,headRefName,body,state
-
-# Get CI check status
-gh pr checks $ARGUMENTS --repo ai-sdlc-framework/ai-sdlc
-
-# Get review agent findings (latest review)
-gh pr view $ARGUMENTS --repo ai-sdlc-framework/ai-sdlc --json reviews --jq '.reviews[-1].body'
-
-# Get codecov patch details
-gh api repos/ai-sdlc-framework/ai-sdlc/commits/$(gh pr view $ARGUMENTS --repo ai-sdlc-framework/ai-sdlc --json headRefOid --jq '.headRefOid')/check-runs --jq '.check_runs[] | select(.name | contains("codecov")) | {name: .name, conclusion: .conclusion, summary: .output.summary[0:500]}'
-
-# Get CI failure logs if build/test failed
-gh pr checks $ARGUMENTS --repo ai-sdlc-framework/ai-sdlc 2>&1 | grep "fail" | head -5
-```
-
-## Step 2: Checkout the PR branch
+Don't hardcode `--repo`. The cwd's git remote drives `gh`.
 
 ```bash
-gh pr checkout $ARGUMENTS
+PR=$ARGUMENTS
+
+gh pr view "$PR" --json number,title,headRefName,body,state,statusCheckRollup \
+  > /tmp/pr.json
+
+# Most recent failed CI run on the PR head ref (drives cli-fix-ci's --run-id)
+HEAD_SHA=$(gh pr view "$PR" --json headRefOid --jq '.headRefOid')
+RUN_ID=$(gh run list --commit "$HEAD_SHA" --status failure --limit 1 --json databaseId --jq '.[0].databaseId // empty')
 ```
 
-## Step 3: Analyze and categorize issues
+If `RUN_ID` is empty, there are no failing CI runs on the head SHA —
+skip Step 2.
 
-Categorize each issue as:
-- **CI failure** — build error, test failure, lint error, format error
-- **Review finding (real)** — legitimate bug, missing test, security issue
-- **Review finding (false positive)** — matches a pattern in `.ai-sdlc/review-policy.md`
-- **Coverage gap** — new lines not covered by tests
-
-For false positives: update `.ai-sdlc/review-policy.md` with more specific calibration instead of fixing non-issues.
-
-## Step 4: Fix issues in priority order
-
-1. **CI failures first** — build must pass before anything else
-2. **Coverage gaps** — write missing tests
-3. **Real review findings** — fix legitimate bugs/issues
-4. **Format/lint** — run `pnpm lint` and `pnpm format:check`, fix any issues
-
-## Step 5: Verify fixes locally
+## Step 2 — Fix CI failures (if any)
 
 ```bash
-pnpm build
-pnpm test
-pnpm lint
-pnpm format:check
+if [ -n "$RUN_ID" ]; then
+  pnpm --filter @ai-sdlc/dogfood fix-ci \
+    --pr "$PR" \
+    --run-id "$RUN_ID" \
+    > /tmp/fix-ci.json 2>/tmp/fix-ci.stderr
+fi
 ```
 
-ALL of these must pass before committing.
+`executeFixCI` checks the `<!-- ai-sdlc-fix-ci-attempt -->` marker
+comments on the PR and refuses to retry past `MAX_FIX_ATTEMPTS`. If it
+hits the cap, surface the message — don't paper over it.
 
-## Step 6: Commit and push
+## Step 3 — Fix review findings
+
+`executeFixReview` reads the latest review on the PR, filters by
+severity, and pushes a fix commit. It also tracks
+`<!-- ai-sdlc-fix-review-attempt -->` markers and caps at
+`MAX_REVIEW_FIX_ATTEMPTS = 2`.
 
 ```bash
-git add <specific files>
-git commit -m "fix: address CI failures and review findings on PR #$ARGUMENTS"
-git push
+pnpm --filter @ai-sdlc/dogfood fix-review \
+  --pr "$PR" \
+  > /tmp/fix-review.json 2>/tmp/fix-review.stderr
 ```
 
-## Step 7: Report status
+If the latest review state is `APPROVED` with no findings, this is a
+no-op — surface that.
 
-After pushing, report:
-- What was fixed
-- What was identified as a false positive (and if the review policy was updated)
-- What the user needs to review
+## Step 4 — False-positive triage
 
-**IMPORTANT: Do NOT merge the PR. Only fix and push. The human merges.**
+If `cli-fix-review` reports a finding the user disagrees with, the
+right move is to update `.ai-sdlc/review-policy.md` with a more
+specific calibration rule, **not** to fix the non-issue. The
+orchestrator's `ReviewFeedbackStore` learns from these calibration
+updates.
+
+The skill should:
+- Not edit `.ai-sdlc/review-policy.md` automatically
+- Instead surface the finding and say "to suppress this finding, add a rule to `.ai-sdlc/review-policy.md`. Want me to draft one?"
+
+## Step 5 — Verify locally
+
+After both wrappers complete, run the verification suite locally if
+the workspace allows it:
+
+```bash
+pnpm build && pnpm test && pnpm lint && pnpm format:check
+```
+
+If any of these fail, the wrappers' fixes were incomplete — surface
+the failure and stop. Do not push partial fixes.
+
+## Step 6 — Report
+
+Present:
+
+- What was fixed by `executeFixCI` (commit SHA, files changed)
+- What was fixed by `executeFixReview` (commit SHA, findings addressed)
+- What was identified as a false positive
+- Whether retry caps were hit (`MAX_FIX_ATTEMPTS` / `MAX_REVIEW_FIX_ATTEMPTS`)
+- Local verification status (build / test / lint / format)
+- What the human still needs to review
+
+## Step 7 — Never merge
+
+Do **not** run `gh pr merge`. The skill fixes and surfaces; humans merge.
+This is a hard rule from CLAUDE.md.
+
+## Notes
+
+- The skill replaces the prior prose recipe. Do **not** reimplement
+  the categorization / fix-priority logic in markdown — the
+  orchestrator's `executeFixCI` and `executeFixReview` are the source
+  of truth, and they preserve retry semantics that the prose version
+  cannot.
+- If `pnpm --filter @ai-sdlc/dogfood fix-ci` or `fix-review` is
+  unavailable, say so. Do not fall back to inline manual fixing —
+  that loses the retry-marker dedupe and could re-attempt a fix that
+  has already failed twice.

--- a/ai-sdlc-plugin/commands/review.md
+++ b/ai-sdlc-plugin/commands/review.md
@@ -1,54 +1,110 @@
 ---
 name: review
-description: Run AI-SDLC review agents on a pull request
+description: Run AI-SDLC review agents on a pull request (testing + critic + security)
 argument-hint: <pr-number>
-allowed-tools: Read,Grep,Glob,Bash
+allowed-tools: Read, Grep, Glob, Bash
 ---
 
-Run a comprehensive code review on PR #$ARGUMENTS using three review perspectives.
+Review PR #$ARGUMENTS by invoking `@ai-sdlc/orchestrator`'s
+`executeReview()` for the three review perspectives. The orchestrator
+already drives the LLM-based `ReviewAgentRunner` and applies the
+meta-review pass that filters medium-confidence findings; this skill's
+job is to fetch context, fan out to the three review types, and
+present the structured verdicts.
 
-## Step 1: Gather PR context
+## Step 1 — Fetch PR context
+
+Don't hardcode `--repo` — let the cwd's git remote drive `gh`.
 
 ```bash
-# Get the PR diff
-gh pr diff $ARGUMENTS --repo ai-sdlc-framework/ai-sdlc > /tmp/pr-diff.txt
+PR=$ARGUMENTS
 
-# Get PR details
-gh pr view $ARGUMENTS --repo ai-sdlc-framework/ai-sdlc --json title,body,headRefName,changedFiles
+# Diff + metadata for the review agents
+gh pr diff "$PR" > /tmp/pr-diff.txt
+gh pr view "$PR" --json number,title,body,headRefName,changedFiles > /tmp/pr.json
+
+# Linked issue (if any) — feeds acceptance-criteria extraction
+LINKED=$(gh pr view "$PR" --json body --jq '
+  (.body | scan("(?i)(?:closes|fixes|resolves)\\s+#([0-9]+)"))[0][0] // empty
+')
+if [ -n "$LINKED" ]; then
+  gh issue view "$LINKED" --json number,title,body > /tmp/issue.json
+fi
 ```
 
-## Step 2: Load review policy
+If there's no linked issue, omit `--issue-file` from the calls below —
+`cli-review` falls back to the PR title/body.
 
-Read `.ai-sdlc/review-policy.md` for calibration context. Apply the golden rule: "When in doubt, approve with a suggestion — do not request changes."
+## Step 2 — Run the three review types
 
-## Step 3: Review from three perspectives
+```bash
+for TYPE in testing critic security; do
+  pnpm --filter @ai-sdlc/dogfood review \
+    --pr "$PR" \
+    --diff-file /tmp/pr-diff.txt \
+    --type "$TYPE" \
+    ${LINKED:+--issue-file /tmp/issue.json} \
+    > "/tmp/review-$TYPE.json" 2>"/tmp/review-$TYPE.stderr"
+done
+```
 
-### Testing Review
-- Are new/changed functions covered by tests?
-- Do tests cover edge cases and error paths?
-- Are test assertions meaningful (not just checking truthiness)?
-- Defer coverage percentages to codecov — do NOT guess coverage numbers.
+Each call writes a structured `ReviewVerdict` JSON to its own file:
 
-### Code Quality Review
-- Are there logic errors, off-by-one bugs, or incorrect assumptions?
-- Is the code readable and following project conventions?
-- Are there unnecessary abstractions or missing error handling?
-- Check naming, file organization, and import structure.
+```json
+{
+  "approved": true | false,
+  "findings": [
+    { "severity": "critical"|"major"|"minor"|"suggestion",
+      "file": "path",
+      "line": 42,
+      "message": "string" }
+  ],
+  "summary": "string"
+}
+```
 
-### Security Review
-- Check for injection vulnerabilities (command, SQL, XSS)
-- Look for hardcoded secrets, credentials, or API keys
-- Verify input validation at system boundaries
-- Check for path traversal, SSRF, and deserialization issues
+If any of the three calls writes to stderr, surface it — typically a
+config issue, not a true review failure.
 
-## Step 4: Report findings
+## Step 3 — Present verdicts
 
-For each finding, provide:
-- **Severity**: critical, major, minor, or suggestion
-- **File and line**: exact location in the diff
-- **Description**: what the issue is and why it matters
-- **Recommendation**: how to fix it
+For each review type in order (testing, critic, security):
 
-Only report issues you are confident are real problems. If you cannot describe a concrete failure scenario, downgrade to suggestion.
+1. Header line — `Testing: APPROVED with 2 suggestions` or `Critic: CHANGES REQUESTED — 1 critical, 3 major`
+2. Summary — the orchestrator's `summary` string
+3. Findings — only critical and major; minor and suggestion go in a collapsed list
 
-**IMPORTANT: Do NOT merge the PR. Only review and report findings.**
+End with a combined verdict line:
+
+- **All three approved** → `READY TO MERGE` (but never run `gh pr merge` — see Step 5)
+- **Any critical** → `BLOCKED — fix critical findings`
+- **Major findings only** → `CHANGES REQUESTED — see findings above`
+- **Suggestions only** → `APPROVED with suggestions` (per the golden rule from `.ai-sdlc/review-policy.md`: when in doubt, approve with a suggestion)
+
+## Step 4 — Calibration context
+
+Read `.ai-sdlc/review-policy.md` if it exists and apply its calibration
+overrides to the verdicts. The orchestrator already filters
+medium-confidence findings via the meta-review pass; the policy file
+captures additional project-specific guidance (e.g. "do not flag
+unused `_var` parameters").
+
+If you suppress a finding because it matches a policy rule, say so
+explicitly — `(suppressed by .ai-sdlc/review-policy.md: <rule>)`.
+
+## Step 5 — Never merge
+
+Do **not** run `gh pr merge` regardless of verdict. The skill reports;
+humans merge. This is a hard rule from CLAUDE.md.
+
+## Notes
+
+- The skill replaces the prior prose review prompts. Do **not**
+  reimplement the three review checklists in markdown — the orchestrator's
+  `ReviewAgentRunner` is the source of truth for review prompts.
+- If `pnpm --filter @ai-sdlc/dogfood review` is unavailable (no Node
+  workspace, no built dist), say so explicitly. Do not fall back to
+  inline review prose — that would skip the meta-review filter and
+  produce non-conformant verdicts.
+- For a focused subset (e.g. only security), pass `--type security` to
+  the loop variable directly — the wrapper supports a single type.

--- a/ai-sdlc-plugin/commands/status.md
+++ b/ai-sdlc-plugin/commands/status.md
@@ -1,40 +1,83 @@
 ---
 name: status
-description: Show AI-SDLC pipeline status for the current branch or a specific issue
-argument-hint: [issue-number]
-allowed-tools: Read,Bash
+description: Show AI-SDLC pipeline status for the current branch or a specific issue/task
+argument-hint: [issue-id]
+allowed-tools: Read, Bash, mcp__backlog__task_view
 ---
 
-Show the current AI-SDLC pipeline status.
+Show the current AI-SDLC pipeline status. Auto-detects the issue
+tracker the same way the `triage` skill does — Backlog.md or GitHub.
 
-## If an issue number is provided ($ARGUMENTS)
+## Step 1 — Detect mode
+
+- If `$ARGUMENTS` is empty → **branch mode** (look up open PRs on the
+  current branch)
+- If `$ARGUMENTS` matches `^[A-Za-z][A-Za-z0-9]*-\d+$` (e.g.
+  `AISDLC-42`) → **Backlog task mode**
+- If `$ARGUMENTS` is `\d+` or `#\d+` → **GitHub issue mode**
+
+Don't hardcode `--repo`. The cwd's git remote drives `gh`.
+
+## Step 2a — Branch mode (no argument)
 
 ```bash
-# Get issue details and labels
-gh issue view $ARGUMENTS --repo ai-sdlc-framework/ai-sdlc --json title,state,labels,assignees
+BRANCH=$(git branch --show-current)
+echo "Branch: $BRANCH"
 
-# Find linked PRs
-gh pr list --repo ai-sdlc-framework/ai-sdlc --search "Closes #$ARGUMENTS OR Fixes #$ARGUMENTS" --json number,title,state,headRefName,statusCheckRollup
+PR_NUM=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number // empty')
+if [ -n "$PR_NUM" ]; then
+  gh pr view "$PR_NUM" --json number,title,state,statusCheckRollup,reviews
+  gh pr checks "$PR_NUM"
+else
+  echo "No open PR on this branch."
+fi
 ```
 
-## If no issue number (check current branch)
+## Step 2b — GitHub issue mode
 
 ```bash
-# Get current branch
-git branch --show-current
+gh issue view "$ARGUMENTS" --json number,title,state,labels,assignees
 
-# Check for open PRs on this branch
-gh pr list --repo ai-sdlc-framework/ai-sdlc --head $(git branch --show-current) --json number,title,state,statusCheckRollup,reviews
-
-# Show recent CI status
-gh pr checks $(gh pr list --repo ai-sdlc-framework/ai-sdlc --head $(git branch --show-current) --json number --jq '.[0].number') --repo ai-sdlc-framework/ai-sdlc 2>/dev/null || echo "No open PR on this branch"
+# Find linked PRs via "Closes #N" / "Fixes #N" backlinks
+gh pr list --search "linked:$ARGUMENTS" --json number,title,state,headRefName,statusCheckRollup
 ```
 
-## Report
+## Step 2c — Backlog task mode
+
+Use `mcp__backlog__task_view` with id `$ARGUMENTS`. The task carries
+`title`, `status`, `labels`, `priority`, `assignee`. Map `status` to a
+pipeline stage:
+
+| Backlog status | Pipeline stage |
+|---|---|
+| `Draft` | not yet ready (missing AC) |
+| `To Do` | admitted, awaiting agent |
+| `In Progress` | agent working |
+| `Done` (still in `backlog/tasks/`) | closing — needs `task_complete` |
+| File in `backlog/completed/` | closed |
+
+Then look for a PR that mentions the task id in its body or branch name:
+
+```bash
+gh pr list --search "$ARGUMENTS in:title,body" --json number,title,state,statusCheckRollup
+```
+
+## Step 3 — Report
 
 Present a clear status summary:
-- **Issue**: title, state, labels (which pipeline stage)
-- **PR**: number, state, CI checks (pass/fail/pending)
-- **Reviews**: approved/changes-requested/pending
-- **Coverage**: codecov status if available
-- **Next action**: what needs to happen next (fix CI, address reviews, ready to merge, etc.)
+
+- **Issue / task** — title, state/status, labels (which pipeline stage)
+- **PR** — number, state, CI checks (pass/fail/pending), review state
+- **Coverage** — codecov status if available (`gh pr checks` output already includes it)
+- **Next action** — what needs to happen next:
+  - CI failing → "run `/fix-pr <N>`"
+  - Reviews requesting changes → "run `/fix-pr <N>`" or "address review findings"
+  - All green → "ready for human merge"
+  - Backlog task in `Done` but file still in `backlog/tasks/` → "run `mcp__backlog__task_complete` to archive"
+
+## Notes
+
+- Status is presentation, not orchestration. Don't try to invoke
+  `cli-admit` or any other scoring CLI from this skill — that's the
+  triage skill's job.
+- Don't apply labels or change status. Status is read-only.

--- a/ai-sdlc-plugin/commands/triage.md
+++ b/ai-sdlc-plugin/commands/triage.md
@@ -1,50 +1,146 @@
 ---
 name: triage
-description: Score and triage a GitHub issue using the Product Priority Algorithm (PPA)
-argument-hint: <issue-number>
-allowed-tools: Read,Grep,Glob,Bash
+description: Score and triage an issue with the RFC-0008 admission composite (PPA + pillar breakdown). Auto-detects GitHub or Backlog.md.
+argument-hint: <issue-id>
+allowed-tools: Read, Grep, Glob, Bash, mcp__backlog__task_view
 ---
 
-Triage issue #$ARGUMENTS by scoring it with the Product Priority Algorithm and recommending a routing strategy.
+Triage issue `$ARGUMENTS` by running it through `@ai-sdlc/orchestrator`'s
+admission composite — the RFC-0008 §A.6 implementation
+(`P_admission = SA × D-pi_adjusted × ER × (1 + HC)` with pillar
+breakdown and tension flags). The orchestrator already does the math;
+this skill's job is to detect the tracker, fetch the issue, normalize
+it into `AdmissionInput`, and present the result.
 
-## Step 1: Gather issue context
+## Step 1 — Detect the tracker
+
+Inspect the form of `$ARGUMENTS`:
+
+- **Backlog.md** when the id matches `^[A-Za-z][A-Za-z0-9]*-\d+$` (e.g. `AISDLC-42`, `task-7`, `INGEST-101`)
+- **GitHub** when the id is `\d+` or `#\d+` (e.g. `42`, `#42`)
+- If ambiguous, prefer **Backlog** when `backlog/tasks/` exists in the repo, else GitHub.
+
+Allow override: if `$ARGUMENTS` contains `--tracker gh` or `--tracker backlog`, honour that.
+
+## Step 2 — Fetch the issue
+
+### Backlog branch
+
+Call `mcp__backlog__task_view` with the id. The returned task carries
+`title`, `description`, `labels` (string array), `status`, `priority`,
+`assignee`, `created_date`, `created_by`. Reactions and comments are
+not first-class on Backlog, default both to `0`.
+
+### GitHub branch
 
 ```bash
-gh issue view $ARGUMENTS --repo ai-sdlc-framework/ai-sdlc --json title,body,labels,author,createdAt,comments
+gh issue view <N> --json number,title,body,labels,authorAssociation,createdAt,comments,reactions \
+  > /tmp/issue.json
 ```
 
-## Step 2: Score with PPA signals
+Don't hardcode `--repo`. The current working directory's git remote
+already drives `gh`. If the user supplies `--repo OWNER/NAME` in
+`$ARGUMENTS`, pass it through.
 
-Evaluate these signals (0-1 scale each):
+## Step 3 — Normalize to AdmissionInput
 
-- **Conviction**: How well-defined is the problem? Clear reproduction steps? Specific files referenced?
-- **Demand**: How many users affected? Comments/reactions? Related issues?
-- **Consensus**: Alignment with project roadmap? Related to known priorities?
-- **Effort**: Estimated complexity (1=trivial, 10=massive rewrite)
+Build the args `cli-admit` expects. Write the body to `/tmp/issue-body.txt`
+(safer than shell-quoting multi-line markdown):
 
-Weight by author trust level:
-- `OWNER`/`MEMBER`/`COLLABORATOR`: baseline conviction=0.3, demand=0.2, consensus=0.2
-- External contributors: need external validation signals
+| AdmissionInput field | GitHub source | Backlog source |
+|---|---|---|
+| `--title` | `.title` | `.title` |
+| `--body-file` | `.body` → `/tmp/issue-body.txt` | `.description` → `/tmp/issue-body.txt` |
+| `--issue-number` | `.number` | numeric tail of the id (e.g. `42` for `AISDLC-42`) |
+| `--labels` (JSON array of strings) | `.labels[].name` | `.labels` |
+| `--reactions` | `(.reactions["+1"] // 0) + (.reactions.heart // 0)` | `0` |
+| `--comments` | `(.comments \| length)` | `0` |
+| `--created-at` | `.createdAt` | `.created_date` |
+| `--author-association` | `.authorAssociation` | `OWNER` if `created_by` matches a maintainer in `.ai-sdlc/`, else `MEMBER` |
+| `--author-login` | `.author.login` (if present) | `.created_by` |
 
-## Step 3: Complexity assessment
+For Backlog, the issue number passed to `cli-admit` is just the
+numeric tail — `cli-admit` only uses it for the `itemId` provenance
+string (`#42`), so cross-tracker collisions are harmless for the
+score itself. Track the full id (`AISDLC-42`) separately in the report.
 
-Estimate task complexity (1-10):
-- **1-3**: Simple bug fix, config change, docs update → AI-eligible
-- **4-6**: Moderate feature, multi-file refactor → AI with review
-- **7-10**: Architectural change, new subsystem → Human-led
+## Step 4 — Score with the admission composite
 
-## Step 4: Recommend routing
+```bash
+pnpm --filter @ai-sdlc/dogfood admit \
+  --title "$TITLE" \
+  --body-file /tmp/issue-body.txt \
+  --issue-number "$ISSUE_NUMBER" \
+  --labels "$LABELS_JSON" \
+  --reactions "$REACTIONS" \
+  --comments "$COMMENTS" \
+  --created-at "$CREATED_AT" \
+  --author-association "$AUTHOR_ASSOC" \
+  --author-login "$AUTHOR_LOGIN" \
+  --enrich-from-state \
+  ${CODE_AREA:+--code-area "$CODE_AREA"} \
+  2>/tmp/admit-stderr.txt | tail -1 > /tmp/admit-result.json
+```
 
-Based on PPA score and complexity:
-- **Score > 0.3 AND complexity 1-3**: Auto-route to AI agent (`ai-eligible` label)
-- **Score > 0.3 AND complexity 4-6**: Route to AI with human review
-- **Score > 0.3 AND complexity 7+**: Flag for human lead
-- **Score < 0.3**: Needs more information or demand signals
+`--enrich-from-state` opens `.ai-sdlc/state.db` and resolves the
+`DesignSystemBinding`, `DesignIntentDocument`, and `AutonomyPolicy` from
+`.ai-sdlc/` — that's what wires C2 readiness, C3 defect risk, C4
+autonomy factor, and C5 design-authority weight into the composite.
 
-## Step 5: Report
+If `cli-admit` writes anything to `/tmp/admit-stderr.txt`, surface it
+in the report — it's typically a config-load warning, not fatal.
 
-Present the triage assessment:
-- PPA score breakdown (conviction, demand, consensus, effort)
-- Complexity rating with justification
-- Recommended routing strategy
-- Suggested labels to add
+## Step 5 — Render the result
+
+Parse `/tmp/admit-result.json`. The shape is:
+
+```json
+{
+  "admitted": true | false,
+  "score": {
+    "composite": 0.0,
+    "dimensions": { "soulAlignment": 0.0, "demandPressure": 0.0, ... },
+    "confidence": 0.0
+  },
+  "reason": "string",
+  "pillarBreakdown": {
+    "product":     { "signal": 0.0, "interpretation": "..." },
+    "design":      { "signal": 0.0, "interpretation": "..." },
+    "engineering": { "signal": 0.0, "interpretation": "..." },
+    "shared":      { "hcComposite": { ... } },
+    "tensions":    [ { "type": "PRODUCT_HIGH_DESIGN_LOW", "severity": "..." } ]
+  }
+}
+```
+
+Present back to the user in this exact order:
+
+1. **Verdict line** — admitted or rejected, composite score, confidence
+2. **Dimensions table** — SA, D-π, M-φ, E-ρ, E-τ, HC, C-κ
+3. **Pillar breakdown** — Product / Design / Engineering signals with interpretations
+4. **Tensions** — each tension flag with its type and what it means (e.g. `PRODUCT_HIGH_DESIGN_LOW` → "design system not ready for the work product wants")
+5. **Reason** — the orchestrator's `reason` string
+6. **Suggested labels** — derived from the verdict:
+   - admitted + complexity ≤ 3 → `ai-eligible`
+   - admitted + tension `PRODUCT_HIGH_DESIGN_LOW` → also `needs-design-review`
+   - rejected → `needs-more-info` (low confidence) or `out-of-scope` (SA hard gate)
+
+## Step 6 — Offer to apply labels
+
+Don't apply labels automatically — confirm first. If the user agrees,
+apply via the right tracker:
+
+- **GitHub**: `gh issue edit <N> --add-label "$LABEL"`
+- **Backlog**: use the `mcp__backlog__task_edit` MCP tool with `addLabels`. (Not in the allowed-tools above — instruct the user to run `/backlog task edit` themselves, or escalate by asking the user to enable that tool.)
+
+## Notes
+
+- This skill replaces the pre-RFC-0008 4-signal heuristic. The composite
+  comes from `@ai-sdlc/orchestrator`; do **not** reimplement scoring in
+  prose.
+- If `pnpm --filter @ai-sdlc/dogfood admit` is unavailable (no Node
+  workspace, no built dist), say so explicitly. Do not fall back to the
+  old prose heuristic — the score wouldn't be RFC-0008 conformant and a
+  silent fallback hides the gap.
+- The skill is **stateless w.r.t. the tracker**: it never writes to
+  GitHub or Backlog without explicit user confirmation in Step 6.


### PR DESCRIPTION
## Summary

- Replaces the prior 51-line prose checklist (4-signal heuristic, flat 0.3 threshold, hardcoded \`--repo ai-sdlc-framework/ai-sdlc\`) with a recipe that calls \`@ai-sdlc/orchestrator\`'s admission composite end-to-end.
- Auto-detects the issue tracker from the id format: \`AISDLC-42\`-style → Backlog.md (\`mcp__backlog__task_view\`); pure digits → GitHub (\`gh issue view\`, no hardcoded \`--repo\`); falls through to \`backlog/tasks/\` layout when ambiguous; accepts an explicit \`--tracker\` override.
- Single normalisation step maps both tracker shapes to \`cli-admit\`'s flags. Single scoring call (\`pnpm --filter @ai-sdlc/dogfood admit --enrich-from-state\`) does the rest — C2 readiness, C3 defect risk, C4 autonomy factor, C5 design-authority weight, plus \`pillarBreakdown\` + \`tensions[]\` per RFC-0008 §A.6.
- Renders verdict + dimensions + pillar breakdown + tensions + reason + suggested labels in that order. Confirmation-gated label apply — never writes to GH or Backlog without the user's explicit say-so.

## Why now

A side-by-side analysis flagged that the existing skill was three layers behind the orchestrator's actual scorer:

1. The skill scored 4 hand-rolled signals (Conviction/Demand/Consensus/Effort), not the multiplicative PPA composite.
2. The orchestrator already implements PPA v1.0 (\`computePriority()\` in \`@ai-sdlc/orchestrator\`).
3. RFC-0008 (just merged) added \`designSystemReadiness\`, \`autonomyFactor\`, \`defectRiskFactor\`, \`designAuthorityWeight\` plus \`enrichAdmissionInput()\`. The skill ignored all of them.

The skill now invokes \`cli-admit\`, which already exposes everything via \`--enrich-from-state\`.

## Strict no-fallback policy

If \`cli-admit\` is unavailable (no Node workspace, no built dist), the skill says so explicitly. It does **not** silently fall back to the prose heuristic — that would hide the conformance gap.

## Out of scope (deferred)

- Pluggable \`IssueTracker\` interface threaded into \`cli-admit\` itself (today the skill does the tracker dispatch; the CLI is still GH-shaped under the hood). RFC-sized change.
- \`asyncRewake\` for long-running enrichment so triage doesn't block stop hooks.

## Test plan

- [ ] \`/triage 42\` against a numeric GitHub issue → fetches via \`gh\`, scores, prints \`pillarBreakdown\`
- [ ] \`/triage AISDLC-67\` against a Backlog.md task → fetches via \`mcp__backlog__task_view\`, scores, prints \`pillarBreakdown\`
- [ ] \`/triage 42 --tracker backlog\` → honours the explicit override
- [ ] Verify the skill does NOT auto-apply labels — must wait for user confirmation
- [ ] Verify a clear error when \`pnpm --filter @ai-sdlc/dogfood admit\` is missing (no silent fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)