### PR TITLE
fix(orchestrator): four pipeline-side issues surfaced by AISDLC-68 run

### DIFF
--- a/orchestrator/src/dispatch/dispatch.test.ts
+++ b/orchestrator/src/dispatch/dispatch.test.ts
@@ -1,7 +1,21 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { access, mkdtemp, rm, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+
+/** Poll until a file exists or `timeoutMs` elapses (test sync helper). */
+async function waitForFile(path: string, timeoutMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      await access(path);
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+  }
+  throw new Error(`waitForFile timed out after ${timeoutMs}ms: ${path}`);
+}
 import { runWorkerPool, type WorkItem } from './worker-pool.js';
 import { withMergeGate, isBranchUpToDate, MergeGateLockTimeoutError } from './merge-gate.js';
 import { decideRequeue, appendTriageHistory } from './requeue.js';
@@ -146,7 +160,16 @@ describe('withMergeGate', () => {
         releaseFirst = r;
       });
     });
-    await expect(withMergeGate(tmpRoot, async () => 'never', { timeoutMs: 200 })).rejects.toThrow(
+    // Wait until `first` has actually acquired the lock before launching the
+    // contender; without this, the second call can win the exclusive-create
+    // race and the test asserts on the wrong arm. (The 5s default is a
+    // CI-load-friendly upper bound — the lock should appear in <50ms.)
+    await waitForFile(join(tmpRoot, '.merge-gate.lock'));
+
+    // Bumped from 200ms to 1500ms so the test isn't pinned to the merge-gate
+    // poll cadence (POLL_INTERVAL_MS=100); under CI load 200ms gave only ~2
+    // poll cycles before the timeout fired, racing other I/O.
+    await expect(withMergeGate(tmpRoot, async () => 'never', { timeoutMs: 1500 })).rejects.toThrow(
       MergeGateLockTimeoutError,
     );
     releaseFirst();

--- a/orchestrator/src/execute.head-restore.test.ts
+++ b/orchestrator/src/execute.head-restore.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for the HEAD save+restore helpers in execute.ts.
+ *
+ * These shipped to fix the AISDLC-68 incident where the pipeline switched the
+ * user's worktree to the issue branch and never restored it.
+ *
+ * Uses real temp git repos rather than mocking — execute.ts has a deep
+ * dependency tree that's expensive to mock, and the helpers run only `git`
+ * subprocess calls so a 50ms temp-repo setup is faster than mocking it all.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { captureCurrentBranch, restoreOriginalBranch } from './execute.js';
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+  await execFileAsync('git', args, { cwd });
+}
+
+async function makeRepo(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'execute-headrestore-'));
+  await git(dir, 'init', '-q');
+  await git(dir, 'config', 'user.email', 'test@test.com');
+  await git(dir, 'config', 'user.name', 'test');
+  await writeFile(join(dir, 'README.md'), '# initial\n');
+  await git(dir, 'add', 'README.md');
+  await git(dir, 'commit', '-q', '-m', 'initial');
+  // Rename default branch to 'main' for predictability across systems.
+  try {
+    await git(dir, 'branch', '-M', 'main');
+  } catch {
+    // already main
+  }
+  return dir;
+}
+
+describe('captureCurrentBranch', () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    repo = await makeRepo();
+  });
+
+  afterEach(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('returns the symbolic branch name when HEAD is on a branch', async () => {
+    expect(await captureCurrentBranch(repo)).toBe('main');
+  });
+
+  it('falls back to commit SHA when HEAD is detached', async () => {
+    const { stdout: sha } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repo });
+    await git(repo, 'checkout', '--detach', sha.trim());
+
+    const result = await captureCurrentBranch(repo);
+    expect(result).toBe(sha.trim());
+  });
+
+  it('returns null when workDir is not a git repo', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'not-a-repo-'));
+    try {
+      const result = await captureCurrentBranch(tmp);
+      expect(result).toBeNull();
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('restoreOriginalBranch', () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    repo = await makeRepo();
+    // Add a feature branch we can switch to in tests.
+    await git(repo, 'checkout', '-q', '-b', 'feat/work');
+    await writeFile(join(repo, 'feat.md'), 'feat\n');
+    await git(repo, 'add', 'feat.md');
+    await git(repo, 'commit', '-q', '-m', 'feat');
+    await git(repo, 'checkout', '-q', 'main');
+  });
+
+  afterEach(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  function makeLog() {
+    return { info: vi.fn() };
+  }
+
+  it('does nothing when originalHead is null', async () => {
+    const log = makeLog();
+    await restoreOriginalBranch(repo, null, log);
+    expect(await captureCurrentBranch(repo)).toBe('main');
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when current HEAD already matches original', async () => {
+    const log = makeLog();
+    await restoreOriginalBranch(repo, 'main', log);
+    expect(await captureCurrentBranch(repo)).toBe('main');
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it('checks out original HEAD when worktree is clean and HEAD differs', async () => {
+    await git(repo, 'checkout', '-q', 'feat/work');
+    expect(await captureCurrentBranch(repo)).toBe('feat/work');
+
+    const log = makeLog();
+    await restoreOriginalBranch(repo, 'main', log);
+
+    expect(await captureCurrentBranch(repo)).toBe('main');
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it('refuses to checkout when worktree has uncommitted changes — logs recovery hint', async () => {
+    await git(repo, 'checkout', '-q', 'feat/work');
+    // Dirty the worktree.
+    await writeFile(join(repo, 'README.md'), '# modified\n');
+
+    const log = makeLog();
+    await restoreOriginalBranch(repo, 'main', log);
+
+    // HEAD did NOT change.
+    expect(await captureCurrentBranch(repo)).toBe('feat/work');
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining('worktree dirty'));
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining('git stash'));
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining('git checkout main'));
+  });
+
+  it('logs a warning when checkout itself fails (target ref does not exist)', async () => {
+    await git(repo, 'checkout', '-q', 'feat/work');
+
+    const log = makeLog();
+    await restoreOriginalBranch(repo, 'no-such-branch', log);
+
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining('failed to restore HEAD'));
+  });
+
+  it('handles missing log gracefully', async () => {
+    await git(repo, 'checkout', '-q', 'feat/work');
+    await writeFile(join(repo, 'README.md'), 'modified\n');
+
+    await expect(restoreOriginalBranch(repo, 'main', undefined)).resolves.toBeUndefined();
+  });
+});

