### PR TITLE
feat(orchestrator): Backlog tracker adapter for admission scoring

### DIFF
--- a/ai-sdlc-plugin/commands/triage.md
+++ b/ai-sdlc-plugin/commands/triage.md
@@ -8,9 +8,9 @@ allowed-tools: Read, Grep, Glob, Bash, mcp__backlog__task_view
 Triage issue `$ARGUMENTS` by running it through `@ai-sdlc/orchestrator`'s
 admission composite — the RFC-0008 §A.6 implementation
 (`P_admission = SA × D-pi_adjusted × ER × (1 + HC)` with pillar
-breakdown and tension flags). The orchestrator already does the math;
-this skill's job is to detect the tracker, fetch the issue, normalize
-it into `AdmissionInput`, and present the result.
+breakdown and tension flags). The orchestrator does the math; this
+skill's job is to detect the tracker, resolve the right config root,
+invoke `cli-admit`, and present the result with full provenance.
 
 ## Step 1 — Detect the tracker
 
@@ -20,127 +20,143 @@ Inspect the form of `$ARGUMENTS`:
 - **GitHub** when the id is `\d+` or `#\d+` (e.g. `42`, `#42`)
 - If ambiguous, prefer **Backlog** when `backlog/tasks/` exists in the repo, else GitHub.
 
-Allow override: if `$ARGUMENTS` contains `--tracker gh` or `--tracker backlog`, honour that.
+Allow override: if `$ARGUMENTS` contains `--tracker github` or `--tracker backlog`, honour that.
 
-## Step 2 — Fetch the issue
+## Step 2 — Resolve the config root
+
+Cross-repo confusion is the #1 silent failure. Explicitly pin the
+config root before fetching the issue:
+
+- **Backlog**: walk up from the task file's directory (or repo cwd) until `.ai-sdlc/` is found. That's the config root.
+- **GitHub**: walk up from cwd. If `gh pr view`'s remote URL points at a different repo than the cwd, surface a warning and ask the user to confirm or pass `--config-root <path>`.
+
+Pass that path through to every `cli-admit` call as `--config-root`. The
+CLI also auto-walks but explicit pinning eliminates ambiguity in the
+report.
+
+## Step 3 — Fetch + score
 
 ### Backlog branch
 
-Call `mcp__backlog__task_view` with the id. The returned task carries
-`title`, `description`, `labels` (string array), `status`, `priority`,
-`assignee`, `created_date`, `created_by`. Reactions and comments are
-not first-class on Backlog, default both to `0`.
+`cli-admit` parses the task file directly — no separate fetch step.
+Call `mcp__backlog__task_view` only if you need to render the task
+title/body to the user before scoring.
+
+```bash
+ID=$ARGUMENTS
+CONFIG_ROOT=...   # from Step 2
+
+pnpm --filter @ai-sdlc/dogfood admit \
+  --tracker backlog \
+  --task-id "$ID" \
+  --config-root "$CONFIG_ROOT" \
+  --enrich-from-state \
+  > /tmp/admit.json 2> /tmp/admit-provenance.json
+```
+
+The Backlog adapter does the label/AC/quality-flag mapping internally
+(`priority:p*`, `size:[SML]`, `track:*`, `source:*`, `Done`-with-unchecked-ACs
+zombie close, etc.). You don't fan signals out by hand.
 
 ### GitHub branch
 
-```bash
-gh issue view <N> --json number,title,body,labels,authorAssociation,createdAt,comments,reactions \
-  > /tmp/issue.json
-```
-
-Don't hardcode `--repo`. The current working directory's git remote
-already drives `gh`. If the user supplies `--repo OWNER/NAME` in
-`$ARGUMENTS`, pass it through.
-
-## Step 3 — Normalize to AdmissionInput
-
-Build the args `cli-admit` expects. Write the body to `/tmp/issue-body.txt`
-(safer than shell-quoting multi-line markdown):
-
-| AdmissionInput field | GitHub source | Backlog source |
-|---|---|---|
-| `--title` | `.title` | `.title` |
-| `--body-file` | `.body` → `/tmp/issue-body.txt` | `.description` → `/tmp/issue-body.txt` |
-| `--issue-number` | `.number` | numeric tail of the id (e.g. `42` for `AISDLC-42`) |
-| `--labels` (JSON array of strings) | `.labels[].name` | `.labels` |
-| `--reactions` | `(.reactions["+1"] // 0) + (.reactions.heart // 0)` | `0` |
-| `--comments` | `(.comments \| length)` | `0` |
-| `--created-at` | `.createdAt` | `.created_date` |
-| `--author-association` | `.authorAssociation` | `OWNER` if `created_by` matches a maintainer in `.ai-sdlc/`, else `MEMBER` |
-| `--author-login` | `.author.login` (if present) | `.created_by` |
-
-For Backlog, the issue number passed to `cli-admit` is just the
-numeric tail — `cli-admit` only uses it for the `itemId` provenance
-string (`#42`), so cross-tracker collisions are harmless for the
-score itself. Track the full id (`AISDLC-42`) separately in the report.
-
-## Step 4 — Score with the admission composite
+Use the OS tmp dir for the body file (the safe-path guard accepts
+`/tmp` on macOS/Linux and `os.tmpdir()` on any platform). Don't
+hardcode `--repo`; if the cwd's git remote and the issue's repo
+differ, the orchestrator will warn — surface that.
 
 ```bash
+N=$ARGUMENTS
+TMPDIR_REAL=${TMPDIR:-/tmp}
+
+gh issue view "$N" --json number,title,body,labels,authorAssociation,createdAt,comments,reactions \
+  > "$TMPDIR_REAL/issue.json"
+
+jq -r '.body' "$TMPDIR_REAL/issue.json" > "$TMPDIR_REAL/issue-body.txt"
+TITLE=$(jq -r '.title' "$TMPDIR_REAL/issue.json")
+LABELS=$(jq -c '[.labels[].name]' "$TMPDIR_REAL/issue.json")
+REACTIONS=$(jq '(.reactions["+1"] // 0) + (.reactions.heart // 0)' "$TMPDIR_REAL/issue.json")
+COMMENTS=$(jq '.comments | length' "$TMPDIR_REAL/issue.json")
+CREATED_AT=$(jq -r '.createdAt' "$TMPDIR_REAL/issue.json")
+ASSOC=$(jq -r '.authorAssociation' "$TMPDIR_REAL/issue.json")
+AUTHOR=$(jq -r '.author.login // empty' "$TMPDIR_REAL/issue.json")
+
 pnpm --filter @ai-sdlc/dogfood admit \
+  --tracker github \
   --title "$TITLE" \
-  --body-file /tmp/issue-body.txt \
-  --issue-number "$ISSUE_NUMBER" \
-  --labels "$LABELS_JSON" \
+  --body-file "$TMPDIR_REAL/issue-body.txt" \
+  --issue-number "$N" \
+  --labels "$LABELS" \
   --reactions "$REACTIONS" \
   --comments "$COMMENTS" \
   --created-at "$CREATED_AT" \
-  --author-association "$AUTHOR_ASSOC" \
-  --author-login "$AUTHOR_LOGIN" \
+  --author-association "$ASSOC" \
+  ${AUTHOR:+--author-login "$AUTHOR"} \
+  --config-root "$CONFIG_ROOT" \
   --enrich-from-state \
-  ${CODE_AREA:+--code-area "$CODE_AREA"} \
-  2>/tmp/admit-stderr.txt | tail -1 > /tmp/admit-result.json
+  > /tmp/admit.json 2> /tmp/admit-provenance.json
 ```
 
-`--enrich-from-state` opens `.ai-sdlc/state.db` and resolves the
-`DesignSystemBinding`, `DesignIntentDocument`, and `AutonomyPolicy` from
-`.ai-sdlc/` — that's what wires C2 readiness, C3 defect risk, C4
-autonomy factor, and C5 design-authority weight into the composite.
+## Step 4 — Render the result
 
-If `cli-admit` writes anything to `/tmp/admit-stderr.txt`, surface it
-in the report — it's typically a config-load warning, not fatal.
-
-## Step 5 — Render the result
-
-Parse `/tmp/admit-result.json`. The shape is:
+Parse `/tmp/admit.json` (the verdict) and `/tmp/admit-provenance.json`
+(the resolved enrichment context). The shape is:
 
 ```json
 {
   "admitted": true | false,
-  "score": {
-    "composite": 0.0,
-    "dimensions": { "soulAlignment": 0.0, "demandPressure": 0.0, ... },
-    "confidence": 0.0
-  },
+  "score": { "composite": 0.0, "dimensions": { ... }, "confidence": 0.0 },
   "reason": "string",
   "pillarBreakdown": {
     "product":     { "signal": 0.0, "interpretation": "..." },
     "design":      { "signal": 0.0, "interpretation": "..." },
     "engineering": { "signal": 0.0, "interpretation": "..." },
     "shared":      { "hcComposite": { ... } },
-    "tensions":    [ { "type": "PRODUCT_HIGH_DESIGN_LOW", "severity": "..." } ]
-  }
+    "tensions":    [ { "type": "...", "severity": "..." } ]
+  },
+  "qualityFlags": [
+    { "kind": "unchecked-acs-on-done", "detail": "...", "severity": "high" }
+  ]
 }
 ```
 
-Present back to the user in this exact order:
+Provenance (`/tmp/admit-provenance.json`) carries the resolved
+context — emit it FIRST so cross-repo confusion is impossible to miss:
 
-1. **Verdict line** — admitted or rejected, composite score, confidence
+```
+## Provenance
+Tracker:                backlog
+Config root:            /Users/.../forge   (resolved from --config-root)
+DesignSystemBinding:    forge-ds
+DesignIntentDocument:   forge-did
+AutonomyPolicy:         forge-autonomy
+```
+
+Then in this order:
+
+1. **Verdict line** — admitted/rejected, composite, confidence
 2. **Dimensions table** — SA, D-π, M-φ, E-ρ, E-τ, HC, C-κ
-3. **Pillar breakdown** — Product / Design / Engineering signals with interpretations
-4. **Tensions** — each tension flag with its type and what it means (e.g. `PRODUCT_HIGH_DESIGN_LOW` → "design system not ready for the work product wants")
-5. **Reason** — the orchestrator's `reason` string
-6. **Suggested labels** — derived from the verdict:
-   - admitted + complexity ≤ 3 → `ai-eligible`
-   - admitted + tension `PRODUCT_HIGH_DESIGN_LOW` → also `needs-design-review`
-   - rejected → `needs-more-info` (low confidence) or `out-of-scope` (SA hard gate)
+3. **Pillar breakdown** — Product / Design / Engineering signals
+4. **Tensions** — each flag with type + interpretation
+5. **Quality concerns** — when `qualityFlags[]` is non-empty, list each with severity and the one-liner explanation of how it affected the score (e.g. zombie close → defectRiskFactor +0.15)
+6. **Reason** — the orchestrator's `reason` string
+7. **Suggested labels** — derived from the verdict (admitted + complexity ≤ 3 → `ai-eligible`; tension `PRODUCT_HIGH_DESIGN_LOW` → `needs-design-review`; rejected → `needs-more-info` or `out-of-scope`)
 
-## Step 6 — Offer to apply labels
+## Step 5 — Offer to apply labels
 
 Don't apply labels automatically — confirm first. If the user agrees,
 apply via the right tracker:
 
 - **GitHub**: `gh issue edit <N> --add-label "$LABEL"`
-- **Backlog**: use the `mcp__backlog__task_edit` MCP tool with `addLabels`. (Not in the allowed-tools above — instruct the user to run `/backlog task edit` themselves, or escalate by asking the user to enable that tool.)
+- **Backlog**: ask the user to run `mcp__backlog__task_edit` themselves (it's intentionally not in `allowed-tools` here).
 
 ## Notes
 
-- This skill replaces the pre-RFC-0008 4-signal heuristic. The composite
-  comes from `@ai-sdlc/orchestrator`; do **not** reimplement scoring in
-  prose.
+- The Backlog adapter (`mapBacklogTaskToAdmissionInput`) is the source
+  of truth for Backlog → AdmissionInput mapping. Do **not** restate
+  the label table in prose — refer to the adapter.
 - If `pnpm --filter @ai-sdlc/dogfood admit` is unavailable (no Node
-  workspace, no built dist), say so explicitly. Do not fall back to the
-  old prose heuristic — the score wouldn't be RFC-0008 conformant and a
-  silent fallback hides the gap.
-- The skill is **stateless w.r.t. the tracker**: it never writes to
-  GitHub or Backlog without explicit user confirmation in Step 6.
+  workspace, no built dist), say so explicitly. Do not fall back to a
+  prose heuristic.
+- The skill never writes to GitHub or Backlog without explicit user
+  confirmation in Step 5.

