### PR TITLE
fix(orchestrator): disable git core.quotepath so unicode filenames stage cleanly

### DIFF
--- a/orchestrator/src/runners/claude-code.test.ts
+++ b/orchestrator/src/runners/claude-code.test.ts
@@ -139,7 +139,11 @@ function setupGitExec(
     const callback =
       typeof _opts === 'function' ? _opts : (cb as ((...a: unknown[]) => void) | undefined);
     const cmdStr = typeof _cmd === 'string' ? _cmd : '';
-    const gitArgs = Array.isArray(args) ? args : [];
+    // gitExec now prepends `-c core.quotePath=false` to every git invocation;
+    // strip it so the subcommand parsing below stays simple.
+    const rawArgs = Array.isArray(args) ? args : [];
+    const gitArgs =
+      rawArgs[0] === '-c' && typeof rawArgs[1] === 'string' ? rawArgs.slice(2) : rawArgs;
 
     let stdout = '';
     let error: Error | null = null;
@@ -587,7 +591,7 @@ describe('ClaudeCodeRunner', () => {
 
       // git add must be called with explicit file args, NOT `-A`
       const addCalls = execFileMock.mock.calls.filter(
-        (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1][0] === 'add',
+        (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1].includes('add'),
       );
       for (const call of addCalls) {
         const args = call[1] as string[];
@@ -605,13 +609,13 @@ describe('ClaudeCodeRunner', () => {
 
       // git add should be called (at least twice: once before autofix, once after)
       const addCalls = execFileMock.mock.calls.filter(
-        (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1][0] === 'add',
+        (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1].includes('add'),
       );
       expect(addCalls.length).toBeGreaterThanOrEqual(2);
 
       // git commit should be called
       const commitCall = execFileMock.mock.calls.find(
-        (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1][0] === 'commit',
+        (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1].includes('commit'),
       );
       expect(commitCall).toBeTruthy();
     });
@@ -627,7 +631,7 @@ describe('ClaudeCodeRunner', () => {
 
       // Commit should have been called twice
       const commitCalls = execFileMock.mock.calls.filter(
-        (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1][0] === 'commit',
+        (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1].includes('commit'),
       );
       expect(commitCalls.length).toBe(2);
     });
@@ -645,7 +649,7 @@ describe('ClaudeCodeRunner', () => {
       );
 
       const commitCall = execFileMock.mock.calls.find(
-        (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1][0] === 'commit',
+        (c) => c[0] === 'git' && Array.isArray(c[1]) && c[1].includes('commit'),
       );
       const commitArgs = commitCall![1] as string[];
       const msg = commitArgs[commitArgs.indexOf('-m') + 1];
@@ -750,7 +754,10 @@ describe('ClaudeCodeRunner', () => {
           const callback =
             typeof _opts === 'function' ? _opts : (cb as ((...a: unknown[]) => void) | undefined);
           const cmdStr = typeof _cmd === 'string' ? _cmd : '';
-          const gitArgs = Array.isArray(args) ? args : [];
+          // Strip the gitExec-injected `-c core.quotePath=false` prefix.
+          const rawArgs = Array.isArray(args) ? args : [];
+          const gitArgs =
+            rawArgs[0] === '-c' && typeof rawArgs[1] === 'string' ? rawArgs.slice(2) : rawArgs;
           _callCount++;
 
           let stdout = '';

--- a/orchestrator/src/runners/git-utils.test.ts
+++ b/orchestrator/src/runners/git-utils.test.ts
@@ -29,9 +29,18 @@ describe('gitExec', () => {
 
     const result = await gitExec('/tmp/repo', ['branch', '--show-current']);
     expect(result).toBe('main');
-    expect(mockExecFileAsync).toHaveBeenCalledWith('git', ['branch', '--show-current'], {
-      cwd: '/tmp/repo',
-    });
+    expect(mockExecFileAsync).toHaveBeenCalledWith(
+      'git',
+      ['-c', 'core.quotePath=false', 'branch', '--show-current'],
+      { cwd: '/tmp/repo' },
+    );
+  });
+
+  it('always prepends -c core.quotePath=false so unicode paths come back raw', async () => {
+    mockExecFileAsync.mockResolvedValue({ stdout: '', stderr: '' });
+    await gitExec('/tmp/repo', ['diff', '--name-only']);
+    const args = mockExecFileAsync.mock.calls[0][1];
+    expect(args.slice(0, 2)).toEqual(['-c', 'core.quotePath=false']);
   });
 
   it('trims whitespace from output', async () => {
@@ -45,7 +54,11 @@ describe('gitExec', () => {
     mockExecFileAsync.mockResolvedValue({ stdout: '', stderr: '' });
 
     await gitExec('/my/project', ['status']);
-    expect(mockExecFileAsync).toHaveBeenCalledWith('git', ['status'], { cwd: '/my/project' });
+    expect(mockExecFileAsync).toHaveBeenCalledWith(
+      'git',
+      ['-c', 'core.quotePath=false', 'status'],
+      { cwd: '/my/project' },
+    );
   });
 
   it('propagates errors from git', async () => {

--- a/orchestrator/src/runners/git-utils.ts
+++ b/orchestrator/src/runners/git-utils.ts
@@ -7,9 +7,20 @@ import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 
-/** Run a git command in the given directory. */
+/**
+ * Run a git command in the given directory.
+ *
+ * Always passes `-c core.quotePath=false` so paths containing non-ASCII
+ * characters (e.g. ↔, é, 中) come back as raw UTF-8 instead of git's default
+ * octal-escaped form (`"file with \342\206\224.md"`). Without this, the AISDLC-68
+ * task file (which has ↔ in its name) showed up in `git diff --name-only`
+ * as a quoted+escaped string and the subsequent `git add -- <file>` rejected
+ * with "pathspec did not match".
+ */
 export async function gitExec(workDir: string, args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync('git', args, { cwd: workDir });
+  const { stdout } = await execFileAsync('git', ['-c', 'core.quotePath=false', ...args], {
+    cwd: workDir,
+  });
   return stdout.trim();
 }
 


### PR DESCRIPTION
## Summary

Third AISDLC-68 pipeline run failed at `git add`:

```
fatal: pathspec '"backlog/tasks/aisdlc-68 - Documentation-consolidation
-ai-sdlc-docs-\342\206\224-ai-sdlc-io-content.md"' did not match any files
```

The task filename contains `↔` (U+2194). git's default `core.quotePath=true` returns paths in `git diff --name-only` and `git ls-files` as quoted + octal-escaped strings (`"...\342\206\224..."`). When PR #70's Phase 1 fix (the explicit `git add -- <file>` instead of `add -A`) passed those literally back to git, no on-disk file matched the literal escape sequence.

## Fix

Prepend `-c core.quotePath=false` to every `gitExec` invocation. All git output (and the pathspecs we then feed back in) now round-trips as raw UTF-8.

This single change covers:
- `detectChangedFiles` (diff/ls-files paths)
- `detectCrossRepoWrites` (porcelain status)
- the agent-files staging in `ClaudeCodeRunner` / `ClaudeCodeSdkRunner`
- every other call routed through `gitExec`

## Test plan

- [x] 4514 / 4514 workspace tests pass (orchestrator: 2690)
- [x] New unit test in `git-utils.test.ts` pinning the prepended flag

## Verification path

After merge: re-run `pnpm --filter @ai-sdlc/dogfood watch --issue AISDLC-68` (the same task that surfaced this bug). Expect: pipeline reaches `validate-output` and PR creation. Will also exercise PR #72's `pushBranchWithRebase` and PR #70's `detectCrossRepoWrites` warning path (which was unreached on prior runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)