--- a/orchestrator/src/execute.ts
+++ b/orchestrator/src/execute.ts
@@ -314,6 +314,13 @@ export async function executePipeline(
     });
   }
 
+  // Capture the user's current HEAD so we can restore it after the pipeline.
+  // Without this, `git checkout <issue-branch>` inside the pipeline body
+  // leaves the user's working tree on the issue branch even after the run
+  // completes (the AISDLC-68 incident). Long-term fix is a worktree pool
+  // (RFC-0010 §7); this is the pragmatic save+restore.
+  const originalHead = await captureCurrentBranch(workDir);
+
   // Wrap pipeline body in try/catch to record failure episodes
   try {
     return await executePipelineBody(
@@ -346,6 +353,63 @@ export async function executePipeline(
       options.memory.working.clear();
     }
     throw err;
+  } finally {
+    await restoreOriginalBranch(workDir, originalHead, log);
+  }
+}
+
+/**
+ * Capture the current branch name (or commit SHA in detached-HEAD state) so the
+ * pipeline can restore the user's worktree after the run. Returns null on git
+ * failure — callers treat null as "don't try to restore".
+ */
+async function captureCurrentBranch(workDir: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('git', ['symbolic-ref', '--short', 'HEAD'], {
+      cwd: workDir,
+    });
+    return stdout.trim();
+  } catch {
+    // Detached HEAD or no git repo. Try the SHA fallback.
+    try {
+      const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: workDir });
+      return stdout.trim();
+    } catch {
+      return null;
+    }
+  }
+}
+
+/**
+ * Restore the user's original HEAD if the pipeline switched branches AND the
+ * working tree is clean. If the working tree has uncommitted changes (from a
+ * partial pipeline run), log a warning and leave HEAD where it is — better to
+ * preserve the pipeline's state than to clobber whatever the user has.
+ */
+async function restoreOriginalBranch(
+  workDir: string,
+  originalHead: string | null,
+  log: { info: (msg: string) => void } | undefined,
+): Promise<void> {
+  if (!originalHead) return;
+  try {
+    const current = await captureCurrentBranch(workDir);
+    if (current === originalHead) return;
+    // Refuse to checkout if the worktree has uncommitted changes — git would
+    // either block the checkout or carry the changes across, both bad.
+    const { stdout } = await execFileAsync('git', ['status', '--porcelain'], { cwd: workDir });
+    if (stdout.trim().length > 0) {
+      log?.info(
+        `[pipeline] worktree dirty after pipeline; HEAD left at \`${current}\`. ` +
+          `To restore: \`git stash && git checkout ${originalHead}\``,
+      );
+      return;
+    }
+    await execFileAsync('git', ['checkout', originalHead], { cwd: workDir });
+  } catch (err) {
+    log?.info(
+      `[pipeline] failed to restore HEAD to \`${originalHead}\`: ${(err as Error).message}`,
+    );
   }
 }
 
@@ -788,14 +852,26 @@ async function executePipelineBody(
   );
 
   if (!validation.passed) {
-    // Record validation failure in audit log
+    // One-line summary suitable for log lines + thrown error message.
+    const violationSummary = validation.violations.map((v) => `${v.rule}: ${v.message}`).join('; ');
+
+    // Record validation failure in audit log with full violation detail (rule
+    // + message), not just the rule names — the rule name alone doesn't tell
+    // the operator what to fix.
     auditLog.record({
       actor: 'system',
       action: 'check',
       resource: 'agent-output',
       decision: 'denied',
-      details: { violations: validation.violations.map((v) => v.rule) },
+      details: {
+        violations: validation.violations.map((v) => ({ rule: v.rule, message: v.message })),
+      },
     });
+
+    // Surface the rejection detail to the structured log so the operator sees
+    // it in stderr immediately. Without this the only signal was the
+    // (detail-free) thrown error message.
+    log.error(`[validate-output] rejected: ${violationSummary}`);
 
     // Post comment explaining the violations
     const violationList = validation.violations
@@ -808,9 +884,11 @@ async function executePipelineBody(
         `cherry-pick valid changes, or adjust the guardrails as needed.`,
     );
 
-    // Exit without creating PR
+    // Exit without creating PR. Include the violation summary in the error
+    // message so cli-watch and downstream loggers see the actual rejection.
     throw new Error(
-      `Agent output failed guardrail validation. Branch ${branchName} preserved for review.`,
+      `Agent output failed guardrail validation: ${violationSummary}. ` +
+        `Branch ${branchName} preserved for review.`,
     );
   }
 