--- a/dogfood/src/cli-admit.test.ts
+++ b/dogfood/src/cli-admit.test.ts
@@ -80,6 +80,49 @@ const mocks = vi.hoisted(() => ({
     },
   }),
   resolveRepoRoot: vi.fn(),
+  loadBacklogTaskFromRoot: vi.fn(() => ({
+    id: 'AISDLC-42',
+    numericId: 42,
+    title: 'Backlog task',
+    description: 'desc',
+    status: 'To Do',
+    priority: 'high',
+    labels: ['priority:p1', 'size:M'],
+    createdDate: '2026-04-25 09:00',
+    updatedDate: '2026-04-25 09:00',
+    acceptanceCriteria: [],
+    references: [],
+  })),
+  parseBacklogTask: vi.fn((content: string) => ({
+    id: 'TASK-FILE-1',
+    numericId: 1,
+    title: 'parsed from file',
+    description: content.slice(0, 50),
+    status: 'To Do',
+    priority: null,
+    labels: ['source:rfc'],
+    createdDate: '2026-04-25 09:00',
+    updatedDate: '2026-04-25 09:00',
+    acceptanceCriteria: [],
+    references: [],
+  })),
+  mapBacklogTaskToAdmissionInput: vi.fn(
+    (snap: { id: string; title: string; numericId: number }) => ({
+      input: {
+        issueNumber: snap.numericId,
+        title: snap.title,
+        body: 'mapped body',
+        labels: ['priority:p1'],
+        reactionCount: 0,
+        commentCount: 0,
+        createdAt: '2026-04-25T09:00:00Z',
+        authorAssociation: 'MEMBER' as const,
+      },
+      priorityInputOverrides: { explicitPriority: 0.75, complexity: 5 },
+      qualityFlags: [],
+    }),
+  ),
+  loadSoulTracks: vi.fn(() => ({})),
 }));
 
 vi.mock('@ai-sdlc/orchestrator', () => ({
@@ -89,6 +132,10 @@ vi.mock('@ai-sdlc/orchestrator', () => ({
   scoreIssueForAdmission: mocks.scoreIssueForAdmission,
   enrichAdmissionInput: mocks.enrichAdmissionInput,
   StateStore: { open: mocks.stateStoreOpen },
+  loadBacklogTaskFromRoot: mocks.loadBacklogTaskFromRoot,
+  parseBacklogTask: mocks.parseBacklogTask,
+  mapBacklogTaskToAdmissionInput: mocks.mapBacklogTaskToAdmissionInput,
+  loadSoulTracks: mocks.loadSoulTracks,
 }));
 
 describe('cli-admit.ts', () => {
@@ -112,6 +159,10 @@ describe('cli-admit.ts', () => {
     mocks.scoreIssueForAdmission.mockClear();
     mocks.enrichAdmissionInput.mockClear();
     mocks.stateStoreOpen.mockClear();
+    mocks.loadBacklogTaskFromRoot.mockClear();
+    mocks.parseBacklogTask.mockClear();
+    mocks.mapBacklogTaskToAdmissionInput.mockClear();
+    mocks.loadSoulTracks.mockClear();
     mocks.resolveRepoRoot.mockResolvedValue(tempDir);
     vi.resetModules();
   });
@@ -316,5 +367,257 @@ describe('cli-admit.ts', () => {
     expect(ctx.designIntentDocument).toBeUndefined();
     expect(ctx.autonomyPolicy).toBeUndefined();
     expect(mocks.scoreIssueForAdmission).toHaveBeenCalled();
+  });
+
+  it('Backlog tracker via --task-id dispatches to loadBacklogTaskFromRoot + mapBacklogTaskToAdmissionInput', async () => {
+    process.argv = [
+      'node',
+      'cli-admit.ts',
+      '--tracker',
+      'backlog',
+      '--task-id',
+      'AISDLC-42',
+      '--config-root',
+      tempDir,
+    ];
+    await import('./cli-admit.js');
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mocks.loadBacklogTaskFromRoot).toHaveBeenCalledWith(tempDir, 'AISDLC-42');
+    expect(mocks.mapBacklogTaskToAdmissionInput).toHaveBeenCalledTimes(1);
+    expect(mocks.parseBacklogTask).not.toHaveBeenCalled();
+    expect(mocks.scoreIssueForAdmission).toHaveBeenCalledTimes(1);
+    // priorityInputOverrides flow through to scoreIssueForAdmission's options arg
+    const call = mocks.scoreIssueForAdmission.mock.calls[0] as unknown[];
+    const options = call[3] as { priorityInputOverrides?: Record<string, unknown> } | undefined;
+    expect(options).toBeDefined();
+    expect(options?.priorityInputOverrides).toEqual({
+      explicitPriority: 0.75,
+      complexity: 5,
+    });
+  });
+
+  it('Backlog tracker via --task-file dispatches to parseBacklogTask', async () => {
+    const taskFile = join(tempDir, 'aisdlc-7.md');
+    writeFileSync(taskFile, `---\nid: AISDLC-7\ntitle: From file\nstatus: To Do\n---\n\nbody`);
+    process.argv = [
+      'node',
+      'cli-admit.ts',
+      '--tracker',
+      'backlog',
+      '--task-file',
+      taskFile,
+      '--config-root',
+      tempDir,
+    ];
+    await import('./cli-admit.js');
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mocks.parseBacklogTask).toHaveBeenCalledTimes(1);
+    expect(mocks.loadBacklogTaskFromRoot).not.toHaveBeenCalled();
+    expect(mocks.mapBacklogTaskToAdmissionInput).toHaveBeenCalledTimes(1);
+  });
+
+  it('auto-detects Backlog tracker when --task-id is supplied with no --tracker flag', async () => {
+    process.argv = ['node', 'cli-admit.ts', '--task-id', 'AISDLC-7', '--config-root', tempDir];
+    await import('./cli-admit.js');
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mocks.loadBacklogTaskFromRoot).toHaveBeenCalledTimes(1);
+    expect(mocks.mapBacklogTaskToAdmissionInput).toHaveBeenCalledTimes(1);
+  });
+
+  it('Backlog tracker exits 1 when neither --task-id nor --task-file is provided', async () => {
+    process.argv = ['node', 'cli-admit.ts', '--tracker', 'backlog'];
+    await import('./cli-admit.js');
+    await new Promise((r) => setTimeout(r, 50));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--tracker backlog --task-id'));
+  });
+
+  it('Backlog tracker exits 1 when the task id is not found', async () => {
+    (
+      mocks.loadBacklogTaskFromRoot as unknown as { mockReturnValueOnce: (v: unknown) => void }
+    ).mockReturnValueOnce(undefined);
+    process.argv = [
+      'node',
+      'cli-admit.ts',
+      '--tracker',
+      'backlog',
+      '--task-id',
+      'NOPE-1',
+      '--config-root',
+      tempDir,
+    ];
+    await import('./cli-admit.js');
+    await new Promise((r) => setTimeout(r, 50));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Backlog task NOPE-1 not found'));
+  });
+
+  it('emits provenance JSON on stderr (tracker, configRoot, configSource)', async () => {
+    process.argv = [
+      'node',
+      'cli-admit.ts',
+      '--tracker',
+      'backlog',
+      '--task-id',
+      'AISDLC-42',
+      '--config-root',
+      tempDir,
+      '--enrich-from-state',
+    ];
+    await import('./cli-admit.js');
+    await new Promise((r) => setTimeout(r, 50));
+
+    const provenanceCall = errorSpy.mock.calls
+      .map((args) => String(args[0]))
+      .find((line) => line.includes('"provenance"'));
+    expect(provenanceCall).toBeDefined();
+    const parsed = JSON.parse(provenanceCall as string);
+    expect(parsed.provenance.tracker).toBe('backlog');
+    expect(parsed.provenance.configRoot).toBe(tempDir);
+    expect(parsed.provenance.configSource).toBe('flag');
+    expect(parsed.provenance.designSystemBinding).toBe('acme-ds');
+    expect(parsed.provenance.designIntentDocument).toBe('acme-did');
+    expect(parsed.provenance.autonomyPolicy).toBe('acme-ap');
+  });
+
+  it('emits a fallback warning on stderr when no .ai-sdlc/ ancestor is found', async () => {
+    // resolveRepoRoot returns tempDir, no .ai-sdlc/ in it → cwd-walk fails
+    // → fallback. The skill-side caller should see this WARN and confirm.
+    process.argv = [
+      'node',
+      'cli-admit.ts',
+      '--title',
+      't',
+      '--body-file',
+      bodyFile,
+      '--issue-number',
+      '1',
+      '--labels',
+      '[]',
+      '--reactions',
+      '0',
+      '--comments',
+      '0',
+      '--created-at',
+      '2026-04-01T00:00:00Z',
+    ];
+    await import('./cli-admit.js');
+    await new Promise((r) => setTimeout(r, 50));
+
+    const warnCall = errorSpy.mock.calls
+      .map((args) => String(args[0]))
+      .find((line) => line.includes('via fallback'));
+    expect(warnCall).toBeDefined();
+  });
+
+  it('GitHub usage exits 1 when --title is missing', async () => {
+    process.argv = ['node', 'cli-admit.ts', '--issue-number', '1'];
+    await import('./cli-admit.js');
+    await new Promise((r) => setTimeout(r, 50));
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('admit --title'));
+  });
+
+  it('--config-root with task-file walks up to find .ai-sdlc and reports configSource=task-file', async () => {
+    // Place a task file inside a sibling subdir; .ai-sdlc/ at tempDir.
+    const subdir = join(tempDir, 'sub');
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(subdir, { recursive: true });
+    mkdirSync(join(tempDir, '.ai-sdlc'), { recursive: true });
+    const taskFile = join(subdir, 'aisdlc-7.md');
+    writeFileSync(taskFile, `---\nid: AISDLC-7\ntitle: t\nstatus: To Do\n---\n\nbody`);
+
+    process.argv = [
+      'node',
+      'cli-admit.ts',
+      '--tracker',
+      'backlog',
+      '--task-file',
+      taskFile,
+      // No --config-root — let the walk-up resolve it.
+    ];
+    await import('./cli-admit.js');
+    await new Promise((r) => setTimeout(r, 50));
+
+    const provenance = errorSpy.mock.calls
+      .map((args) => String(args[0]))
+      .find((line) => line.includes('"provenance"'));
+    expect(provenance).toBeDefined();
+    const parsed = JSON.parse(provenance as string);
+    expect(parsed.provenance.configSource).toBe('task-file');
+    expect(parsed.provenance.configRoot).toBe(tempDir);
+  });
+
+  it('emits Warning on stderr when loadConfigAsync rejects', async () => {
+    mocks.loadConfigAsync.mockRejectedValueOnce(new Error('disk full'));
+    process.argv = [
+      'node',
+      'cli-admit.ts',
+      '--title',
+      't',
+      '--body-file',
+      bodyFile,
+      '--issue-number',
+      '1',
+      '--labels',
+      '[]',
+      '--reactions',
+      '0',
+      '--comments',
+      '0',
+      '--created-at',
+      '2026-04-01T00:00:00Z',
+    ];
+    await import('./cli-admit.js');
+    await new Promise((r) => setTimeout(r, 50));
+
+    const warning = errorSpy.mock.calls
+      .map((args) => String(args[0]))
+      .find((line) => line.includes('could not load pipeline config'));
+    expect(warning).toBeDefined();
+  });
+
+  it('attaches qualityFlags from the Backlog mapping onto the result', async () => {
+    (
+      mocks.mapBacklogTaskToAdmissionInput as unknown as {
+        mockReturnValueOnce: (v: unknown) => void;
+      }
+    ).mockReturnValueOnce({
+      input: {
+        issueNumber: 42,
+        title: 'zombie close',
+        body: 'body',
+        labels: ['priority:p1'],
+        reactionCount: 0,
+        commentCount: 0,
+        createdAt: '2026-04-25T09:00:00Z',
+        authorAssociation: 'MEMBER',
+      },
+      priorityInputOverrides: { defectRiskFactor: 0.3 },
+      qualityFlags: [
+        { kind: 'unchecked-acs-on-done', detail: '5/5 ACs unchecked', severity: 'high' },
+      ],
+    });
+    process.argv = [
+      'node',
+      'cli-admit.ts',
+      '--tracker',
+      'backlog',
+      '--task-id',
+      'AISDLC-42',
+      '--config-root',
+      tempDir,
+    ];
+    await import('./cli-admit.js');
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(logSpy).toHaveBeenCalled();
+    const output = logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.qualityFlags).toHaveLength(1);
+    expect(parsed.qualityFlags[0].kind).toBe('unchecked-acs-on-done');
   });
 });

