### PR TITLE
chore: gitignore sqlite wal + episodic memory runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,10 @@ pnpm-debug.log*
 # AI-SDLC runtime artifacts
 .ai-sdlc/audit.jsonl
 .ai-sdlc/state.db
+.ai-sdlc/state.db-shm
+.ai-sdlc/state.db-wal
 .ai-sdlc/state/
+.ai-sdlc/memory/
 .enterprise.yaml
 
 # Package manager


### PR DESCRIPTION
## Summary

`.gitignore` covered `.ai-sdlc/state.db` (the main SQLite file) and `.ai-sdlc/state/` but missed three runtime artifacts:

- `.ai-sdlc/state.db-shm` — SQLite shared-memory file (WAL mode companion)
- `.ai-sdlc/state.db-wal` — SQLite write-ahead log (WAL mode companion)
- `.ai-sdlc/memory/` — orchestrator's local episodic memory (machine-specific)

## Why now

These caused two real incidents during the AISDLC-68 pipeline test:
1. The agent's `git add` swept `state.db-shm` and `state.db-wal` (zero-byte files) into commit `731796e`. We cleaned those up post-hoc as part of PR #70 prep, but the right fix is to keep them out of git status entirely.
2. `pnpm format:check` warned on `.ai-sdlc/memory/episodes.json` every local run.

## Test plan

- [x] `git status --short` shows none of the four files after the change
- [x] `pnpm format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)