--- a/orchestrator/src/execute.ts
+++ b/orchestrator/src/execute.ts
@@ -362,8 +362,10 @@ export async function executePipeline(
  * Capture the current branch name (or commit SHA in detached-HEAD state) so the
  * pipeline can restore the user's worktree after the run. Returns null on git
  * failure — callers treat null as "don't try to restore".
+ *
+ * @internal — exported for unit tests.
  */
-async function captureCurrentBranch(workDir: string): Promise<string | null> {
+export async function captureCurrentBranch(workDir: string): Promise<string | null> {
   try {
     const { stdout } = await execFileAsync('git', ['symbolic-ref', '--short', 'HEAD'], {
       cwd: workDir,
@@ -385,8 +387,10 @@ async function captureCurrentBranch(workDir: string): Promise<string | null> {
  * working tree is clean. If the working tree has uncommitted changes (from a
  * partial pipeline run), log a warning and leave HEAD where it is — better to
  * preserve the pipeline's state than to clobber whatever the user has.
+ *
+ * @internal — exported for unit tests.
  */
-async function restoreOriginalBranch(
+export async function restoreOriginalBranch(
   workDir: string,
   originalHead: string | null,
   log: { info: (msg: string) => void } | undefined,

--- a/orchestrator/src/runners/claude-code-sdk.ts
+++ b/orchestrator/src/runners/claude-code-sdk.ts
@@ -11,7 +11,7 @@
 
 import type { AgentRunner, AgentContext, AgentResult, TokenUsage } from './types.js';
 import { buildPrompt } from './claude-code.js';
-import { detectChangedFiles, gitExec, runAutoFix } from './git-utils.js';
+import { detectChangedFiles, gitExec, runAutoFix, snapshotWorktree } from './git-utils.js';
 import {
   DEFAULT_MODEL,
   DEFAULT_ALLOWED_TOOLS,
@@ -108,6 +108,10 @@ export class ClaudeCodeSdkRunner implements AgentRunner {
     let summary = '';
     let tokenUsage: TokenUsage | undefined;
 
+    // Capture worktree state before invoking the agent so untracked noise
+    // doesn't get swept into the eventual `git add`.
+    const baseline = await snapshotWorktree(ctx.workDir);
+
     /* v8 ignore start — SDK streaming loop requires real SDK connection */
     try {
       const result = query({
@@ -202,8 +206,9 @@ export class ClaudeCodeSdkRunner implements AgentRunner {
     /* v8 ignore stop */
 
     /* v8 ignore start — post-SDK commit/lint logic only runs when SDK succeeds */
-    // Detect changed files (same logic as ClaudeCodeRunner)
-    const { filesChanged, agentAlreadyCommitted } = await detectChangedFiles(ctx.workDir);
+    // Detect changed files (same logic as ClaudeCodeRunner), excluding any
+    // untracked noise that pre-existed the agent invocation.
+    const { filesChanged, agentAlreadyCommitted } = await detectChangedFiles(ctx.workDir, baseline);
 
     if (filesChanged.length === 0) {
       return {
@@ -224,13 +229,15 @@ export class ClaudeCodeSdkRunner implements AgentRunner {
       };
     }
 
-    // Stage, lint/format, commit
-    await gitExec(ctx.workDir, ['add', '-A']);
+    // Stage only the files the agent touched (NOT `git add -A` — the
+    // AISDLC-68 incident showed `add -A` sweeps in pre-existing untracked
+    // noise like sqlite working files and unrelated draft files).
+    await gitExec(ctx.workDir, ['add', '--', ...filesChanged]);
 
     const lintCmd = ctx.lintCommand ?? DEFAULT_LINT_COMMAND;
     const fmtCmd = ctx.formatCommand ?? DEFAULT_FORMAT_COMMAND;
     await runAutoFix(ctx.workDir, lintCmd, fmtCmd);
-    await gitExec(ctx.workDir, ['add', '-A']);
+    await gitExec(ctx.workDir, ['add', '--', ...filesChanged]);
 
     const tmpl = ctx.commitMessageTemplate ?? DEFAULT_COMMIT_MESSAGE_TEMPLATE;
     const coAuthor = ctx.commitCoAuthor ?? DEFAULT_COMMIT_CO_AUTHOR;
@@ -243,7 +250,7 @@ export class ClaudeCodeSdkRunner implements AgentRunner {
     } catch {
       // Pre-commit hook failure — auto-fix and retry once
       await runAutoFix(ctx.workDir, lintCmd, fmtCmd);
-      await gitExec(ctx.workDir, ['add', '-A']);
+      await gitExec(ctx.workDir, ['add', '--', ...filesChanged]);
       try {
         await gitExec(ctx.workDir, ['commit', '-m', `${commitMsg}\n\nCo-Authored-By: ${coAuthor}`]);
       } catch (retryErr) {

--- a/orchestrator/src/runners/claude-code.test.ts
+++ b/orchestrator/src/runners/claude-code.test.ts
@@ -186,7 +186,7 @@ describe('ClaudeCodeRunner', () => {
     // specific git output call setupGitExec() to override. Without this
     // default, runner code that calls git outside the tested path (e.g.
     // pre-agent worktree snapshot) would hang on the unimplemented mock.
-     
+
     (
       execFileMock as unknown as { mockImplementation: (fn: (...a: unknown[]) => unknown) => void }
     ).mockImplementation((..._args: unknown[]) => {

--- a/orchestrator/src/runners/claude-code.test.ts
+++ b/orchestrator/src/runners/claude-code.test.ts
@@ -80,19 +80,23 @@ function makeStreamResult(text: string, cost?: number): string {
 
 function setupSpawn(opts: { stdout?: string; stderr?: string; code?: number }) {
   const child = makeFakeChild();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  spawnMock.mockReturnValue(child as any);
+  // Schedule emission INSIDE the mock so events fire after spawn is invoked,
+  // not after setupSpawn is called. This matters when the runner does async
+  // pre-spawn work (e.g. snapshotting the worktree) — without this, the
+  // microtask fires before spawn() attaches listeners and tests time out.
 
-  queueMicrotask(() => {
-    // Wrap stdout in stream-json format if it's plain text
-    if (opts.stdout) {
-      const streamOutput = opts.stdout.startsWith('{')
-        ? opts.stdout
-        : makeStreamResult(opts.stdout);
-      child.stdout.emit('data', Buffer.from(streamOutput));
-    }
-    if (opts.stderr) child.stderr.emit('data', Buffer.from(opts.stderr));
-    child.emit('close', opts.code ?? 0);
+  spawnMock.mockImplementation(() => {
+    queueMicrotask(() => {
+      if (opts.stdout) {
+        const streamOutput = opts.stdout.startsWith('{')
+          ? opts.stdout
+          : makeStreamResult(opts.stdout);
+        child.stdout.emit('data', Buffer.from(streamOutput));
+      }
+      if (opts.stderr) child.stderr.emit('data', Buffer.from(opts.stderr));
+      child.emit('close', opts.code ?? 0);
+    });
+    return child as never;
   });
 
   return child;
@@ -100,24 +104,35 @@ function setupSpawn(opts: { stdout?: string; stderr?: string; code?: number }) {
 
 function setupSpawnError(err: Error) {
   const child = makeFakeChild();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  spawnMock.mockReturnValue(child as any);
-  queueMicrotask(() => {
-    child.emit('error', err);
+
+  spawnMock.mockImplementation(() => {
+    queueMicrotask(() => {
+      child.emit('error', err);
+    });
+    return child as never;
   });
   return child;
 }
 
 /**
  * Mock execFile for git and lint/format commands.
- * commitFailOnce: if true, the first 'commit' call fails, the second succeeds (tests retry logic).
+ *
+ * `untrackedFiles` is the post-agent untracked set (agent-created files). The
+ * mock seeds the pre-agent baseline as empty by default — to model files that
+ * existed pre-agent (and should be excluded from the agent's diff), pass
+ * `preExistingUntracked`.
+ *
+ * commitFailOnce: if true, the first 'commit' call fails, the second succeeds
+ * (tests retry logic).
  */
 function setupGitExec(
   changedFiles: string[],
   untrackedFiles: string[] = [],
-  opts?: { commitFailOnce?: boolean },
+  opts?: { commitFailOnce?: boolean; preExistingUntracked?: string[] },
 ) {
   let commitAttempt = 0;
+  let lsFilesCallCount = 0;
+  const baselineUntracked = opts?.preExistingUntracked ?? [];
 
   // @ts-expect-error -- partial mock for test
   execFileMock.mockImplementation((_cmd: unknown, args: unknown, _opts: unknown, cb?: unknown) => {
@@ -133,7 +148,10 @@ function setupGitExec(
       if (gitArgs[0] === 'diff' && gitArgs[1] === '--name-only') {
         stdout = changedFiles.join('\n');
       } else if (gitArgs[0] === 'ls-files') {
-        stdout = untrackedFiles.join('\n');
+        // First call (pre-agent snapshot) → baseline; subsequent → post-agent.
+        lsFilesCallCount++;
+        const out = lsFilesCallCount === 1 ? baselineUntracked : untrackedFiles;
+        stdout = out.join('\n');
       } else if (gitArgs[0] === 'commit') {
         commitAttempt++;
         if (opts?.commitFailOnce && commitAttempt === 1) {
@@ -164,6 +182,20 @@ function setupGitExec(
 describe('ClaudeCodeRunner', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default execFile behavior — empty stdout, no error. Tests that need
+    // specific git output call setupGitExec() to override. Without this
+    // default, runner code that calls git outside the tested path (e.g.
+    // pre-agent worktree snapshot) would hang on the unimplemented mock.
+     
+    (
+      execFileMock as unknown as { mockImplementation: (fn: (...a: unknown[]) => unknown) => void }
+    ).mockImplementation((..._args: unknown[]) => {
+      const cb = _args.find((a) => typeof a === 'function') as
+        | ((...a: unknown[]) => void)
+        | undefined;
+      if (cb) cb(null, { stdout: '', stderr: '' });
+      return undefined;
+    });
   });
 
   afterEach(() => {
@@ -534,6 +566,34 @@ describe('ClaudeCodeRunner', () => {
 
       expect(result.success).toBe(true);
       expect(result.filesChanged).toEqual(['modified.ts', 'new.ts']);
+    });
+
+    it('excludes pre-existing untracked files from filesChanged (AISDLC-68 fix)', async () => {
+      // The agent created `new.ts`. The user's worktree had stale `.db-wal`
+      // and `draft.md` untracked before the agent ran — those must NOT end
+      // up in the agent's filesChanged or commit.
+      setupSpawn({ stdout: 'Created new file', stderr: '' });
+      setupGitExec(['modified.ts'], ['.db-wal', 'draft.md', 'new.ts'], {
+        preExistingUntracked: ['.db-wal', 'draft.md'],
+      });
+
+      const runner = new ClaudeCodeRunner();
+      const result = await runner.run(makeCtx());
+
+      expect(result.success).toBe(true);
+      expect(result.filesChanged).toEqual(['modified.ts', 'new.ts']);
+      expect(result.filesChanged).not.toContain('.db-wal');
+      expect(result.filesChanged).not.toContain('draft.md');
+
+      // git add must be called with explicit file args, NOT `-A`
+      const addCalls = execFileMock.mock.calls.filter(
+        (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1][0] === 'add',
+      );
+      for (const call of addCalls) {
+        const args = call[1] as string[];
+        expect(args).not.toContain('-A');
+        expect(args).toContain('--');
+      }
     });
 
     it('stages, runs autofix, and commits', async () => {

--- a/orchestrator/src/runners/claude-code.ts
+++ b/orchestrator/src/runners/claude-code.ts
@@ -21,7 +21,7 @@ import {
   DEFAULT_COMMIT_CO_AUTHOR,
 } from '../defaults.js';
 import { formatContextForPrompt } from '../analysis/context-builder.js';
-import { gitExec, detectChangedFiles, runAutoFix } from './git-utils.js';
+import { gitExec, detectChangedFiles, runAutoFix, snapshotWorktree } from './git-utils.js';
 
 /**
  * Build verification step instructions (lint, format, typecheck).
@@ -538,6 +538,12 @@ export class ClaudeCodeRunner implements AgentRunner {
     const prompt = buildPrompt(ctx);
 
     try {
+      // Snapshot the worktree BEFORE invoking the agent so we can subtract any
+      // pre-existing untracked noise (sqlite working files, draft files the user
+      // hasn't decided to commit yet, in-flight edits) from the agent's diff.
+      // Without this, `git add` would sweep them into the agent's commit.
+      const baseline = await snapshotWorktree(ctx.workDir);
+
       // Invoke Claude Code CLI with stream-json for real-time progress
       const result = await runClaude(prompt, ctx.workDir, {
         allowedTools: ctx.allowedTools,
@@ -550,8 +556,12 @@ export class ClaudeCodeRunner implements AgentRunner {
       // Token usage from stream-json result event (falls back to stderr parsing)
       const tokenUsage = parseTokenUsage(result.stderr, result.model);
 
-      // Collect changed files (uncommitted + agent-committed)
-      const { filesChanged, agentAlreadyCommitted } = await detectChangedFiles(ctx.workDir);
+      // Collect changed files (uncommitted + agent-committed), excluding
+      // pre-existing untracked noise.
+      const { filesChanged, agentAlreadyCommitted } = await detectChangedFiles(
+        ctx.workDir,
+        baseline,
+      );
 
       if (filesChanged.length === 0) {
         return {
@@ -573,16 +583,19 @@ export class ClaudeCodeRunner implements AgentRunner {
         };
       }
 
-      // Stage, lint/format, and commit
-      await gitExec(ctx.workDir, ['add', '-A']);
+      // Stage only the files the agent touched (NOT `git add -A`, which
+      // would include pre-existing untracked noise per the AISDLC-68 incident).
+      await gitExec(ctx.workDir, ['add', '--', ...filesChanged]);
 
       // Run lint and format before committing to avoid pre-commit hook failures
       const lintCmd = ctx.lintCommand ?? DEFAULT_LINT_COMMAND;
       const fmtCmd = ctx.formatCommand ?? DEFAULT_FORMAT_COMMAND;
       await runAutoFix(ctx.workDir, lintCmd, fmtCmd);
 
-      // Re-stage after auto-fix may have modified files
-      await gitExec(ctx.workDir, ['add', '-A']);
+      // Re-stage the same set in case auto-fix re-modified them. Auto-fix should
+      // not touch files outside the agent's diff, but if it does, those changes
+      // are the user's problem to commit separately.
+      await gitExec(ctx.workDir, ['add', '--', ...filesChanged]);
 
       const tmpl = ctx.commitMessageTemplate ?? DEFAULT_COMMIT_MESSAGE_TEMPLATE;
       const coAuthor = ctx.commitCoAuthor ?? DEFAULT_COMMIT_CO_AUTHOR;
@@ -593,9 +606,10 @@ export class ClaudeCodeRunner implements AgentRunner {
       try {
         await gitExec(ctx.workDir, ['commit', '-m', `${commitMsg}\n\nCo-Authored-By: ${coAuthor}`]);
       } catch {
-        // Pre-commit hook may have auto-fixed files — re-stage and retry once
+        // Pre-commit hook may have auto-fixed files — re-stage the agent's
+        // file set and retry once.
         await runAutoFix(ctx.workDir, lintCmd, fmtCmd);
-        await gitExec(ctx.workDir, ['add', '-A']);
+        await gitExec(ctx.workDir, ['add', '--', ...filesChanged]);
         await gitExec(ctx.workDir, ['commit', '-m', `${commitMsg}\n\nCo-Authored-By: ${coAuthor}`]);
       }
 

--- a/orchestrator/src/runners/claude-code.ts
+++ b/orchestrator/src/runners/claude-code.ts
@@ -21,7 +21,13 @@ import {
   DEFAULT_COMMIT_CO_AUTHOR,
 } from '../defaults.js';
 import { formatContextForPrompt } from '../analysis/context-builder.js';
-import { gitExec, detectChangedFiles, runAutoFix, snapshotWorktree } from './git-utils.js';
+import {
+  gitExec,
+  detectChangedFiles,
+  runAutoFix,
+  snapshotWorktree,
+  detectCrossRepoWrites,
+} from './git-utils.js';
 
 /**
  * Build verification step instructions (lint, format, typecheck).
@@ -611,6 +617,19 @@ export class ClaudeCodeRunner implements AgentRunner {
         await runAutoFix(ctx.workDir, lintCmd, fmtCmd);
         await gitExec(ctx.workDir, ['add', '--', ...filesChanged]);
         await gitExec(ctx.workDir, ['commit', '-m', `${commitMsg}\n\nCo-Authored-By: ${coAuthor}`]);
+      }
+
+      // Detect cross-repo writes (e.g., agent edited files in ../sister-repo)
+      // and surface them as a stderr warning so the operator knows to commit
+      // them in the sibling repo separately. Not a hard failure — sometimes
+      // cross-repo work is intended (the AISDLC-68 docs sync, for example).
+      const crossRepoWrites = await detectCrossRepoWrites(ctx.workDir);
+      for (const write of crossRepoWrites) {
+        process.stderr.write(
+          `[ai-sdlc:runner] WARNING: agent wrote ${write.files.length} file(s) into sibling repo ` +
+            `${write.repoPath} — those changes are NOT in this PR. ` +
+            `Files: ${write.files.slice(0, 5).join(', ')}${write.files.length > 5 ? ` (+${write.files.length - 5} more)` : ''}\n`,
+        );
       }
 
       return {

--- a/orchestrator/src/runners/git-utils.cross-repo.test.ts
+++ b/orchestrator/src/runners/git-utils.cross-repo.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Real-fs integration tests for `detectCrossRepoWrites`.
+ *
+ * Lives in its own file so it doesn't inherit git-utils.test.ts's
+ * `vi.mock('node:child_process')` — these tests need to spawn real `git`
+ * processes against real temp directories.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm, realpath } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { detectCrossRepoWrites } from './git-utils.js';
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+  await execFileAsync('git', args, { cwd });
+}
+
+async function makeRepo(dir: string): Promise<void> {
+  await mkdir(dir);
+  await git(dir, 'init', '-q');
+  await git(dir, 'config', 'user.email', 't@t.com');
+  await git(dir, 'config', 'user.name', 't');
+  await writeFile(join(dir, 'README.md'), '# init\n');
+  await git(dir, 'add', 'README.md');
+  await git(dir, 'commit', '-q', '-m', 'init');
+}
+
+describe('detectCrossRepoWrites — real fs integration', () => {
+  let parent: string;
+
+  beforeEach(async () => {
+    // Resolve symlinks (macOS /var → /private/var) so paths match what the
+    // function returns after its own realpath/resolve calls.
+    parent = await realpath(await mkdtemp(join(tmpdir(), 'cross-repo-real-')));
+  });
+
+  afterEach(async () => {
+    await rm(parent, { recursive: true, force: true });
+  });
+
+  it('detects dirty sibling repo and returns the modified file list', async () => {
+    const workRepo = join(parent, 'main-repo');
+    const sister = join(parent, 'sister-repo');
+    await makeRepo(workRepo);
+    await makeRepo(sister);
+
+    // Dirty the sister.
+    await writeFile(join(sister, 'README.md'), '# changed\n');
+    await writeFile(join(sister, 'newfile.md'), 'new\n');
+
+    const writes = await detectCrossRepoWrites(workRepo);
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0].repoPath).toBe(sister);
+    expect(writes[0].files.sort()).toEqual(['README.md', 'newfile.md']);
+  });
+
+  it('returns [] when sibling repos exist but are clean', async () => {
+    const workRepo = join(parent, 'main-repo');
+    const sister = join(parent, 'sister-repo');
+    await makeRepo(workRepo);
+    await makeRepo(sister);
+
+    const writes = await detectCrossRepoWrites(workRepo);
+    expect(writes).toEqual([]);
+  });
+
+  it('skips non-git sibling directories silently', async () => {
+    const workRepo = join(parent, 'main-repo');
+    const notARepo = join(parent, 'just-a-folder');
+    await makeRepo(workRepo);
+    await mkdir(notARepo);
+    await writeFile(join(notARepo, 'random.txt'), 'not tracked anywhere\n');
+
+    const writes = await detectCrossRepoWrites(workRepo);
+    expect(writes).toEqual([]);
+  });
+
+  it('reports each dirty sibling separately when there are multiple', async () => {
+    const workRepo = join(parent, 'main-repo');
+    const sisterA = join(parent, 'sister-a');
+    const sisterB = join(parent, 'sister-b');
+    await makeRepo(workRepo);
+    await makeRepo(sisterA);
+    await makeRepo(sisterB);
+
+    await writeFile(join(sisterA, 'a.md'), 'a\n');
+    await writeFile(join(sisterB, 'b.md'), 'b\n');
+
+    const writes = await detectCrossRepoWrites(workRepo);
+    expect(writes.map((w) => w.repoPath).sort()).toEqual([sisterA, sisterB].sort());
+    for (const w of writes) {
+      expect(w.files.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/orchestrator/src/runners/git-utils.test.ts
+++ b/orchestrator/src/runners/git-utils.test.ts
@@ -11,7 +11,7 @@ vi.mock('node:util', () => ({
   promisify: () => mockExecFileAsync,
 }));
 
-import { gitExec, detectChangedFiles, runAutoFix } from './git-utils.js';
+import { gitExec, detectChangedFiles, runAutoFix, snapshotWorktree } from './git-utils.js';
 
 describe('gitExec', () => {
   beforeEach(() => {
@@ -165,6 +165,51 @@ describe('detectChangedFiles', () => {
 
     const result = await detectChangedFiles('/tmp/repo');
     expect(result.filesChanged).toEqual(['a.ts', 'b.ts']);
+  });
+
+  it('subtracts pre-existing untracked files from filesChanged when baseline is provided', async () => {
+    setupSequence([
+      { stdout: 'mod.ts' }, // git diff (post-agent)
+      { stdout: 'mod.ts\n.db-wal\nstale.md\nnew.ts' }, // ls-files (post-agent: pre-existing + new)
+      { error: 'no base' },
+    ]);
+
+    const baseline = {
+      untracked: new Set(['.db-wal', 'stale.md']),
+      modified: new Set<string>(),
+    };
+    const result = await detectChangedFiles('/tmp/repo', baseline);
+
+    // Only the agent's new file (`new.ts`) survives — the user's stale
+    // untracked files (`.db-wal`, `stale.md`) are filtered out.
+    expect(result.filesChanged).not.toContain('.db-wal');
+    expect(result.filesChanged).not.toContain('stale.md');
+    expect(result.filesChanged).toContain('new.ts');
+  });
+});
+
+describe('snapshotWorktree', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('captures the untracked + modified file sets', async () => {
+    mockExecFileAsync
+      .mockResolvedValueOnce({ stdout: '.db-wal\ndraft.md', stderr: '' }) // ls-files
+      .mockResolvedValueOnce({ stdout: 'src/foo.ts', stderr: '' }); // diff
+
+    const baseline = await snapshotWorktree('/tmp/repo');
+    expect(baseline.untracked.has('.db-wal')).toBe(true);
+    expect(baseline.untracked.has('draft.md')).toBe(true);
+    expect(baseline.modified.has('src/foo.ts')).toBe(true);
+  });
+
+  it('returns an empty baseline when git fails (degrades gracefully)', async () => {
+    mockExecFileAsync.mockRejectedValue(new Error('git not a repo'));
+
+    const baseline = await snapshotWorktree('/tmp/not-a-repo');
+    expect(baseline.untracked.size).toBe(0);
+    expect(baseline.modified.size).toBe(0);
   });
 });
 

--- a/orchestrator/src/runners/git-utils.test.ts
+++ b/orchestrator/src/runners/git-utils.test.ts
@@ -11,7 +11,13 @@ vi.mock('node:util', () => ({
   promisify: () => mockExecFileAsync,
 }));
 
-import { gitExec, detectChangedFiles, runAutoFix, snapshotWorktree } from './git-utils.js';
+import {
+  gitExec,
+  detectChangedFiles,
+  runAutoFix,
+  snapshotWorktree,
+  detectCrossRepoWrites,
+} from './git-utils.js';
 
 describe('gitExec', () => {
   beforeEach(() => {
@@ -211,6 +217,22 @@ describe('snapshotWorktree', () => {
     expect(baseline.untracked.size).toBe(0);
     expect(baseline.modified.size).toBe(0);
   });
+});
+
+describe('detectCrossRepoWrites', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns [] when rev-parse fails (workDir is not a git repo)', async () => {
+    mockExecFileAsync.mockRejectedValue(new Error('not a git repository'));
+    const writes = await detectCrossRepoWrites('/tmp/not-a-repo');
+    expect(writes).toEqual([]);
+  });
+
+  // Sibling-walk paths use real fs (readdir/stat). The mocked execFile
+  // makes a true integration test impractical from this unit suite; the
+  // happy-path detection is verified end-to-end in the cli-watch run.
 });
 
 describe('runAutoFix', () => {

--- a/orchestrator/src/runners/git-utils.test.ts
+++ b/orchestrator/src/runners/git-utils.test.ts
@@ -230,9 +230,22 @@ describe('detectCrossRepoWrites', () => {
     expect(writes).toEqual([]);
   });
 
-  // Sibling-walk paths use real fs (readdir/stat). The mocked execFile
-  // makes a true integration test impractical from this unit suite; the
-  // happy-path detection is verified end-to-end in the cli-watch run.
+  it('returns [] when readdir on the parent directory fails', async () => {
+    // rev-parse succeeds, but the synthetic path's parent doesn't exist —
+    // readdir throws ENOENT and the function catches and returns [].
+    mockExecFileAsync.mockImplementation((cmd: string, args: string[]) => {
+      if (Array.isArray(args) && args[0] === 'rev-parse' && args[1] === '--show-toplevel') {
+        return Promise.resolve({ stdout: '/nonexistent/lonely-repo\n', stderr: '' });
+      }
+      return Promise.resolve({ stdout: '', stderr: '' });
+    });
+    const writes = await detectCrossRepoWrites('/nonexistent/lonely-repo');
+    expect(writes).toEqual([]);
+  });
+
+  // Real-fs sibling-repo integration tests live in
+  // git-utils.cross-repo.test.ts (separate file so it doesn't inherit this
+  // file's child_process mock — the test creates real git repos).
 });
 
 describe('runAutoFix', () => {

--- a/orchestrator/src/runners/git-utils.ts
+++ b/orchestrator/src/runners/git-utils.ts
@@ -91,6 +91,70 @@ export async function detectChangedFiles(
   };
 }
 
+export interface CrossRepoWrite {
+  /** Sibling repository absolute path. */
+  repoPath: string;
+  /** Files modified or added in that sibling, relative to its root. */
+  files: string[];
+}
+
+/**
+ * Detect writes the agent made into sibling git repositories (i.e., directories
+ * adjacent to `workDir` that are themselves git repos). Surfaced as a warning,
+ * not a hard failure — the AISDLC-68 task LEGITIMATELY needed to sync into
+ * `../ai-sdlc-io/`, and we don't want to forbid that. The orchestrator just
+ * needs to surface that the changes exist so the operator knows to commit them
+ * separately in the sibling repo.
+ *
+ * Returns one entry per dirty sibling repo, with the list of changed files.
+ * Empty array when no siblings are dirty (the common case).
+ */
+export async function detectCrossRepoWrites(workDir: string): Promise<CrossRepoWrite[]> {
+  const { readdir, stat } = await import('node:fs/promises');
+  const { dirname, join, resolve } = await import('node:path');
+
+  let workTreeRoot: string;
+  try {
+    workTreeRoot = await gitExec(workDir, ['rev-parse', '--show-toplevel']);
+  } catch {
+    return [];
+  }
+
+  const parent = dirname(resolve(workTreeRoot));
+  let entries: string[];
+  try {
+    entries = await readdir(parent);
+  } catch {
+    return [];
+  }
+
+  const writes: CrossRepoWrite[] = [];
+  for (const entry of entries) {
+    const candidate = join(parent, entry);
+    if (resolve(candidate) === resolve(workTreeRoot)) continue; // skip self
+    try {
+      const s = await stat(candidate);
+      if (!s.isDirectory()) continue;
+      // Quick git-repo check via `rev-parse --is-inside-work-tree`.
+      await gitExec(candidate, ['rev-parse', '--is-inside-work-tree']);
+    } catch {
+      continue;
+    }
+    try {
+      const status = await gitExec(candidate, ['status', '--porcelain']);
+      if (!status.trim()) continue;
+      const files = status
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => line.slice(3).trim());
+      writes.push({ repoPath: candidate, files });
+    } catch {
+      // Couldn't read status — skip silently.
+    }
+  }
+  return writes;
+}
+
 /**
  * Run lint and format auto-fix commands (best-effort, non-fatal).
  */

--- a/orchestrator/src/runners/git-utils.ts
+++ b/orchestrator/src/runners/git-utils.ts
@@ -143,10 +143,17 @@ export async function detectCrossRepoWrites(workDir: string): Promise<CrossRepoW
     try {
       const status = await gitExec(candidate, ['status', '--porcelain']);
       if (!status.trim()) continue;
+      // Porcelain v1: first 2 chars are status (XY), then 1+ whitespace, then
+      // path. Cannot use slice(3) — gitExec already trimmed the leading space
+      // when X is unmodified ("M " becomes "M" after trim, dropping a column
+      // and eating the first filename character).
       const files = status
         .split('\n')
         .filter(Boolean)
-        .map((line) => line.slice(3).trim());
+        .map((line) => {
+          const m = line.match(/^.{1,2}\s+(.+)$/);
+          return m ? m[1] : line;
+        });
       writes.push({ repoPath: candidate, files });
     } catch {
       // Couldn't read status — skip silently.

--- a/orchestrator/src/runners/git-utils.ts
+++ b/orchestrator/src/runners/git-utils.ts
@@ -18,18 +18,58 @@ export interface DetectedChanges {
   agentAlreadyCommitted: boolean;
 }
 
+export interface WorktreeBaseline {
+  /** Set of paths that were untracked BEFORE the agent ran. */
+  untracked: Set<string>;
+  /** Set of paths that had unstaged modifications BEFORE the agent ran. */
+  modified: Set<string>;
+}
+
 /**
- * Detect files changed by an agent — checks both uncommitted changes
- * and already-committed changes (agent may have self-committed).
+ * Snapshot the untracked + modified file lists in the worktree. Captured before
+ * the agent runs so detectChangedFiles can subtract pre-existing noise (SQLite
+ * working files, draft RFCs the user hasn't decided to commit yet, in-flight
+ * edits on the previous branch). Without this, `git add -A` sweeps everything
+ * into the agent's commit (the AISDLC-68 incident).
+ *
+ * Failures degrade gracefully to an empty baseline — never block the pipeline
+ * because the snapshot couldn't run.
  */
-export async function detectChangedFiles(workDir: string): Promise<DetectedChanges> {
+export async function snapshotWorktree(workDir: string): Promise<WorktreeBaseline> {
+  try {
+    const [untrackedOutput, modifiedOutput] = await Promise.all([
+      gitExec(workDir, ['ls-files', '--others', '--exclude-standard']),
+      gitExec(workDir, ['diff', '--name-only']),
+    ]);
+    return {
+      untracked: new Set(untrackedOutput.split('\n').filter(Boolean)),
+      modified: new Set(modifiedOutput.split('\n').filter(Boolean)),
+    };
+  } catch {
+    return { untracked: new Set(), modified: new Set() };
+  }
+}
+
+/**
+ * Detect files changed by an agent — checks both uncommitted changes and
+ * already-committed changes (agent may have self-committed). When `baseline`
+ * is provided, untracked files that existed BEFORE the agent ran are excluded
+ * (they belong to the user, not the agent's diff).
+ */
+export async function detectChangedFiles(
+  workDir: string,
+  baseline?: WorktreeBaseline,
+): Promise<DetectedChanges> {
   const diffOutput = await gitExec(workDir, ['diff', '--name-only']);
   const untrackedOutput = await gitExec(workDir, ['ls-files', '--others', '--exclude-standard']);
 
-  const uncommittedFiles = [
-    ...diffOutput.split('\n').filter(Boolean),
-    ...untrackedOutput.split('\n').filter(Boolean),
-  ];
+  const allUntracked = untrackedOutput.split('\n').filter(Boolean);
+  // Untracked files that existed pre-agent are user state — exclude them.
+  const agentUntracked = baseline
+    ? allUntracked.filter((f) => !baseline.untracked.has(f))
+    : allUntracked;
+
+  const uncommittedFiles = [...diffOutput.split('\n').filter(Boolean), ...agentUntracked];
 
   // Check if agent already committed — compare against merge base with main
   let committedFiles: string[] = [];


### PR DESCRIPTION
## Summary

Four root-cause fixes for issues the AISDLC-68 end-to-end pipeline run surfaced. None of these were introduced by the run — they were latent. Builds on PR #69 (foundation work).

## The 4 fixes

### #1 — Don't sweep untracked files into the agent's commit (de8a2bb)
Pipeline previously ran `git add -A` after the agent completed, sweeping any pre-existing untracked files (sqlite working files, draft files, in-flight edits on the prior branch) into the agent's commit. AISDLC-68's commit 731796e accidentally shipped 4 unwanted files because of this.

- New `snapshotWorktree(workDir)` captures untracked + modified file sets BEFORE the agent runs
- New `detectChangedFiles(workDir, baseline?)` subtracts pre-existing untracked from the diff
- Both `ClaudeCodeRunner` and `ClaudeCodeSdkRunner` snapshot upfront and replace `git add -A` with explicit `git add -- <file1> <file2>` against the agent's actual file set

### #2 — Restore the user's HEAD after the pipeline runs (e4cdece)
`executePipeline` previously did `git checkout <issue-branch>` and never restored it, leaving the user's worktree on the issue branch. Now captures original HEAD (symbolic-ref → SHA fallback) and restores it in a finally block. If the worktree is dirty (partial run), logs a recovery hint instead of clobbering. Long-term fix is the worktree pool (RFC-0010 §7); this is the pragmatic save+restore.

### #3 — Surface validate-output guardrail rejection detail (e4cdece)
Previously the only signal on rejection was the generic "Agent output failed guardrail validation" thrown error. Now:
- Error message includes the violation summary (rule + message) so cli-watch and downstream loggers see what actually failed
- Structured logger emits an explicit error line at rejection time
- Audit log records full violation objects (rule + message), not just rule names

### #4 — Detect cross-repo writes from the agent (e4cdece)
On AISDLC-68, the agent wrote 39 files into `../ai-sdlc-io/content/` that the pipeline silently dropped (sister repo, not in scope). New `detectCrossRepoWrites(workDir)` walks sibling directories, identifies dirty sibling git repos, and `ClaudeCodeRunner` emits a stderr WARNING per dirty sibling with file count + first 5 names. Not a hard failure — sometimes cross-repo work is intended; the orchestrator just makes sure the operator sees it.

### Bonus — fix cli-triage.test.ts mock (317968c)
Pre-existing breakage on PR #69 from commit 3d6dcf3 — cli-triage.ts's new `ClaudeCodeAdapter` import wasn't added to the test mock, so module init crashed silently and 7 spy assertions failed. Mock added.

## Verification

- `pnpm build` clean
- `pnpm test` — 4470+ tests pass; 1 pre-existing flake in `dispatch.test.ts` (timing-sensitive merge-gate timeout, unrelated to this PR)
- 6 new tests covering snapshot baseline + cross-repo detector + explicit `git add` args
- AISDLC-68 commit 731796e cleaned up to ff621bc on `ai-sdlc/issue-AISDLC-68` (force-pushed) — only the 7 files the agent actually intended to ship are in the commit now

## Test plan

- [ ] CI passes
- [ ] Verify on next pipeline run: only agent-touched files in the commit, HEAD restored after run, guardrail rejections surface detail, cross-repo writes log warning

## Depends on

PR #69 — should be reviewed/merged first since this branch builds on its commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)