--- a/dogfood/src/cli-admit.ts
+++ b/dogfood/src/cli-admit.ts
@@ -2,39 +2,56 @@
 /**
  * CLI entry point for issue admission scoring.
  *
- * Scores a GitHub issue using the Product Priority Algorithm (RFC-0008
- * §A.6 admission-subset composite) and outputs a JSON verdict
- * indicating whether it should enter the pipeline.
+ * Scores an issue (GitHub or Backlog.md) using the Product Priority
+ * Algorithm (RFC-0008 §A.6 admission-subset composite) and outputs a
+ * JSON verdict indicating whether it should enter the pipeline.
  *
- * Usage:
+ * GitHub usage:
  *   admit --title "..." --body-file /tmp/body.txt --issue-number 42 \
  *     --labels '["bug"]' --reactions 3 --comments 2 --created-at 2026-01-01T00:00:00Z
+ *
+ * Backlog usage:
+ *   admit --tracker backlog --task-id AISDLC-42 [--config-root /repo]
+ *   admit --tracker backlog --task-file /path/to/aisdlc-42.md
  *
  * Optional RFC-0008 flags (stateless by default):
  *   --enrich-from-state              Load .ai-sdlc/ config + state store,
  *                                     resolve refs, and populate enrichment
  *                                     context (C2/C3/C4/C5).
+ *   --config-root <path>              Override the directory whose .ai-sdlc/
+ *                                     and state.db are consulted. Defaults
+ *                                     to a walk-up from --body-file or cwd.
  *   --design-system-ref <name>        Override DSB selection by name.
  *   --autonomy-policy-ref <name>      Override AutonomyPolicy selection.
  *   --did-ref <name>                  Override DesignIntentDocument selection.
- *   --author-login <handle>           Issue author GitHub handle (C5 match).
+ *   --author-login <handle>           Issue author handle (C5 match).
  *   --code-area <path>                Code area identifier (C3 lookup).
  */
 
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 import {
   DEFAULT_CONFIG_DIR_NAME,
+  loadBacklogTaskFromRoot,
   loadConfigAsync,
+  loadSoulTracks,
+  mapBacklogTaskToAdmissionInput,
+  parseBacklogTask,
   resolveRepoRoot,
   scoreIssueForAdmission,
   enrichAdmissionInput,
   StateStore,
   type AdmissionInput,
   type AdmissionThresholds,
+  type BacklogAdmissionMapping,
   type EnrichmentContext,
 } from '@ai-sdlc/orchestrator';
-import type { AutonomyPolicy, DesignIntentDocument, DesignSystemBinding } from '@ai-sdlc/reference';
+import type {
+  AutonomyPolicy,
+  DesignIntentDocument,
+  DesignSystemBinding,
+  PriorityInput,
+} from '@ai-sdlc/reference';
 import { assertSafeReadPath, UnsafePathError } from './safe-path.js';
 
 // ── Arg parsing ──────────────────────────────────────────────────────
@@ -49,25 +66,35 @@ function hasFlag(argv: string[], flag: string): boolean {
   return argv.indexOf(flag) !== -1;
 }
 
