### PR TITLE
fix(orchestrator): include staged diff in detectChangedFiles

### DIFF
--- a/orchestrator/src/runners/git-utils.test.ts
+++ b/orchestrator/src/runners/git-utils.test.ts
@@ -101,7 +101,8 @@ describe('detectChangedFiles', () => {
 
   it('returns empty when no uncommitted or committed changes', async () => {
     setupSequence([
-      { stdout: '' }, // git diff --name-only
+      { stdout: '' }, // git diff --name-only (unstaged)
+      { stdout: '' }, // git diff --name-only --cached (staged)
       { stdout: '' }, // git ls-files --others --exclude-standard
       { stdout: 'abc123' }, // git merge-base HEAD origin/main
       { stdout: '' }, // git diff --name-only abc123..HEAD
@@ -114,23 +115,50 @@ describe('detectChangedFiles', () => {
 
   it('returns uncommitted files when there are local changes', async () => {
     setupSequence([
-      { stdout: 'src/foo.ts\nsrc/bar.ts' }, // git diff --name-only
+      { stdout: 'src/foo.ts\nsrc/bar.ts' }, // git diff --name-only (unstaged)
+      { stdout: '' }, // git diff --name-only --cached (no staged)
       { stdout: 'src/new.ts' }, // git ls-files --others
       { stdout: 'abc123' }, // git merge-base
       { stdout: '' }, // git diff merge-base..HEAD
     ]);
 
     const result = await detectChangedFiles('/tmp/repo');
-    expect(result.filesChanged).toEqual(['src/foo.ts', 'src/bar.ts', 'src/new.ts']);
+    expect(result.filesChanged.sort()).toEqual(['src/bar.ts', 'src/foo.ts', 'src/new.ts']);
     expect(result.agentAlreadyCommitted).toBe(false);
+  });
+
+  it('returns staged files (agent self-staged via git add)', async () => {
+    setupSequence([
+      { stdout: '' }, // unstaged
+      { stdout: 'src/agent-staged.ts\nREADME.md' }, // staged
+      { stdout: '' }, // untracked
+      { error: 'no merge base' },
+    ]);
+
+    const result = await detectChangedFiles('/tmp/repo');
+    expect(result.filesChanged.sort()).toEqual(['README.md', 'src/agent-staged.ts']);
+    expect(result.agentAlreadyCommitted).toBe(false);
+  });
+
+  it('dedupes when a file is in both staged and unstaged diffs', async () => {
+    setupSequence([
+      { stdout: 'src/foo.ts' }, // unstaged
+      { stdout: 'src/foo.ts\nsrc/bar.ts' }, // staged (overlaps with unstaged on foo.ts)
+      { stdout: '' }, // untracked
+      { error: 'no merge base' },
+    ]);
+
+    const result = await detectChangedFiles('/tmp/repo');
+    expect(result.filesChanged.sort()).toEqual(['src/bar.ts', 'src/foo.ts']);
   });
 
   it('detects agent-committed changes when no uncommitted files but commits ahead', async () => {
     setupSequence([
-      { stdout: '' }, // git diff --name-only (no uncommitted)
-      { stdout: '' }, // git ls-files --others (no untracked)
-      { stdout: 'abc123' }, // git merge-base
-      { stdout: 'src/committed.ts\nREADME.md' }, // git diff merge-base..HEAD
+      { stdout: '' }, // unstaged
+      { stdout: '' }, // staged
+      { stdout: '' }, // untracked
+      { stdout: 'abc123' }, // merge-base
+      { stdout: 'src/committed.ts\nREADME.md' }, // commit-diff
     ]);
 
     const result = await detectChangedFiles('/tmp/repo');
@@ -140,10 +168,11 @@ describe('detectChangedFiles', () => {
 
   it('returns uncommitted files even when there are also committed changes', async () => {
     setupSequence([
-      { stdout: 'src/modified.ts' }, // git diff --name-only
-      { stdout: '' }, // git ls-files --others
-      { stdout: 'abc123' }, // git merge-base
-      { stdout: 'src/committed.ts' }, // git diff merge-base..HEAD
+      { stdout: 'src/modified.ts' }, // unstaged
+      { stdout: '' }, // staged
+      { stdout: '' }, // untracked
+      { stdout: 'abc123' }, // merge-base
+      { stdout: 'src/committed.ts' }, // commit-diff
     ]);
 
     const result = await detectChangedFiles('/tmp/repo');
@@ -154,8 +183,9 @@ describe('detectChangedFiles', () => {
 
   it('handles merge-base failure gracefully (no origin/main)', async () => {
     setupSequence([
-      { stdout: 'src/foo.ts' }, // git diff --name-only
-      { stdout: '' }, // git ls-files --others
+      { stdout: 'src/foo.ts' }, // unstaged
+      { stdout: '' }, // staged
+      { stdout: '' }, // untracked
       { error: 'fatal: Not a valid object name origin/main' }, // merge-base fails
     ]);
 
@@ -166,29 +196,32 @@ describe('detectChangedFiles', () => {
 
   it('filters empty lines from git output', async () => {
     setupSequence([
-      { stdout: '\n\nfile1.ts\n\nfile2.ts\n\n' }, // diff with extra newlines
+      { stdout: '\n\nfile1.ts\n\nfile2.ts\n\n' }, // unstaged with extra newlines
+      { stdout: '' }, // staged
       { stdout: '\n' }, // ls-files with just newline
       { error: 'no merge base' }, // merge-base fails
     ]);
 
     const result = await detectChangedFiles('/tmp/repo');
-    expect(result.filesChanged).toEqual(['file1.ts', 'file2.ts']);
+    expect(result.filesChanged.sort()).toEqual(['file1.ts', 'file2.ts']);
   });
 
   it('combines diff and untracked files', async () => {
     setupSequence([
-      { stdout: 'a.ts' }, // git diff
-      { stdout: 'b.ts' }, // git ls-files
+      { stdout: 'a.ts' }, // unstaged diff
+      { stdout: '' }, // staged
+      { stdout: 'b.ts' }, // ls-files
       { error: 'no base' }, // merge-base fails
     ]);
 
     const result = await detectChangedFiles('/tmp/repo');
-    expect(result.filesChanged).toEqual(['a.ts', 'b.ts']);
+    expect(result.filesChanged.sort()).toEqual(['a.ts', 'b.ts']);
   });
 
   it('subtracts pre-existing untracked files from filesChanged when baseline is provided', async () => {
     setupSequence([
       { stdout: 'mod.ts' }, // git diff (post-agent)
+      { stdout: '' }, // staged
       { stdout: 'mod.ts\n.db-wal\nstale.md\nnew.ts' }, // ls-files (post-agent: pre-existing + new)
       { error: 'no base' },
     ]);

--- a/orchestrator/src/runners/git-utils.ts
+++ b/orchestrator/src/runners/git-utils.ts
@@ -62,17 +62,32 @@ export async function snapshotWorktree(workDir: string): Promise<WorktreeBaselin
 }
 
 /**
- * Detect files changed by an agent — checks both uncommitted changes and
- * already-committed changes (agent may have self-committed). When `baseline`
- * is provided, untracked files that existed BEFORE the agent ran are excluded
- * (they belong to the user, not the agent's diff).
+ * Detect files changed by an agent. Three signals contribute:
+ *
+ *   - **Unstaged working-tree changes** (`git diff --name-only`)
+ *   - **Staged but uncommitted changes** (`git diff --name-only --cached`) — the
+ *     agent sometimes runs `git add` itself before yielding control. Without
+ *     this signal the orchestrator returned "Agent made no changes" and bailed
+ *     even though the agent's work was sitting in the index (the AISDLC-68
+ *     fourth-rerun bug).
+ *   - **Untracked files** (`git ls-files --others`)
+ *
+ * When `baseline` is provided, untracked files that existed BEFORE the agent
+ * ran are excluded — they belong to the user, not the agent's diff.
+ *
+ * Also checks whether the agent self-committed (compares HEAD to merge-base
+ * with origin/main). Self-committed runs short-circuit the orchestrator's
+ * commit step.
  */
 export async function detectChangedFiles(
   workDir: string,
   baseline?: WorktreeBaseline,
 ): Promise<DetectedChanges> {
-  const diffOutput = await gitExec(workDir, ['diff', '--name-only']);
-  const untrackedOutput = await gitExec(workDir, ['ls-files', '--others', '--exclude-standard']);
+  const [diffOutput, stagedOutput, untrackedOutput] = await Promise.all([
+    gitExec(workDir, ['diff', '--name-only']),
+    gitExec(workDir, ['diff', '--name-only', '--cached']),
+    gitExec(workDir, ['ls-files', '--others', '--exclude-standard']),
+  ]);
 
   const allUntracked = untrackedOutput.split('\n').filter(Boolean);
   // Untracked files that existed pre-agent are user state — exclude them.
@@ -80,7 +95,15 @@ export async function detectChangedFiles(
     ? allUntracked.filter((f) => !baseline.untracked.has(f))
     : allUntracked;
 
-  const uncommittedFiles = [...diffOutput.split('\n').filter(Boolean), ...agentUntracked];
+  // Combine + dedupe: a file may show up in both unstaged and staged diffs
+  // (partial-stage scenario), and untracked files are mutually exclusive
+  // with diffs but include for completeness.
+  const uncommittedSet = new Set<string>([
+    ...diffOutput.split('\n').filter(Boolean),
+    ...stagedOutput.split('\n').filter(Boolean),
+    ...agentUntracked,
+  ]);
+  const uncommittedFiles = [...uncommittedSet];
 
   // Check if agent already committed — compare against merge base with main
   let committedFiles: string[] = [];


### PR DESCRIPTION
## Summary

When the agent runs `git add` itself before yielding control to the orchestrator, modified files sit in the index — invisible to `git diff --name-only`. The orchestrator returned `Agent failed on issue AISDLC-68: No files were modified` and bailed even though the agent had clearly worked. This was the AISDLC-68 fourth-rerun bug.

`detectChangedFiles` now combines three signals:
- unstaged working-tree changes (`git diff --name-only`)
- **staged but uncommitted changes (`git diff --name-only --cached`)** ← new
- untracked files (`git ls-files --others`)

A `Set` collapses duplicates from partial-stage scenarios.

## Changes

- `orchestrator/src/runners/git-utils.ts` — fan out the cached-diff call in parallel with the existing two; dedupe via Set; updated docstring naming all three signals plus the AISDLC-68 incident reference
- `orchestrator/src/runners/git-utils.test.ts` — updated 6 existing `setupSequence` cases to include the new staged-diff stub between unstaged + untracked; added two new tests (`returns staged files (agent self-staged via git add)`, `dedupes when a file is in both staged and unstaged diffs`)

## Test plan

- [x] `pnpm vitest run src/runners/git-utils.test.ts` — 29/29 pass
- [x] `pnpm vitest run src/runners/` — 312/312 pass
- [x] `pnpm test` (full workspace) — all green
- [x] `pnpm build` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [ ] Re-run AISDLC-68 pipeline end-to-end — should reach push/PR-create stage now

🤖 Generated with [Claude Code](https://claude.com/claude-code)