+type Tracker = 'github' | 'backlog' | 'auto';
+
 interface AdmitArgs {
-  title: string;
+  tracker: Tracker;
+  title?: string;
   body: string;
   bodyFile?: string;
-  issueNumber: number;
+  taskId?: string;
+  taskFile?: string;
+  issueNumber?: number;
   labels: string[];
   reactions: number;
   comments: number;
-  createdAt: string;
+  createdAt?: string;
   authorAssociation: string;
   authorLogin?: string;
   codeArea?: string;
   enrichFromState: boolean;
+  configRoot?: string;
   designSystemRef?: string;
   autonomyPolicyRef?: string;
   didRef?: string;
+  maintainers?: string[];
 }
 
 function parseArgs(argv: string[]): AdmitArgs {
+  const trackerArg = (getArg(argv, '--tracker') as Tracker | undefined) ?? 'auto';
+  const taskId = getArg(argv, '--task-id');
+  const taskFile = getArg(argv, '--task-file');
   const title = getArg(argv, '--title') ?? process.env.ISSUE_TITLE;
   const bodyFile = getArg(argv, '--body-file');
   const issueNumberStr = getArg(argv, '--issue-number');
@@ -78,18 +105,33 @@ function parseArgs(argv: string[]): AdmitArgs {
   const authorAssociation = getArg(argv, '--author-association') ?? 'NONE';
   const authorLogin = getArg(argv, '--author-login');
   const codeArea = getArg(argv, '--code-area');
+  const configRoot = getArg(argv, '--config-root');
   const designSystemRef = getArg(argv, '--design-system-ref');
   const autonomyPolicyRef = getArg(argv, '--autonomy-policy-ref');
   const didRef = getArg(argv, '--did-ref');
   const enrichFromState = hasFlag(argv, '--enrich-from-state');
 
-  if (!title || !issueNumberStr) {
+  // Tracker auto-detection
+  let tracker: Tracker = trackerArg;
+  if (tracker === 'auto') {
+    if (taskId || taskFile) tracker = 'backlog';
+    else tracker = 'github';
+  }
+
+  // Validation per tracker
+  if (tracker === 'backlog') {
+    if (!taskId && !taskFile) {
+      console.error('Usage: admit --tracker backlog --task-id <id> [--config-root <path>]');
+      console.error('       admit --tracker backlog --task-file <path>');
+      process.exit(1);
+    }
+  } else if (!title || !issueNumberStr) {
     console.error('Usage: admit --title "..." --body-file /path --issue-number N');
     console.error(
       '       --labels \'["bug"]\' --reactions N --comments N --created-at ISO --author-association OWNER',
     );
     console.error(
-      '       [--enrich-from-state] [--design-system-ref NAME] [--autonomy-policy-ref NAME] [--did-ref NAME]',
+      '       [--enrich-from-state] [--config-root PATH] [--design-system-ref NAME] [--autonomy-policy-ref NAME] [--did-ref NAME]',
     );
     console.error('       [--author-login HANDLE] [--code-area PATH]');
     process.exit(1);
@@ -105,22 +147,59 @@ function parseArgs(argv: string[]): AdmitArgs {
   }
 
   return {
+    tracker,
     title,
     body: '',
     bodyFile,
-    issueNumber: Number(issueNumberStr),
+    taskId,
+    taskFile,
+    issueNumber: issueNumberStr ? Number(issueNumberStr) : undefined,
     labels,
     reactions: Number(reactionsStr ?? '0'),
     comments: Number(commentsStr ?? '0'),
-    createdAt: createdAt ?? new Date().toISOString(),
+    createdAt,
     authorAssociation,
     authorLogin,
     codeArea,
     enrichFromState,
+    configRoot,
     designSystemRef,
     autonomyPolicyRef,
     didRef,
   };
+}
+
+// ── Config root resolution ───────────────────────────────────────────
+
+function findUpwards(start: string, marker: string): string | undefined {
+  let dir = resolve(start);
+  for (let i = 0; i < 10; i++) {
+    if (existsSync(join(dir, marker))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+  return undefined;
+}
+
+function resolveConfigRoot(
+  args: AdmitArgs,
+  cwd: string,
+): { configRoot: string; source: 'flag' | 'body-file' | 'task-file' | 'cwd-walk' | 'fallback' } {
+  if (args.configRoot) {
+    return { configRoot: resolve(args.configRoot), source: 'flag' };
+  }
+  if (args.taskFile) {
+    const fromTask = findUpwards(dirname(args.taskFile), DEFAULT_CONFIG_DIR_NAME);
+    if (fromTask) return { configRoot: fromTask, source: 'task-file' };
+  }
+  if (args.bodyFile && isAbsolute(args.bodyFile)) {
+    const fromBody = findUpwards(dirname(args.bodyFile), DEFAULT_CONFIG_DIR_NAME);
+    if (fromBody) return { configRoot: fromBody, source: 'body-file' };
+  }
+  const fromCwd = findUpwards(cwd, DEFAULT_CONFIG_DIR_NAME);
+  if (fromCwd) return { configRoot: fromCwd, source: 'cwd-walk' };
+  return { configRoot: cwd, source: 'fallback' };
 }
 
 // ── Resource selection ───────────────────────────────────────────────
@@ -147,46 +226,85 @@ function selectAutonomyPolicy(
   policy: AutonomyPolicy | undefined,
   ref: string | undefined,
 ): AutonomyPolicy | undefined {
-  // AutonomyPolicy is a single-instance resource in AiSdlcConfig today;
-  // accepting a ref for future-proofing lets the workflow name it
-  // explicitly even when there's only one.
   if (!policy) return undefined;
   if (ref && policy.metadata.name !== ref) return undefined;
   return policy;
+}
+
+// ── Backlog path ─────────────────────────────────────────────────────
+
+function loadBacklogMapping(args: AdmitArgs, configRoot: string): BacklogAdmissionMapping {
+  let snapshot;
+  if (args.taskFile) {
+    const safe = assertSafeReadPath(args.taskFile, configRoot);
+    snapshot = parseBacklogTask(readFileSync(safe, 'utf-8'), safe);
+  } else if (args.taskId) {
+    snapshot = loadBacklogTaskFromRoot(configRoot, args.taskId);
+    if (!snapshot) {
+      console.error(
+        `Backlog task ${args.taskId} not found under ${configRoot}/backlog/{tasks,completed}`,
+      );
+      process.exit(1);
+    }
+  } else {
+    console.error('Backlog mode requires --task-id or --task-file');
+    process.exit(1);
+  }
+  const soulTracks = loadSoulTracks(configRoot);
+  return mapBacklogTaskToAdmissionInput(snapshot, {
+    soulTracks,
+    maintainers: args.maintainers,
+  });
+}
+
+// ── GitHub path ──────────────────────────────────────────────────────
+
+function buildGitHubAdmissionInput(args: AdmitArgs, workDir: string): AdmissionInput {
+  let body = '';
+  if (args.bodyFile) {
+    try {
+      const safe = assertSafeReadPath(args.bodyFile, workDir);
+      body = readFileSync(safe, 'utf-8');
+    } catch (err) {
+      if (err instanceof UnsafePathError) {
+        console.error(err.message);
+        process.exit(1);
+      }
+      body = '';
+    }
+  }
+  return {
+    issueNumber: args.issueNumber!,
+    title: args.title!,
+    body,
+    labels: args.labels,
+    reactionCount: args.reactions,
+    commentCount: args.comments,
+    createdAt: args.createdAt ?? new Date().toISOString(),
+    authorAssociation: args.authorAssociation as AdmissionInput['authorAssociation'],
+    ...(args.authorLogin ? { authorLogin: args.authorLogin } : {}),
+  };
 }
 
 // ── Main ─────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv);
+  const cwd = await resolveRepoRoot();
+  const { configRoot, source: configSource } = resolveConfigRoot(args, cwd);
 
-  // Resolve repo root first so we can validate user-supplied paths.
-  const workDir = await resolveRepoRoot();
+  // Build admission input + optional priority overrides per tracker
+  let admissionInput: AdmissionInput;
+  let priorityOverrides: Partial<PriorityInput> | undefined;
+  let backlogMapping: BacklogAdmissionMapping | undefined;
 
-  if (args.bodyFile) {
-    try {
-      const safe = assertSafeReadPath(args.bodyFile, workDir);
-      args.body = readFileSync(safe, 'utf-8');
-    } catch (err) {
-      if (err instanceof UnsafePathError) {
-        console.error(err.message);
-        process.exit(1);
-      }
-      args.body = '';
-    }
+  if (args.tracker === 'backlog') {
+    backlogMapping = loadBacklogMapping(args, configRoot);
+    admissionInput = backlogMapping.input;
+    priorityOverrides = backlogMapping.priorityInputOverrides;
+  } else {
+    admissionInput = buildGitHubAdmissionInput(args, configRoot);
   }
-
-  const input: AdmissionInput = {
-    issueNumber: args.issueNumber,
-    title: args.title,
-    body: args.body,
-    labels: args.labels,
-    reactionCount: args.reactions,
-    commentCount: args.comments,
-    createdAt: args.createdAt,
-    authorAssociation: args.authorAssociation as AdmissionInput['authorAssociation'],
-    ...(args.authorLogin ? { authorLogin: args.authorLogin } : {}),
-  };
 
   // Load priority policy thresholds from pipeline.yaml
   let thresholds: AdmissionThresholds = {
@@ -194,10 +312,13 @@ async function main(): Promise<void> {
     minimumConfidence: 0.2,
   };
 
-  let enrichedInput = input;
+  let enrichedInput = admissionInput;
+  let resolvedDsbName: string | undefined;
+  let resolvedDidName: string | undefined;
+  let resolvedAutonomyPolicyName: string | undefined;
 
   try {
-    const configDir = join(workDir, DEFAULT_CONFIG_DIR_NAME);
+    const configDir = join(configRoot, DEFAULT_CONFIG_DIR_NAME);
     const config = await loadConfigAsync(configDir);
     const policy = config.pipeline?.spec?.priorityPolicy;
     if (policy) {
@@ -211,8 +332,11 @@ async function main(): Promise<void> {
       const dsb = selectDsb(config.designSystemBindings, args.designSystemRef);
       const did = selectDid(config.designIntentDocuments, args.didRef);
       const autonomyPolicy = selectAutonomyPolicy(config.autonomyPolicy, args.autonomyPolicyRef);
+      resolvedDsbName = dsb?.metadata.name;
+      resolvedDidName = did?.metadata.name;
+      resolvedAutonomyPolicyName = autonomyPolicy?.metadata.name;
 
-      const stateDbPath = join(workDir, '.ai-sdlc', 'state.db');
+      const stateDbPath = join(configRoot, '.ai-sdlc', 'state.db');
       let stateStore: StateStore | undefined;
       try {
         stateStore = StateStore.open(stateDbPath);
@@ -228,16 +352,44 @@ async function main(): Promise<void> {
         ...(args.codeArea ? { codeArea: args.codeArea } : {}),
       };
 
-      enrichedInput = enrichAdmissionInput(input, ctx);
+      enrichedInput = enrichAdmissionInput(admissionInput, ctx);
       stateStore?.close();
     }
   } catch {
     console.error('Warning: could not load pipeline config, using default thresholds');
   }
 
-  const result = scoreIssueForAdmission(enrichedInput, thresholds);
+  // Provenance line on stderr — makes "wrong product enrichment"
+  // detectable when running cli-admit from one repo against another's
+  // tracker (the silent failure mode the bug fix targets).
+  if (configSource === 'fallback') {
+    console.error(
+      `WARN: enrichment context resolved to ${configRoot} via fallback — confirm this is the right product`,
+    );
+  }
+  console.error(
+    JSON.stringify({
+      provenance: {
+        tracker: args.tracker,
+        configRoot,
+        configSource,
+        designSystemBinding: resolvedDsbName,
+        designIntentDocument: resolvedDidName,
+        autonomyPolicy: resolvedAutonomyPolicyName,
+      },
+    }),
+  );
 
-  // Output JSON on last line for the workflow to capture
+  const result = scoreIssueForAdmission(enrichedInput, thresholds, undefined, {
+    ...(priorityOverrides ? { priorityInputOverrides: priorityOverrides } : {}),
+  });
+
+  // Attach quality flags from the Backlog mapping so renderers can
+  // surface them without reaching back into the snapshot.
+  if (backlogMapping?.qualityFlags.length) {
+    (result as unknown as Record<string, unknown>).qualityFlags = backlogMapping.qualityFlags;
+  }
+
   console.log(JSON.stringify(result));
 }
 

--- a/dogfood/src/safe-path.test.ts
+++ b/dogfood/src/safe-path.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { assertSafeReadPath, UnsafePathError } from './safe-path.js';
+
+describe('UnsafePathError', () => {
+  it('inherits from Error and carries the conventional name', () => {
+    const err = new UnsafePathError('boom');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('UnsafePathError');
+    expect(err.message).toBe('boom');
+  });
+});
+
+describe('assertSafeReadPath', () => {
+  it('accepts a path that lives under the supplied repo root', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'safe-path-'));
+    try {
+      const target = join(tmp, 'body.txt');
+      writeFileSync(target, 'hello');
+      expect(assertSafeReadPath(target, tmp)).toContain('body.txt');
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+
+  it('accepts a path under os.tmpdir()', () => {
+    const target = join(tmpdir(), 'safe-path-test-tmpdir.txt');
+    writeFileSync(target, 'hello');
+    try {
+      expect(assertSafeReadPath(target, '/some/other/repo')).toBeTruthy();
+    } finally {
+      rmSync(target);
+    }
+  });
+
+  it('rejects a path outside any allowed root', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'safe-path-'));
+    try {
+      // /etc/hosts lives under / — not under the repo root, not under
+      // any tmp dir, and not under RUNNER_TEMP. Must throw.
+      expect(() => assertSafeReadPath('/etc/hosts', tmp)).toThrow(UnsafePathError);
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+
+  it('falls back to the resolved form when the file does not exist (yet)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'safe-path-'));
+    try {
+      const target = join(tmp, 'will-not-exist.txt');
+      // No throw — caller's readFileSync will raise ENOENT with a clear message.
+      expect(assertSafeReadPath(target, tmp)).toContain('will-not-exist.txt');
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+
+  it('accepts /tmp on macOS even though os.tmpdir() returns a different path', () => {
+    // The fix: /tmp is in allowedRoots even when os.tmpdir() is /var/folders/.../T.
+    // We assume /tmp exists on the host (it does on macOS, Linux, WSL).
+    const target = '/tmp/safe-path-tmp-test.txt';
+    writeFileSync(target, 'hello');
+    try {
+      // Pass an unrelated repo root so the only viable allowed-root is /tmp.
+      expect(assertSafeReadPath(target, '/some/other/repo')).toBeTruthy();
+    } finally {
+      rmSync(target);
+    }
+  });
+});

--- a/dogfood/src/safe-path.ts
+++ b/dogfood/src/safe-path.ts
@@ -7,7 +7,7 @@
  */
 
 import { existsSync, realpathSync } from 'node:fs';
-import { resolve, sep } from 'node:path';
+import { basename, dirname, resolve, sep } from 'node:path';
 import { tmpdir } from 'node:os';
 
 export class UnsafePathError extends Error {
@@ -49,9 +49,15 @@ export function assertSafeReadPath(userPath: string, repoRoot: string): string {
   try {
     real = realpathSync(resolved);
   } catch {
-    // File doesn't exist (yet) — fall back to the resolved form. The
-    // subsequent readFileSync will raise ENOENT with a clear message.
-    real = resolved;
+    // File doesn't exist (yet) — resolve the parent's realpath instead
+    // and rejoin the basename. This preserves the symlink resolution
+    // (macOS /var → /private/var) needed for the trust check, while
+    // letting the subsequent readFileSync raise ENOENT itself.
+    try {
+      real = resolve(realpathSync(dirname(resolved)), basename(resolved));
+    } catch {
+      real = resolved;
+    }
   }
   const realWithSep = real.endsWith(sep) ? real : real + sep;
   for (const root of allowedRoots(repoRoot)) {

--- a/dogfood/src/safe-path.ts
+++ b/dogfood/src/safe-path.ts
@@ -6,7 +6,7 @@
  * RUNNER_TEMP). Refuses symlinks that escape these roots.
  */
 
-import { realpathSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { resolve, sep } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -20,6 +20,11 @@ export class UnsafePathError extends Error {
 function allowedRoots(repoRoot: string): string[] {
   const roots = [repoRoot, tmpdir()];
   if (process.env.RUNNER_TEMP) roots.push(process.env.RUNNER_TEMP);
+  // macOS workflows and shell scripts commonly write to /tmp explicitly,
+  // but `os.tmpdir()` returns `/var/folders/.../T` there. Allow `/tmp`
+  // (and its realpath, which resolves to /private/tmp on macOS) so the
+  // documented `/tmp/issue-body.txt` UX works across Linux + macOS.
+  if (existsSync('/tmp')) roots.push('/tmp');
   // Canonicalize once; include trailing separator so "/repoX" does not
   // prefix-match "/repo".
   return roots.map((r) => {

--- a/orchestrator/src/admission-composite.test.ts
+++ b/orchestrator/src/admission-composite.test.ts
@@ -256,6 +256,55 @@ describe('computeAdmissionComposite — §A.6 admission subset', () => {
     expect(over.breakdown.soulAlignment).toBe(1);
     expect(under.breakdown.soulAlignment).toBe(0);
   });
+
+  it('priorityInputOverrides win over the GitHub-mapper output (Backlog adapter path)', () => {
+    // Input that the GitHub mapper would shape: 'spec' label → SA 0.9,
+    // body Complexity → 3, no priority labels → explicitPriority undefined.
+    const input = makeInput({
+      body: '### Complexity\n3',
+      labels: ['spec'],
+    });
+    const baseline = computeAdmissionComposite(input);
+    const overridden = computeAdmissionComposite(input, undefined, {
+      priorityInputOverrides: {
+        soulAlignment: 0.4,
+        complexity: 8,
+        explicitPriority: 1.0,
+      },
+    });
+    // GitHub mapper said SA=0.9; override says 0.4 — override wins.
+    expect(baseline.breakdown.soulAlignment).toBeCloseTo(0.9, 6);
+    expect(overridden.breakdown.soulAlignment).toBeCloseTo(0.4, 6);
+    // GitHub mapper said complexity=3 → baseER=0.7; override says 8 → 0.2.
+    expect(baseline.breakdown.baseExecutionReality).toBeCloseTo(0.7, 6);
+    expect(overridden.breakdown.baseExecutionReality).toBeCloseTo(0.2, 6);
+    // Composite reflects both shifts.
+    expect(overridden.score.composite).toBeLessThan(baseline.score.composite);
+  });
+
+  it('priorityInputOverrides ignores undefined values (preserves GitHub defaults)', () => {
+    const input = makeInput({ body: '### Complexity\n5', labels: ['spec'] });
+    const baseline = computeAdmissionComposite(input);
+    // soulAlignment undefined → don't overwrite the GitHub mapper's 0.9.
+    const partial = computeAdmissionComposite(input, undefined, {
+      priorityInputOverrides: { soulAlignment: undefined, complexity: 9 },
+    });
+    expect(partial.breakdown.soulAlignment).toBeCloseTo(baseline.breakdown.soulAlignment, 6);
+    // complexity 9 → baseER=0.1, distinct from baseline's complexity=5 → 0.5
+    expect(partial.breakdown.baseExecutionReality).toBeCloseTo(0.1, 6);
+  });
+
+  it('soulAlignmentOverride wins over priorityInputOverrides.soulAlignment', () => {
+    // soulAlignmentOverride is the M5 SA-1 path; priorityInputOverrides is
+    // the tracker-adapter path. Spec: M5 SA-1 takes precedence when both
+    // are present (it's a calibrated score, not a heuristic).
+    const input = makeInput({ body: '### Complexity\n5', labels: ['spec'] });
+    const result = computeAdmissionComposite(input, undefined, {
+      soulAlignmentOverride: 0.2,
+      priorityInputOverrides: { soulAlignment: 0.9 },
+    });
+    expect(result.breakdown.soulAlignment).toBeCloseTo(0.2, 6);
+  });
 });
 
 describe('computeAdmissionComposite — override position-1 bypass', () => {

--- a/orchestrator/src/admission-composite.ts
+++ b/orchestrator/src/admission-composite.ts
@@ -25,7 +25,7 @@
  * the admission math — identical to the legacy PPA behaviour.
  */
 
-import type { PriorityConfig, PriorityScore } from '@ai-sdlc/reference';
+import type { PriorityConfig, PriorityInput, PriorityScore } from '@ai-sdlc/reference';
 import type { AdmissionInput } from './admission-score.js';
 import { mapIssueToPriorityInput } from './admission-score.js';
 import {
@@ -66,6 +66,14 @@ export interface AdmissionCompositeOptions {
    * callers pass undefined and the label-based fallback applies.
    */
   soulAlignmentOverride?: number;
+  /**
+   * Partial PriorityInput overrides applied AFTER `mapIssueToPriorityInput`.
+   * Used by non-GitHub trackers (e.g. Backlog.md adapter) to inject
+   * tracker-specific signals — `priority:p*` labels, AC-derived
+   * complexity, `qualityFlags` — that the GitHub-shaped mapper
+   * cannot extract. Only fields with defined values overwrite.
+   */
+  priorityInputOverrides?: Partial<PriorityInput>;
 }
 
 export function computeAdmissionComposite(
@@ -74,7 +82,10 @@ export function computeAdmissionComposite(
   options?: AdmissionCompositeOptions,
 ): AdmissionComposite {
   const timestamp = new Date().toISOString();
-  const priorityInput = mapIssueToPriorityInput(input);
+  const baseInput = mapIssueToPriorityInput(input);
+  const priorityInput = options?.priorityInputOverrides
+    ? mergePriorityInputOverrides(baseInput, options.priorityInputOverrides)
+    : baseInput;
 
   // ── Override path: position-1 bypass (§6 / AC #4) ─────────────
   if (priorityInput.override) {
@@ -191,4 +202,23 @@ function clamp01(value: number): number {
 function clampCalibration(value: number | undefined): number {
   if (value === undefined) return 1.0;
   return Math.min(1.3, Math.max(0.7, value));
+}
+
+/**
+ * Apply non-GitHub tracker overrides on top of the GitHub-shaped
+ * `mapIssueToPriorityInput` output. A field's override wins iff it is
+ * not `undefined`; this preserves the GitHub mapper's defaults for
+ * any field the override does not specify.
+ */
+function mergePriorityInputOverrides(
+  base: PriorityInput,
+  overrides: Partial<PriorityInput>,
+): PriorityInput {
+  const merged: PriorityInput = { ...base };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value !== undefined) {
+      (merged as unknown as Record<string, unknown>)[key] = value;
+    }
+  }
+  return merged;
 }

--- a/orchestrator/src/admission-score.ts
+++ b/orchestrator/src/admission-score.ts
@@ -285,8 +285,9 @@ export function scoreIssueForAdmission(
   input: AdmissionInput,
   thresholds: AdmissionThresholds,
   priorityConfig?: PriorityConfig,
+  options?: import('./admission-composite.js').AdmissionCompositeOptions,
 ): IssueAdmissionResult {
-  const composite = computeAdmissionComposite(input, priorityConfig);
+  const composite = computeAdmissionComposite(input, priorityConfig, options);
   const { score } = composite;
   const pillarBreakdown = computePillarBreakdown(composite);
 

--- a/orchestrator/src/backlog-adapter.test.ts
+++ b/orchestrator/src/backlog-adapter.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  parseBacklogTask,
+  loadBacklogTaskFromRoot,
+  mapBacklogTaskToAdmissionInput,
+  loadSoulTracks,
+  type BacklogTaskSnapshot,
+} from './backlog-adapter.js';
+
+const FIXTURE = `---
+id: AISDLC-42
+title: Add Backlog tracker adapter
+status: To Do
+priority: high
+labels:
+  - priority:p1
+  - size:M
+  - track:reflect
+  - source:rfc
+created_date: '2026-04-25 09:00'
+updated_date: '2026-04-25 09:00'
+created_by: alice
+references:
+  - orchestrator/src/admission-score.ts
+  - orchestrator/src/cli-admit.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the Backlog.md tracker adapter so admission scoring works on
+non-GitHub trackers.
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 Frontmatter parser handles labels, references, dates
+- [x] #2 Label-mapping table covers priority/size/track/source
+- [ ] #3 Quality flags surface zombie closes
+- [ ] #4 cli-admit dispatch picks the right tracker
+- [ ] #5 --config-root resolves cross-repo enrichment
+<!-- AC:END -->
+`;
+
+function snapWith(overrides: Partial<BacklogTaskSnapshot>): BacklogTaskSnapshot {
+  return {
+    id: 'TASK-1',
+    numericId: 1,
+    title: 't',
+    description: '',
+    status: 'To Do',
+    priority: null,
+    labels: [],
+    createdDate: '2026-04-25 09:00',
+    updatedDate: '2026-04-25 09:00',
+    acceptanceCriteria: [],
+    references: [],
+    ...overrides,
+  };
+}
+
+describe('parseBacklogTask', () => {
+  it('parses frontmatter, description, and AC checklist', () => {
+    const snap = parseBacklogTask(FIXTURE);
+    expect(snap.id).toBe('AISDLC-42');
+    expect(snap.numericId).toBe(42);
+    expect(snap.title).toBe('Add Backlog tracker adapter');
+    expect(snap.status).toBe('To Do');
+    expect(snap.priority).toBe('high');
+    expect(snap.labels).toEqual(['priority:p1', 'size:M', 'track:reflect', 'source:rfc']);
+    expect(snap.references).toHaveLength(2);
+    expect(snap.createdBy).toBe('alice');
+    expect(snap.acceptanceCriteria).toHaveLength(5);
+    expect(snap.acceptanceCriteria[0]).toEqual({
+      index: 1,
+      text: 'Frontmatter parser handles labels, references, dates',
+      checked: true,
+    });
+    expect(snap.acceptanceCriteria[2].checked).toBe(false);
+    expect(snap.description).toContain('Implement the Backlog.md tracker adapter');
+  });
+
+  it('throws on missing frontmatter', () => {
+    expect(() => parseBacklogTask('no frontmatter here')).toThrow(/missing YAML frontmatter/);
+  });
+
+  it('throws on missing id', () => {
+    const noId = '---\ntitle: No id\n---\n\nbody';
+    expect(() => parseBacklogTask(noId)).toThrow(/missing `id`/);
+  });
+
+  it('handles empty acceptance criteria gracefully', () => {
+    const minimal = `---\nid: AISDLC-1\ntitle: t\nstatus: To Do\n---\n\n## Description\n\nfoo`;
+    const snap = parseBacklogTask(minimal);
+    expect(snap.acceptanceCriteria).toEqual([]);
+  });
+
+  it('handles inline `[]` empty labels', () => {
+    const fm = `---\nid: AISDLC-2\ntitle: t\nstatus: To Do\nlabels: []\n---\n\nbody`;
+    const snap = parseBacklogTask(fm);
+    expect(snap.labels).toEqual([]);
+  });
+});
+
+describe('loadBacklogTaskFromRoot', () => {
+  it('finds a task in backlog/tasks/', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'backlog-load-'));
+    try {
+      mkdirSync(join(tmp, 'backlog', 'tasks'), { recursive: true });
+      writeFileSync(
+        join(tmp, 'backlog', 'tasks', 'aisdlc-7 - Hello.md'),
+        `---\nid: AISDLC-7\ntitle: Hello\nstatus: To Do\n---\n`,
+      );
+      const snap = loadBacklogTaskFromRoot(tmp, 'AISDLC-7');
+      expect(snap?.id).toBe('AISDLC-7');
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+
+  it('finds a completed task in backlog/completed/', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'backlog-load-'));
+    try {
+      mkdirSync(join(tmp, 'backlog', 'completed'), { recursive: true });
+      writeFileSync(
+        join(tmp, 'backlog', 'completed', 'aisdlc-9 - Done.md'),
+        `---\nid: AISDLC-9\ntitle: Done\nstatus: Done\n---\n`,
+      );
+      expect(loadBacklogTaskFromRoot(tmp, 'AISDLC-9')?.id).toBe('AISDLC-9');
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+
+  it('returns undefined when no matching file exists', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'backlog-load-'));
+    try {
+      expect(loadBacklogTaskFromRoot(tmp, 'NOPE-1')).toBeUndefined();
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+});
+
+describe('mapBacklogTaskToAdmissionInput — label mapping', () => {
+  it('priority:p0 → explicitPriority 1.0', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapWith({ labels: ['priority:p0'] }));
+    expect(m.priorityInputOverrides.explicitPriority).toBe(1.0);
+  });
+
+  it('priority:p1 → 0.75, priority:p2 → 0.5, priority:p3 → 0.25', () => {
+    expect(
+      mapBacklogTaskToAdmissionInput(snapWith({ labels: ['priority:p1'] })).priorityInputOverrides
+        .explicitPriority,
+    ).toBe(0.75);
+    expect(
+      mapBacklogTaskToAdmissionInput(snapWith({ labels: ['priority:p2'] })).priorityInputOverrides
+        .explicitPriority,
+    ).toBe(0.5);
+    expect(
+      mapBacklogTaskToAdmissionInput(snapWith({ labels: ['priority:p3'] })).priorityInputOverrides
+        .explicitPriority,
+    ).toBe(0.25);
+  });
+
+  it('falls back to frontmatter priority field when no priority:p* label', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapWith({ priority: 'high' }));
+    expect(m.priorityInputOverrides.explicitPriority).toBe(0.75);
+  });
+
+  it('size:S/M/L/XL → complexity 2/5/7/9', () => {
+    const get = (label: string) =>
+      mapBacklogTaskToAdmissionInput(snapWith({ labels: [label] })).priorityInputOverrides
+        .complexity;
+    expect(get('size:S')).toBe(2);
+    expect(get('size:M')).toBe(5);
+    expect(get('size:L')).toBe(7);
+    expect(get('size:XL')).toBe(9);
+  });
+
+  it('source:rfc → soulAlignment 0.9', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapWith({ labels: ['source:rfc'] }));
+    expect(m.priorityInputOverrides.soulAlignment).toBe(0.9);
+  });
+
+  it('governance/compliance → soulAlignment 0.85', () => {
+    expect(
+      mapBacklogTaskToAdmissionInput(snapWith({ labels: ['governance'] })).priorityInputOverrides
+        .soulAlignment,
+    ).toBe(0.85);
+  });
+
+  it('track:* uses soul-tracks.json overrides', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapWith({ labels: ['track:enchantment'] }), {
+      soulTracks: { 'track:enchantment': 0.85 },
+    });
+    expect(m.priorityInputOverrides.soulAlignment).toBe(0.85);
+  });
+
+  it('default soul-track for track:ops is 0.55', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapWith({ labels: ['track:ops'] }));
+    expect(m.priorityInputOverrides.soulAlignment).toBe(0.55);
+  });
+
+  it('bug → bugSeverity 3', () => {
+    expect(
+      mapBacklogTaskToAdmissionInput(snapWith({ labels: ['bug'] })).priorityInputOverrides
+        .bugSeverity,
+    ).toBe(3);
+  });
+
+  it('security → bugSeverity 5 + soulAlignment floor 0.7', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapWith({ labels: ['security'] }));
+    expect(m.priorityInputOverrides.bugSeverity).toBe(5);
+    expect(m.priorityInputOverrides.soulAlignment).toBe(0.7);
+  });
+
+  it('source:*-tonight → demandSignal 0.7 + competitiveDrift bump', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapWith({ labels: ['source:s186-tonight'] }));
+    expect(m.priorityInputOverrides.demandSignal).toBe(0.7);
+    expect(m.priorityInputOverrides.competitiveDrift).toBeCloseTo(0.2, 6);
+  });
+
+  it('scope:v1-ship + tonight → competitiveDrift saturates near 0.8', () => {
+    const m = mapBacklogTaskToAdmissionInput(
+      snapWith({ labels: ['scope:v1-ship', 'source:s1-tonight'] }),
+    );
+    expect(m.priorityInputOverrides.competitiveDrift).toBeCloseTo(0.8, 6);
+  });
+
+  it('competitiveDrift caps at 1.0', () => {
+    const m = mapBacklogTaskToAdmissionInput(
+      snapWith({
+        labels: ['scope:v1-ship', 'source:a-tonight', 'source:b-tonight', 'source:c-tonight'],
+      }),
+    );
+    expect(m.priorityInputOverrides.competitiveDrift).toBe(1);
+  });
+
+  it('multiple references → builderConviction 0.7', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapWith({ references: ['a.ts', 'b.ts'] }));
+    expect(m.priorityInputOverrides.builderConviction).toBe(0.7);
+  });
+
+  it('single reference → builderConviction 0.6', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapWith({ references: ['a.ts'] }));
+    expect(m.priorityInputOverrides.builderConviction).toBe(0.6);
+  });
+
+  it('OWNER author-association when createdBy is in maintainers list', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapWith({ createdBy: 'alice' }), {
+      maintainers: ['alice'],
+    });
+    expect(m.input.authorAssociation).toBe('OWNER');
+  });
+
+  it('MEMBER author-association by default', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapWith({ createdBy: 'bob' }));
+    expect(m.input.authorAssociation).toBe('MEMBER');
+  });
+});
+
+describe('mapBacklogTaskToAdmissionInput — AC progress + quality flags', () => {
+  function snapACs(total: number, checked: number, status = 'Done'): BacklogTaskSnapshot {
+    return snapWith({
+      status,
+      acceptanceCriteria: Array.from({ length: total }, (_, i) => ({
+        index: i + 1,
+        text: `ac ${i + 1}`,
+        checked: i < checked,
+      })),
+    });
+  }
+
+  it('derives complexity from AC count when no size label is present', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapACs(7, 7, 'To Do'));
+    // 1 + 7 × 0.6 = 5.2
+    expect(m.priorityInputOverrides.complexity).toBeCloseTo(5.2, 6);
+  });
+
+  it('AC complexity caps at 9', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapACs(20, 0, 'To Do'));
+    expect(m.priorityInputOverrides.complexity).toBe(9);
+  });
+
+  it('size label wins over AC-derived complexity', () => {
+    const snap = { ...snapACs(20, 0, 'To Do'), labels: ['size:S'] };
+    const m = mapBacklogTaskToAdmissionInput(snap);
+    expect(m.priorityInputOverrides.complexity).toBe(2);
+  });
+
+  it('Done with all ACs checked → no quality flag', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapACs(5, 5, 'Done'));
+    expect(m.qualityFlags).toEqual([]);
+    expect(m.priorityInputOverrides.defectRiskFactor).toBeUndefined();
+    expect(m.priorityInputOverrides.qualityFlags).toBeUndefined();
+  });
+
+  it('Done with 5/7 checked → medium-severity zombie close + defectRiskFactor 0.15', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapACs(7, 5, 'Done'));
+    expect(m.qualityFlags).toHaveLength(1);
+    expect(m.qualityFlags[0].kind).toBe('unchecked-acs-on-done');
+    expect(m.qualityFlags[0].severity).toBe('medium');
+    expect(m.qualityFlags[0].detail).toBe('2/7 ACs unchecked');
+    expect(m.priorityInputOverrides.defectRiskFactor).toBe(0.15);
+    expect(m.priorityInputOverrides.qualityFlags).toEqual(m.qualityFlags);
+  });
+
+  it('Done with 0/5 checked → high-severity zombie close + defectRiskFactor 0.3', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapACs(5, 0, 'Done'));
+    expect(m.qualityFlags[0].severity).toBe('high');
+    expect(m.priorityInputOverrides.defectRiskFactor).toBe(0.3);
+  });
+
+  it('To Do with 0/5 checked → no flag (only Done qualifies as zombie)', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapACs(5, 0, 'To Do'));
+    expect(m.qualityFlags).toEqual([]);
+  });
+});
+
+describe('mapBacklogTaskToAdmissionInput — body construction', () => {
+  it('renders Description + ### Complexity + ### Acceptance Criteria into body', () => {
+    const m = mapBacklogTaskToAdmissionInput(
+      snapWith({
+        description: 'A short description.',
+        labels: ['size:M'],
+        acceptanceCriteria: [
+          { index: 1, text: 'first', checked: true },
+          { index: 2, text: 'second', checked: false },
+        ],
+      }),
+    );
+    expect(m.input.body).toContain('A short description.');
+    expect(m.input.body).toContain('### Complexity\n\n5');
+    expect(m.input.body).toContain('### Acceptance Criteria');
+    expect(m.input.body).toContain('- [x] first');
+    expect(m.input.body).toContain('- [ ] second');
+  });
+});
+
+describe('mapBacklogTaskToAdmissionInput — date normalisation', () => {
+  it('coerces "2026-04-25 09:00" to ISO', () => {
+    const m = mapBacklogTaskToAdmissionInput(snapWith({}));
+    expect(m.input.createdAt).toBe('2026-04-25T09:00:00Z');
+  });
+});
+
+describe('loadSoulTracks', () => {
+  it('returns empty object when file absent', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'soul-tracks-'));
+    try {
+      expect(loadSoulTracks(tmp)).toEqual({});
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+
+  it('reads valid JSON and filters to numeric values in [0,1]', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'soul-tracks-'));
+    try {
+      mkdirSync(join(tmp, '.ai-sdlc'), { recursive: true });
+      writeFileSync(
+        join(tmp, '.ai-sdlc', 'soul-tracks.json'),
+        JSON.stringify({
+          'track:enchantment': 0.85,
+          'track:reflect': 0.9,
+          'track:bogus': 1.5, // out of range
+          'track:wrong-type': 'high',
+        }),
+      );
+      const tracks = loadSoulTracks(tmp);
+      expect(tracks).toEqual({
+        'track:enchantment': 0.85,
+        'track:reflect': 0.9,
+      });
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+
+  it('returns empty on malformed JSON without throwing', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'soul-tracks-'));
+    try {
+      mkdirSync(join(tmp, '.ai-sdlc'), { recursive: true });
+      writeFileSync(join(tmp, '.ai-sdlc', 'soul-tracks.json'), '{not json');
+      expect(loadSoulTracks(tmp)).toEqual({});
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+});

--- a/orchestrator/src/backlog-adapter.test.ts
+++ b/orchestrator/src/backlog-adapter.test.ts
@@ -143,6 +143,73 @@ describe('loadBacklogTaskFromRoot', () => {
       rmSync(tmp, { recursive: true });
     }
   });
+
+  it('matches a file whose name uses a `.` separator (id.md form)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'backlog-load-'));
+    try {
+      mkdirSync(join(tmp, 'backlog', 'tasks'), { recursive: true });
+      writeFileSync(
+        join(tmp, 'backlog', 'tasks', 'aisdlc-11.md'),
+        `---\nid: AISDLC-11\ntitle: dot form\nstatus: To Do\n---\n`,
+      );
+      expect(loadBacklogTaskFromRoot(tmp, 'AISDLC-11')?.id).toBe('AISDLC-11');
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+
+  it('skips non-matching files in the same directory', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'backlog-load-'));
+    try {
+      mkdirSync(join(tmp, 'backlog', 'tasks'), { recursive: true });
+      // Place a non-matching file FIRST in alphabetical order so
+      // readdirSync iterates past it before reaching the target.
+      // This exercises the entry-filter `continue` branch.
+      writeFileSync(
+        join(tmp, 'backlog', 'tasks', 'aisdlc-1 - First.md'),
+        `---\nid: AISDLC-1\ntitle: First\nstatus: To Do\n---\n`,
+      );
+      writeFileSync(
+        join(tmp, 'backlog', 'tasks', 'aisdlc-7 - Hello.md'),
+        `---\nid: AISDLC-7\ntitle: Hello\nstatus: To Do\n---\n`,
+      );
+      expect(loadBacklogTaskFromRoot(tmp, 'AISDLC-7')?.id).toBe('AISDLC-7');
+    } finally {
+      rmSync(tmp, { recursive: true });
+    }
+  });
+});
+
+describe('parseBacklogTask — frontmatter edge cases', () => {
+  it('skips blank lines and comment lines in frontmatter', () => {
+    const fixture = `---
+# This is a comment
+
+id: AISDLC-50
+title: Has comment
+
+status: To Do
+---
+
+body`;
+    const snap = parseBacklogTask(fixture);
+    expect(snap.id).toBe('AISDLC-50');
+    expect(snap.title).toBe('Has comment');
+  });
+
+  it('skips lines that do not match `key: value` shape', () => {
+    const fixture = `---
+id: AISDLC-51
+this line is not a key value pair
+title: Survives malformed lines
+status: To Do
+---
+
+body`;
+    const snap = parseBacklogTask(fixture);
+    expect(snap.id).toBe('AISDLC-51');
+    expect(snap.title).toBe('Survives malformed lines');
+  });
 });
 
 describe('mapBacklogTaskToAdmissionInput — label mapping', () => {
@@ -216,6 +283,16 @@ describe('mapBacklogTaskToAdmissionInput — label mapping', () => {
     const m = mapBacklogTaskToAdmissionInput(snapWith({ labels: ['security'] }));
     expect(m.priorityInputOverrides.bugSeverity).toBe(5);
     expect(m.priorityInputOverrides.soulAlignment).toBe(0.7);
+  });
+
+  it('critical / p0 label promotes bugSeverity to ≥ 5', () => {
+    const fromCritical = mapBacklogTaskToAdmissionInput(snapWith({ labels: ['critical'] }));
+    expect(fromCritical.priorityInputOverrides.bugSeverity).toBe(5);
+    const fromP0 = mapBacklogTaskToAdmissionInput(snapWith({ labels: ['p0'] }));
+    expect(fromP0.priorityInputOverrides.bugSeverity).toBe(5);
+    // Layered with `bug` (severity 3) → critical wins.
+    const layered = mapBacklogTaskToAdmissionInput(snapWith({ labels: ['bug', 'critical'] }));
+    expect(layered.priorityInputOverrides.bugSeverity).toBe(5);
   });
 
   it('source:*-tonight → demandSignal 0.7 + competitiveDrift bump', () => {

--- a/orchestrator/src/backlog-adapter.ts
+++ b/orchestrator/src/backlog-adapter.ts
@@ -1,0 +1,454 @@
+/**
+ * Backlog.md tracker adapter for the admission composite.
+ *
+ * Backlog.md tasks are markdown files in `backlog/tasks/` (open) or
+ * `backlog/completed/` (archived). They carry YAML frontmatter
+ * (`id`, `title`, `status`, `priority`, `labels`, `references`,
+ * `created_date`, `updated_date`, `assignee`) plus a body that
+ * includes a `## Acceptance Criteria` checklist.
+ *
+ * This module:
+ *   1. Parses a task file into `BacklogTaskSnapshot`
+ *   2. Maps the snapshot onto `AdmissionInput` using the conventions
+ *      in the bug-fix doc (priority:p* / size:[SML] / track:* / etc.)
+ *   3. Emits `qualityFlags` for "Done with unchecked ACs" zombie closes
+ *
+ * The GitHub-shaped `mapIssueToPriorityInput` in `admission-score.ts`
+ * is left intact; the dispatch sits in `cli-admit`.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import type { PriorityInput, QualityFlag } from '@ai-sdlc/reference';
+import type { AdmissionInput } from './admission-score.js';
+
+// ── Snapshot shape ──────────────────────────────────────────────────
+
+export interface BacklogAcceptanceCriterion {
+  index: number;
+  text: string;
+  checked: boolean;
+}
+
+export interface BacklogTaskSnapshot {
+  /** Canonical id from the YAML frontmatter, e.g. "AISDLC-42". */
+  id: string;
+  /** Numeric tail of the id, e.g. 42. */
+  numericId: number;
+  title: string;
+  description: string;
+  status: string;
+  priority: string | null;
+  labels: string[];
+  createdDate: string;
+  updatedDate: string;
+  createdBy?: string;
+  acceptanceCriteria: BacklogAcceptanceCriterion[];
+  references: string[];
+  /** Filesystem path the snapshot was read from. */
+  sourcePath?: string;
+}
+
+// ── Parser ──────────────────────────────────────────────────────────
+
+/**
+ * Parse a Backlog.md task markdown file into `BacklogTaskSnapshot`.
+ * Throws when the frontmatter is missing or malformed.
+ */
+export function parseBacklogTask(content: string, sourcePath?: string): BacklogTaskSnapshot {
+  const fm = extractFrontmatter(content);
+  if (!fm) throw new Error('Backlog task is missing YAML frontmatter');
+
+  const id = String(fm.id ?? '').trim();
+  if (!id) throw new Error('Backlog task frontmatter is missing `id`');
+  const numericId = parseNumericId(id);
+
+  const labels = normaliseLabels(fm.labels);
+  const references = normaliseStringArray(fm.references);
+  const description = extractSection(content, 'Description');
+  const acceptanceCriteria = extractAcceptanceCriteria(content);
+
+  return {
+    id,
+    numericId,
+    title: String(fm.title ?? '').trim(),
+    description,
+    status: String(fm.status ?? '').trim(),
+    priority: fm.priority == null ? null : String(fm.priority).trim(),
+    labels,
+    createdDate: String(fm.created_date ?? '').trim(),
+    updatedDate: String(fm.updated_date ?? '').trim(),
+    createdBy: fm.created_by ? String(fm.created_by).trim() : undefined,
+    acceptanceCriteria,
+    references,
+    sourcePath,
+  };
+}
+
+/**
+ * Resolve a Backlog task id ("AISDLC-42" or "task-42") to a snapshot
+ * by searching the `backlog/tasks/` and `backlog/completed/` directories
+ * under `backlogRoot` (typically the project root).
+ */
+export function loadBacklogTaskFromRoot(
+  backlogRoot: string,
+  id: string,
+): BacklogTaskSnapshot | undefined {
+  const idLower = id.toLowerCase();
+  const candidates = [
+    join(backlogRoot, 'backlog', 'tasks'),
+    join(backlogRoot, 'backlog', 'completed'),
+  ];
+  for (const dir of candidates) {
+    if (!existsSync(dir)) continue;
+    for (const entry of readdirSync(dir)) {
+      if (
+        !entry.toLowerCase().startsWith(`${idLower} `) &&
+        !entry.toLowerCase().startsWith(`${idLower}.`)
+      ) {
+        continue;
+      }
+      const path = join(dir, entry);
+      const content = readFileSync(path, 'utf-8');
+      return parseBacklogTask(content, path);
+    }
+  }
+  return undefined;
+}
+
+// ── Frontmatter helpers (no external YAML dep — handle the subset
+// Backlog.md emits: scalar, sequence, null, "Done"-quoted strings) ──
+
+function extractFrontmatter(content: string): Record<string, unknown> | undefined {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return undefined;
+  return parseSimpleYaml(match[1]);
+}
+
+function parseSimpleYaml(src: string): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const lines = src.split(/\r?\n/);
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (!line.trim() || line.trim().startsWith('#')) {
+      i++;
+      continue;
+    }
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)$/);
+    if (!m) {
+      i++;
+      continue;
+    }
+    const key = m[1];
+    let value: string = m[2].trim();
+    if (value === '' || value === '[]') {
+      // Inline empty or block sequence follows.
+      const seq: string[] = [];
+      let j = i + 1;
+      while (j < lines.length && /^\s+-\s+/.test(lines[j])) {
+        seq.push(
+          lines[j]
+            .replace(/^\s+-\s+/, '')
+            .trim()
+            .replace(/^['"]|['"]$/g, ''),
+        );
+        j++;
+      }
+      out[key] = value === '[]' ? [] : seq.length > 0 ? seq : '';
+      i = j;
+      continue;
+    }
+    // Strip wrapping quotes if present.
+    if (
+      (value.startsWith("'") && value.endsWith("'")) ||
+      (value.startsWith('"') && value.endsWith('"'))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+    i++;
+  }
+  return out;
+}
+
+function normaliseLabels(raw: unknown): string[] {
+  if (Array.isArray(raw)) return raw.map((s) => String(s).trim()).filter(Boolean);
+  if (typeof raw === 'string' && raw.trim()) return [raw.trim()];
+  return [];
+}
+
+function normaliseStringArray(raw: unknown): string[] {
+  if (Array.isArray(raw)) return raw.map((s) => String(s).trim()).filter(Boolean);
+  return [];
+}
+
+function parseNumericId(id: string): number {
+  const m = id.match(/(\d+)$/);
+  return m ? Number(m[1]) : 0;
+}
+
+function extractSection(content: string, name: string): string {
+  // Match `## <name>` until the next `## ` header or end of file.
+  const re = new RegExp(`##\\s+${name}[\\s\\S]*?(?=\\n##\\s|$)`, 'i');
+  const match = content.match(re);
+  if (!match) return '';
+  return match[0].replace(/^##\s+\S+\s*/i, '').trim();
+}
+
+function extractAcceptanceCriteria(content: string): BacklogAcceptanceCriterion[] {
+  const section = extractSection(content, 'Acceptance Criteria');
+  if (!section) return [];
+  const out: BacklogAcceptanceCriterion[] = [];
+  for (const line of section.split(/\r?\n/)) {
+    const m = line.match(/^\s*-\s+\[([ x])\]\s+(?:#(\d+)\s+)?(.*)$/i);
+    if (!m) continue;
+    out.push({
+      index: m[2] ? Number(m[2]) : out.length + 1,
+      checked: m[1].toLowerCase() === 'x',
+      text: m[3].trim(),
+    });
+  }
+  return out;
+}
+
+// ── Snapshot → AdmissionInput ──────────────────────────────────────
+
+export interface BacklogMappingOptions {
+  /**
+   * Soul-tracks dictionary loaded from `.ai-sdlc/soul-tracks.json`,
+   * mapping `track:*` labels to a soul-alignment floor in [0, 1].
+   * Absent/empty → only `source:rfc` / `source:spec` /
+   * `governance` / `compliance` lift soulAlignment.
+   */
+  soulTracks?: Record<string, number>;
+  /**
+   * Maintainer logins for `OWNER` author-association mapping. When
+   * `createdBy` matches one of these, AdmissionInput.authorAssociation
+   * is set to OWNER (which feeds the trust-based signal floors in
+   * the existing GitHub mapper).
+   */
+  maintainers?: string[];
+}
+
+const DEFAULT_SOUL_TRACKS: Record<string, number> = {
+  // Generic defaults — projects override via `.ai-sdlc/soul-tracks.json`.
+  'track:ops': 0.55,
+  'track:infra': 0.55,
+  'track:hygiene': 0.55,
+};
+
+export interface BacklogAdmissionMapping {
+  /** Admission input shaped like the GitHub mapper output. */
+  input: AdmissionInput;
+  /**
+   * PriorityInput overrides derived from Backlog conventions
+   * (priority:p* / size:[SML] / track:* / source:* / AC progress).
+   * Pass these to `computeAdmissionComposite` via
+   * `AdmissionCompositeOptions.priorityInputOverrides` so they
+   * win over the GitHub-shaped label heuristic.
+   */
+  priorityInputOverrides: Partial<PriorityInput>;
+  /** Quality flags surfaced for renderers (zombie close, etc). */
+  qualityFlags: QualityFlag[];
+}
+
+/**
+ * Map a Backlog snapshot onto an `AdmissionInput` plus the
+ * `PriorityInput` overrides cli-admit feeds into the composite.
+ * The label-mapping table is the load-bearing piece; tests in
+ * `backlog-adapter.test.ts` pin each row.
+ */
+export function mapBacklogTaskToAdmissionInput(
+  snap: BacklogTaskSnapshot,
+  options: BacklogMappingOptions = {},
+): BacklogAdmissionMapping {
+  const labels = snap.labels;
+  const labelSet = new Set(labels.map((l) => l.toLowerCase()));
+  const tracks = { ...DEFAULT_SOUL_TRACKS, ...(options.soulTracks ?? {}) };
+
+  const authorAssociation: AdmissionInput['authorAssociation'] =
+    snap.createdBy && options.maintainers?.includes(snap.createdBy) ? 'OWNER' : 'MEMBER';
+
+  // Defaults — overridden below as labels apply.
+  let soulAlignment = 0.5;
+  let bugSeverity: number | undefined;
+  let complexity: number | undefined;
+
+  // ── Priority labels → explicit priority signal ────────────────
+  // priority:p0..p3 + frontmatter `priority:` field.
+  let explicitPriority: number | undefined;
+  if (labelSet.has('priority:p0')) explicitPriority = 1.0;
+  else if (labelSet.has('priority:p1')) explicitPriority = 0.75;
+  else if (labelSet.has('priority:p2')) explicitPriority = 0.5;
+  else if (labelSet.has('priority:p3')) explicitPriority = 0.25;
+  else if (snap.priority?.toLowerCase() === 'high') explicitPriority = 0.75;
+  else if (snap.priority?.toLowerCase() === 'medium') explicitPriority = 0.5;
+  else if (snap.priority?.toLowerCase() === 'low') explicitPriority = 0.25;
+
+  // ── Size labels → complexity ─────────────────────────────────
+  if (labelSet.has('size:s')) complexity = 2;
+  else if (labelSet.has('size:m')) complexity = 5;
+  else if (labelSet.has('size:l')) complexity = 7;
+  else if (labelSet.has('size:xl')) complexity = 9;
+  // Otherwise derive from AC count below.
+
+  // ── Soul-alignment signals ────────────────────────────────────
+  if (labelSet.has('source:rfc') || labelSet.has('source:spec')) {
+    soulAlignment = Math.max(soulAlignment, 0.9);
+  }
+  if (labelSet.has('governance') || labelSet.has('compliance')) {
+    soulAlignment = Math.max(soulAlignment, 0.85);
+  }
+  for (const label of labels) {
+    const key = label.toLowerCase();
+    if (key.startsWith('track:') && tracks[key] !== undefined) {
+      soulAlignment = Math.max(soulAlignment, tracks[key]);
+    }
+  }
+
+  // ── Bug-class labels ──────────────────────────────────────────
+  if (labelSet.has('bug') || labelSet.has('regression') || labelSet.has('defect')) {
+    bugSeverity = 3;
+  }
+  if (labelSet.has('security') || labelSet.has('vulnerability')) {
+    bugSeverity = 5;
+    soulAlignment = Math.max(soulAlignment, 0.7);
+  }
+  if (labelSet.has('critical') || labelSet.has('p0')) {
+    bugSeverity = Math.max(bugSeverity ?? 0, 5);
+  }
+
+  // ── AC progress → complexity proxy + quality flags ───────────
+  const acTotal = snap.acceptanceCriteria.length;
+  const acChecked = snap.acceptanceCriteria.filter((a) => a.checked).length;
+  const acProgress = acTotal === 0 ? null : acChecked / acTotal;
+
+  if (complexity === undefined && acTotal > 0) {
+    // 1 AC → 1.6, 5 ACs → 4, 9 ACs → 6.4, 13 ACs → 8.8 (capped at 9).
+    complexity = Math.min(1 + acTotal * 0.6, 9);
+  }
+
+  const qualityFlags: QualityFlag[] = [];
+  let defectRiskFactor: number | undefined;
+  const isZombieClose =
+    snap.status.toLowerCase() === 'done' && acTotal > 0 && acProgress !== null && acProgress < 1.0;
+  if (isZombieClose) {
+    const severity: QualityFlag['severity'] = acProgress! < 0.5 ? 'high' : 'medium';
+    qualityFlags.push({
+      kind: 'unchecked-acs-on-done',
+      detail: `${acTotal - acChecked}/${acTotal} ACs unchecked`,
+      severity,
+    });
+    defectRiskFactor = severity === 'high' ? 0.3 : 0.15;
+  }
+
+  // ── Demand / drift / consensus heuristics ─────────────────────
+  let demandSignal: number | undefined;
+  let competitiveDrift = 0;
+  for (const label of labels) {
+    const key = label.toLowerCase();
+    if (key.startsWith('source:') && key.includes('-tonight')) {
+      demandSignal = Math.max(demandSignal ?? 0, 0.7);
+      competitiveDrift += 0.2;
+    }
+    if (key === 'scope:v1-ship' || key === 'scope:v1') {
+      competitiveDrift += 0.6;
+    }
+  }
+  competitiveDrift = Math.min(competitiveDrift, 1);
+
+  // teamConsensus: someone is on the hook.
+  const teamConsensus = snap.createdBy ? 0.4 : undefined;
+
+  // builderConviction: anchored in references? Multiple references to
+  // existing files = author did the homework.
+  const builderConviction =
+    snap.references.length >= 2 ? 0.7 : snap.references.length === 1 ? 0.6 : undefined;
+
+  // commentCount / reactionCount have no Backlog analog yet; default 0.
+  const reactionCount = 0;
+  const commentCount = 0;
+
+  // Construct the body the existing scorer expects (Description +
+  // Acceptance Criteria) — preserves the GitHub mapper's complexity
+  // regex for callers that bypass the Backlog mapping path.
+  const renderedBody = buildAdmissionBody(snap, complexity);
+
+  const input: AdmissionInput = {
+    issueNumber: snap.numericId,
+    title: snap.title,
+    body: renderedBody,
+    labels,
+    reactionCount,
+    commentCount,
+    createdAt: normaliseIsoDate(snap.createdDate),
+    authorAssociation,
+    authorLogin: snap.createdBy,
+  };
+
+  const priorityInputOverrides: Partial<PriorityInput> = {};
+  if (soulAlignment !== 0.5) priorityInputOverrides.soulAlignment = soulAlignment;
+  if (bugSeverity !== undefined) priorityInputOverrides.bugSeverity = bugSeverity;
+  if (complexity !== undefined) priorityInputOverrides.complexity = complexity;
+  if (explicitPriority !== undefined) priorityInputOverrides.explicitPriority = explicitPriority;
+  if (demandSignal !== undefined) priorityInputOverrides.demandSignal = demandSignal;
+  if (competitiveDrift > 0) priorityInputOverrides.competitiveDrift = competitiveDrift;
+  if (teamConsensus !== undefined) priorityInputOverrides.teamConsensus = teamConsensus;
+  if (builderConviction !== undefined) priorityInputOverrides.builderConviction = builderConviction;
+  if (defectRiskFactor !== undefined) priorityInputOverrides.defectRiskFactor = defectRiskFactor;
+  if (qualityFlags.length > 0) priorityInputOverrides.qualityFlags = qualityFlags;
+
+  return { input, priorityInputOverrides, qualityFlags };
+}
+
+function buildAdmissionBody(snap: BacklogTaskSnapshot, complexity: number | undefined): string {
+  const parts: string[] = [];
+  if (snap.description) parts.push(snap.description);
+  if (complexity !== undefined) {
+    parts.push('');
+    parts.push('### Complexity');
+    parts.push('');
+    parts.push(String(Math.round(complexity)));
+  }
+  if (snap.acceptanceCriteria.length > 0) {
+    parts.push('');
+    parts.push('### Acceptance Criteria');
+    parts.push('');
+    for (const ac of snap.acceptanceCriteria) {
+      parts.push(`- [${ac.checked ? 'x' : ' '}] ${ac.text}`);
+    }
+  }
+  return parts.join('\n');
+}
+
+function normaliseIsoDate(raw: string): string {
+  // Backlog stores '2026-03-08 22:27' — coerce to ISO for `cli-admit`.
+  if (!raw) return new Date().toISOString();
+  if (/T\d{2}:\d{2}/.test(raw)) return raw;
+  const m = raw.match(/^(\d{4}-\d{2}-\d{2})[\s T](\d{2}:\d{2})(?::(\d{2}))?$/);
+  if (!m) return new Date(raw).toISOString();
+  return `${m[1]}T${m[2]}:${m[3] ?? '00'}Z`;
+}
+
+// ── Soul-tracks loader ─────────────────────────────────────────────
+
+/**
+ * Load `.ai-sdlc/soul-tracks.json` from the given config root.
+ * Format: `{ "track:enchantment": 0.85, "track:reflect": 0.85, ... }`.
+ * Missing file → empty object (caller falls back to DEFAULT_SOUL_TRACKS).
+ */
+export function loadSoulTracks(configRoot: string): Record<string, number> {
+  const path = join(configRoot, '.ai-sdlc', 'soul-tracks.json');
+  if (!existsSync(path)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+    const out: Record<string, number> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === 'number' && value >= 0 && value <= 1) out[key] = value;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}

--- a/orchestrator/src/index.ts
+++ b/orchestrator/src/index.ts
@@ -222,6 +222,16 @@ export {
 } from './admission-enrichment.js';
 export { computeAdmissionComposite, type AdmissionComposite } from './admission-composite.js';
 export {
+  parseBacklogTask,
+  loadBacklogTaskFromRoot,
+  mapBacklogTaskToAdmissionInput,
+  loadSoulTracks,
+  type BacklogTaskSnapshot,
+  type BacklogAcceptanceCriterion,
+  type BacklogMappingOptions,
+  type BacklogAdmissionMapping,
+} from './backlog-adapter.js';
+export {
   computePillarBreakdown,
   detectTensions,
   pillarSignalScore,

--- a/reference/src/core/types.ts
+++ b/reference/src/core/types.ts
@@ -203,6 +203,23 @@ export interface PriorityInput {
   defectRiskFactor?: number;
   /** RFC-0008 §A.3 — C5 design-authority signal weight, [-1.0, 1.0]. */
   designAuthorityWeight?: number;
+  /**
+   * Quality concerns surfaced by the tracker adapter (e.g. Backlog
+   * `status:Done` with unchecked ACs, GitHub closed-without-resolution).
+   * Consumed by C3 `defectRiskFactor` and rendered in triage reports.
+   */
+  qualityFlags?: QualityFlag[];
+}
+
+/**
+ * Tracker-surfaced quality concern. The `kind` is a short stable
+ * identifier; downstream consumers (defectRiskFactor populator,
+ * triage report renderer, post-ship Cκ calibration) match on it.
+ */
+export interface QualityFlag {
+  kind: 'unchecked-acs-on-done' | 'no-tests-merged' | 'manual-close-no-resolution' | (string & {});
+  detail: string;
+  severity: 'low' | 'medium' | 'high';
 }
 
 export interface PriorityConfig {


### PR DESCRIPTION
## Summary

Closes the silent failure mode where Backlog.md tasks all admitted at the same composite score (~0.1275 on default inputs) because the GitHub-shaped \`mapIssueToPriorityInput\` extracts no Backlog signals.

Adds:
- A \`BacklogAdapter\` (parser + label/AC mapping) in \`@ai-sdlc/orchestrator\`
- \`PriorityInput.qualityFlags\` + \`QualityFlag\` type in \`@ai-sdlc/reference\`
- \`AdmissionCompositeOptions.priorityInputOverrides\` so non-GitHub trackers can inject signals without disturbing the GitHub mapper
- \`cli-admit --tracker {github,backlog,auto}\` dispatch + \`--config-root <path>\` for cross-repo enrichment context resolution
- \`/tmp\` realpath in \`safe-path.ts\` allowedRoots so macOS workflows referencing \`/tmp/issue-body.txt\` don't trip the path-traversal guard
- Triage skill renders a \"Provenance\" subsection FIRST (tracker, config root, resolved DSB/DID/AutonomyPolicy) and a \"Quality Concerns\" subsection when \`qualityFlags[]\` is non-empty

## Why

A real dogfood pass against Forge tasks (TASK-176, TASK-175, TASK-111) showed all three returning identical scores:

\`\`\`
composite      0.1275
soulAlignment  0.6      ← default
demandPressure 0.425    ← default
executionReal  0.5      ← default
pillarBreakdown product=0.508 design=0.75 engineering=0.833
\`\`\`

The PPA composite math was correct; the inputs were flat because the GitHub mapper:
- Whitelists labels \`bug / security / enhancement / spec / rfc / high / low\` — Backlog convention is \`priority:p* / size:[SML] / track:* / source:*\`
- Looks for \`### Complexity\` body section — Backlog tasks have \`## Acceptance Criteria\` instead
- Has no concept of AC checklist progress (\"Done with unchecked ACs\" is invisible)
- Extracts \`+1\`/\`heart\` reactions and comment counts — Backlog has neither

A second silent failure: running \`cli-admit --enrich-from-state\` from one repo against another's tracker silently used the cwd's \`.ai-sdlc/state.db\`, mixing the wrong DSB/DID/AutonomyPolicy into the score.

## What's in each commit

1. \`feat(reference): add QualityFlag type + PriorityInput.qualityFlags\`
2. \`feat(orchestrator): add BacklogAdapter for admission scoring\` — 37 unit tests pin every row of the label-mapping table
3. \`feat(orchestrator): priorityInputOverrides on AdmissionCompositeOptions\` — wires the Backlog-derived signals into \`computeAdmissionComposite\` without touching the GitHub mapper
4. \`feat: cli-admit Backlog dispatch + --config-root + safe-path /tmp\`
5. \`feat: triage skill renders provenance + quality flags\`

## Label mapping table (load-bearing)

| Backlog signal | PriorityInput field | Mapping |
|---|---|---|
| \`priority:p0\`/\`p1\`/\`p2\`/\`p3\` | explicitPriority | 1.0 / 0.75 / 0.5 / 0.25 |
| \`priority\` field = High/Medium/Low | explicitPriority | 0.75 / 0.5 / 0.25 (fallback) |
| \`size:S\`/\`size:M\`/\`size:L\`/\`size:XL\` | complexity | 2 / 5 / 7 / 9 |
| AC count (no size label) | complexity | min(1 + n × 0.6, 9) |
| \`source:rfc\` / \`source:spec\` | soulAlignment | 0.9 |
| \`governance\` / \`compliance\` | soulAlignment | 0.85 |
| \`track:*\` (per .ai-sdlc/soul-tracks.json) | soulAlignment | from JSON, defaults for ops/infra/hygiene at 0.55 |
| \`bug\` / \`regression\` / \`defect\` | bugSeverity | 3 |
| \`security\` / \`vulnerability\` | bugSeverity + soulAlignment floor | 5, 0.7 |
| \`source:*-tonight\` | demandSignal + competitiveDrift | 0.7, +0.2 |
| \`scope:v1-ship\` / \`scope:v1\` | competitiveDrift | +0.6 |
| ≥ 2 references | builderConviction | 0.7 |
| 1 reference | builderConviction | 0.6 |
| status:Done with unchecked ACs | qualityFlag + defectRiskFactor | unchecked-acs-on-done; +0.3 (high < 50%) or +0.15 (medium) |

## --config-root resolution order

1. \`--config-root <path>\` (explicit override)
2. Walk up from \`--task-file\` directory until \`.ai-sdlc/\` is found
3. Walk up from \`--body-file\` directory (when absolute)
4. Walk up from cwd
5. Fall back to cwd + \`WARN\` to stderr

Provenance is emitted on stderr as JSON (\`{ tracker, configRoot, configSource, designSystemBinding, designIntentDocument, autonomyPolicy }\`) so cross-repo confusion is detectable.

## Test plan

- [x] \`pnpm build\` — all 9 packages compile
- [x] \`pnpm test\` — orchestrator picks up 37 new tests (124 files now, was 123)
- [x] \`pnpm lint\` — clean
- [x] \`pnpm format:check\` — clean
- [ ] Re-run admission against TASK-176, TASK-175, TASK-111 — confirm scores diverge meaningfully (no longer identical)
- [ ] Verify \`--config-root\` override for cross-repo Backlog scoring (\`pnpm admit --tracker backlog --task-id AISDLC-X --config-root /forge\` from the ai-sdlc repo)
- [ ] Verify \"WARN: enrichment context resolved to ... via fallback\" surfaces on stderr when no \`.ai-sdlc/\` exists
- [ ] Verify \`/tmp/issue-body.txt\` works on macOS (was rejected as unsafe path)
- [ ] Verify the triage skill renders \"Provenance\" before dimensions and \"Quality Concerns\" when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)