### PR TITLE
feat(plugin): /ai-sdlc execute slash command for backlog tasks (AISDLC-71)

### DIFF
--- a/.github/workflows/backlog-task-complete.yml
+++ b/.github/workflows/backlog-task-complete.yml
@@ -3,6 +3,14 @@ name: backlog-task-complete
 # Auto-close backlog tasks when a PR with `(AISDLC-N)` in its title merges.
 # Opens a follow-up PR (rather than committing directly to main) so the move is
 # auditable and respects branch protection.
+#
+# IDEMPOTENCY: When the PR was created by the `/ai-sdlc execute` plugin command,
+# the task file was already moved from backlog/tasks/ to backlog/completed/ as
+# part of the merged PR. In that case, scripts/close-backlog-task.sh exits 2
+# (already-completed no-op) and the follow-up-PR step is skipped via the
+# `already_closed` output. Net effect: this workflow is a no-op for tasks shipped
+# through /ai-sdlc execute, and a follow-up-PR creator for tasks shipped through
+# any other path (e.g. external contributors merging via the GitHub UI).
 
 on:
   pull_request:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,14 +41,46 @@
 
 Backlog tasks live in `backlog/tasks/` (Backlog.md) and are managed via the `mcp__backlog__*` MCP tools. Every issue executed under the AI-SDLC pipeline MUST be tracked here.
 
+### Canonical execution paths
+
+| Use case | Command | Billing | Notes |
+|---|---|---|---|
+| **Internal dogfood (backlog tasks)** | `/ai-sdlc execute <task-id>` (slash command) | Subscription (Claude Code Max) | Runs as Claude Code subagents. Worktree-isolated. Auto-creates sibling-repo PRs from `permittedExternalPaths`. Marks Done + moves file in the same PR. |
+| **Manual ad-hoc cleanup** | `/ai-sdlc cleanup [<task-id>]` | n/a | Sweeps merged worktrees from `.worktrees/` (no args) or force-removes one (with task-id). Never deletes branches automatically. |
+| **GitHub-issue / unattended / CI** | `pnpm --filter @ai-sdlc/dogfood watch --issue <id>` | API key | Orchestrator-driven (TypeScript service). Use this when a Claude Code session isn't available — webhooks, cron, contributor-PR workflow. |
+
+For any internal task, default to `/ai-sdlc execute`. The orchestrator-driven path is reserved for unattended/programmatic use.
+
+### Done semantics — `/ai-sdlc execute` vs other paths
+
+- **`/ai-sdlc execute` path**: Done = "reviews-approved-and-PR-opened". The command marks Done + runs `task_complete` (moving the file to `backlog/completed/`) BEFORE pushing the PR, so the entire task lifecycle lands atomically in one PR. No follow-up workflow needed.
+- **Other paths (orchestrator, manual, external contributors)**: Done = "merged". The `.github/workflows/backlog-task-complete.yml` workflow opens a follow-up PR after merge to flip status and move the file. The workflow is idempotent — when the file is already in `backlog/completed/` (because `/ai-sdlc execute` already moved it), the workflow short-circuits to a no-op.
+
+### Cross-repo writes — `permittedExternalPaths`
+
+Tasks that legitimately need to write into sibling git repos (e.g. AISDLC-68 writing into `../ai-sdlc-io/`) declare an allowlist in their frontmatter:
+
+```yaml
+---
+id: AISDLC-68
+title: ...
+permittedExternalPaths:
+  - '../ai-sdlc-io/'
+---
+```
+
+The PreToolUse hook reads this when `AI_SDLC_ACTIVE_TASK_ID` is set (which `/ai-sdlc execute` exports automatically). Without the allowlist, writes outside the worktree are denied. With the allowlist, the developer subagent may write to the listed paths but does NOT commit there itself — `/ai-sdlc execute` Step 12 creates parallel PRs in the sibling repos.
+
 ### Lifecycle rules
 
 - **Create before execution.** When a plan includes multiple issues (e.g. an RFC implementation), create ALL backlog tasks BEFORE starting work on any of them. Use `mcp__backlog__task_create` with `milestone` + `labels` + acceptance criteria.
-- **Claim on start.** Flip status to `In Progress` via `mcp__backlog__task_edit` the moment you begin coding a task. Don't stack multiple tasks in progress unless they're actually being worked in parallel.
-- **Complete on merge — two steps, both required:**
+- **Claim on start.** Flip status to `In Progress` via `mcp__backlog__task_edit` the moment you begin coding a task. (Handled automatically by `/ai-sdlc execute`.) Don't stack multiple tasks in progress unless they're actually being worked in parallel.
+- **Complete — two steps, both required:**
   1. `mcp__backlog__task_edit` with `status: 'Done'`, `acceptanceCriteriaCheck: [1, 2, ...]`, and `finalSummary` documenting changes / design decisions / verification / follow-up.
   2. `mcp__backlog__task_complete` to **physically move the file from `backlog/tasks/` to `backlog/completed/`**. `task_edit` alone only flips the status field — the file stays in `tasks/` until `task_complete` archives it. A task isn't actually closed in the repo until it's in `backlog/completed/`.
-- **Never leave "To Do" after implementation.** If you finish work on AISDLC-N, AISDLC-N must be in `backlog/completed/` before the PR merges. Retroactive close-out is acceptable, blank close-out is not.
+
+  When using `/ai-sdlc execute`, both steps run automatically after reviews approve. When using other paths, run them yourself OR rely on the `backlog-task-complete.yml` post-merge workflow.
+- **Never leave "To Do" after implementation.** If you finish work on AISDLC-N, AISDLC-N must be in `backlog/completed/` before (or atomically with) the PR merge. Retroactive close-out is acceptable, blank close-out is not.
 
 ### `finalSummary` template
 

--- a/ai-sdlc-plugin/agents/agents.test.mjs
+++ b/ai-sdlc-plugin/agents/agents.test.mjs
@@ -59,7 +59,8 @@ function parseFrontmatter(filePath) {
   return result;
 }
 
-const agentFiles = ['code-reviewer.md', 'security-reviewer.md', 'test-reviewer.md'];
+const agentFiles = ['code-reviewer.md', 'security-reviewer.md', 'test-reviewer.md', 'developer.md'];
+const reviewerFiles = ['code-reviewer.md', 'security-reviewer.md', 'test-reviewer.md'];
 const agents = {};
 
 before(() => {
@@ -132,9 +133,51 @@ describe('agent definition tool restrictions', () => {
     }
   });
 
-  it('all agents specify sonnet as the model', () => {
+  it('all agents inherit the model from the parent session', () => {
     for (const file of agentFiles) {
-      assert.equal(agents[file].model, 'sonnet', `${file} should use sonnet model`);
+      assert.equal(
+        agents[file].model,
+        'inherit',
+        `${file} should inherit model — keeps subagent on the orchestrator's tier`,
+      );
     }
+  });
+
+  it('developer.md has Edit and Write in tools (it implements code)', () => {
+    assert.ok(agents['developer.md'].tools.includes('Edit'), 'developer needs Edit');
+    assert.ok(agents['developer.md'].tools.includes('Write'), 'developer needs Write');
+    assert.ok(agents['developer.md'].tools.includes('Bash'), 'developer needs Bash');
+  });
+
+  it('developer.md disallows AgentTool (no recursive subagent spawning)', () => {
+    assert.ok(
+      agents['developer.md'].disallowedTools.includes('AgentTool'),
+      'developer must not spawn nested subagents',
+    );
+  });
+
+  it('developer.md uses claude-code as its harness', () => {
+    assert.equal(
+      agents['developer.md'].harness,
+      'claude-code',
+      'developer is the implementer; reviewer independence is enforced via the reviewer agents',
+    );
+  });
+
+  it('developer.md body documents the [ai-sdlc-progress] convention', () => {
+    const body = readFileSync(join(__dirname, 'developer.md'), 'utf-8');
+    assert.ok(
+      body.includes('[ai-sdlc-progress]'),
+      'developer prompt must instruct emitting progress lines per stage',
+    );
+  });
+
+  it('developer.md body embeds the hard governance rules (defense-in-depth)', () => {
+    const body = readFileSync(join(__dirname, 'developer.md'), 'utf-8');
+    // SubagentStart hook also injects these, but embedding them in the agent
+    // prompt is belt-and-braces in case the hook ever fails to fire.
+    assert.ok(body.includes('Never merge'), 'embed never-merge rule');
+    assert.ok(body.includes('Never force-push'), 'embed never-force-push rule');
+    assert.ok(body.includes('Never edit `.ai-sdlc/**`'), 'embed blocked-paths rule');
   });
 });

--- a/ai-sdlc-plugin/agents/developer.md
+++ b/ai-sdlc-plugin/agents/developer.md
@@ -1,0 +1,87 @@
+---
+name: developer
+description: Implements backlog tasks against the spec, runs verification, commits work
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Edit
+  - Write
+disallowedTools:
+  - AgentTool
+model: inherit
+harness: claude-code
+---
+
+You are an AI-SDLC developer agent. You implement a single backlog task end-to-end inside an isolated git worktree, then return a structured summary so the orchestrating command can run reviews and open a PR.
+
+## Your environment
+
+- Your cwd is a git worktree at `.worktrees/<task-id>/` checked out on a feature branch off `origin/main`.
+- The active task ID is in `AI_SDLC_ACTIVE_TASK_ID` (already exported when you were spawned).
+- The task description, acceptance criteria, references, and `permittedExternalPaths` are in your initial prompt.
+- The PreToolUse hook will refuse `Write`/`Edit` on `.ai-sdlc/**`, `.github/workflows/**` and any path outside the worktree that isn't in `permittedExternalPaths`. Don't try to bypass it — it's a hard governance rule.
+
+## Hard rules (NEVER violate)
+
+1. **Never merge a PR.** Do not run `gh pr merge` under any circumstance.
+2. **Never force-push.** No `git push --force` / `-f`.
+3. **Never close PRs or issues.** No `gh pr close`, `gh issue close`.
+4. **Never delete branches.** No `git branch -D` / `-d`.
+5. **Never edit `.ai-sdlc/**` or `.github/workflows/**`.** Configuration and CI are out of scope for task work.
+6. **Never run destructive git operations.** No `git reset --hard`, `git checkout -- .`, `git restore .`.
+
+## Your workflow
+
+For each major stage, emit a single progress line so the operator can follow along:
+
+```bash
+echo "[ai-sdlc-progress] <stage>: <one-line status>"
+```
+
+Stages and the status line each one should produce:
+
+1. **plan** — Read the task description and acceptance criteria. Read referenced files. State your approach. Emit: `[ai-sdlc-progress] plan: <one-line approach>`
+2. **implement** — Make the code changes. Use `Edit` for existing files, `Write` only for new ones. Stay within the file budget specified in `agent-role.yaml`. Emit: `[ai-sdlc-progress] implement: <N files modified>`
+3. **verify** — Run `pnpm build && pnpm test && pnpm lint && pnpm format:check` (or the project's equivalent). Fix any failures. Emit: `[ai-sdlc-progress] verify: build/test/lint/format clean`
+4. **commit** — Stage only the files you intentionally modified (`git add -- <files>`, never `git add -A`), then commit with a conventional-commit message ending in the `Co-Authored-By` trailer. Emit: `[ai-sdlc-progress] commit: <sha-short> <subject>`
+
+## Commit message format
+
+```
+<type>(<scope>): <imperative subject under 70 chars>
+
+<optional 1-2 sentence body explaining why>
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+`<type>` is one of: `feat`, `fix`, `test`, `docs`, `chore`, `style`, `refactor`. Reference the task ID at the end of the subject in parens: `feat: add docs sync (AISDLC-68)`.
+
+## Cross-repo writes
+
+If `permittedExternalPaths` is non-empty, you may `Edit`/`Write` under those paths but **must not commit there yourself**. The orchestrating command handles sibling-repo commits + PRs after your turn ends. After you've made cross-repo changes, list them in your return summary so the command can pick them up.
+
+## Return value
+
+Return a JSON object as your final message (no other text):
+
+```json
+{
+  "summary": "1-3 sentence description of what shipped",
+  "filesChanged": ["path/in/worktree.ts", "..."],
+  "filesChangedExternal": [{"repo": "/abs/sibling/path", "files": ["..."]}],
+  "commitSha": "abc1234",
+  "verifications": {
+    "build": "passed | failed | skipped",
+    "test": "passed | failed | skipped",
+    "lint": "passed | failed | skipped",
+    "format": "passed | failed | skipped"
+  },
+  "acceptanceCriteriaMet": [1, 2, 3],
+  "notes": "anything the reviewers or operator should know (optional)"
+}
+```
+
+If you cannot complete the task (blocked, ambiguous, infeasible), still return the JSON with `commitSha: null`, `verifications` reflecting what you ran, and `notes` explaining the blocker. The orchestrator handles failure routing — don't try to escalate yourself.

--- a/ai-sdlc-plugin/commands/cleanup.md
+++ b/ai-sdlc-plugin/commands/cleanup.md
@@ -1,0 +1,66 @@
+---
+name: cleanup
+description: Remove worktrees under .worktrees/ — defaults to merged-PR sweep, or pass a task-id to force-remove a specific one.
+argument-hint: '[<task-id>]'
+allowed-tools: Bash, Read
+model: inherit
+---
+
+Companion to `/ai-sdlc execute`. Two modes:
+
+## Mode 1 — Sweep all merged worktrees (no arguments)
+
+When `$ARGUMENTS` is empty, do exactly what `/ai-sdlc execute` does at start: walk `.worktrees/`, check each branch's PR status via `gh pr list`, remove any whose PR has merged.
+
+```bash
+if [ ! -d .worktrees ]; then
+  echo "No .worktrees/ directory — nothing to sweep."
+  exit 0
+fi
+
+REMOVED=0
+for wt in .worktrees/*/; do
+  [ -d "$wt" ] || continue
+  WT_BRANCH=$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null)
+  [ -z "$WT_BRANCH" ] && continue
+  [ "$WT_BRANCH" = "HEAD" ] && continue
+  MERGED_AT=$(gh pr list --head "$WT_BRANCH" --state merged --json mergedAt --jq '.[0].mergedAt' 2>/dev/null)
+  if [ -n "$MERGED_AT" ] && [ "$MERGED_AT" != "null" ]; then
+    echo "Removing $wt (branch $WT_BRANCH merged at $MERGED_AT)"
+    git worktree remove --force "$wt" 2>/dev/null || true
+    REMOVED=$((REMOVED + 1))
+  fi
+done
+echo "Swept $REMOVED merged worktree(s)."
+```
+
+## Mode 2 — Force-remove a specific task's worktree
+
+When `$ARGUMENTS` is a task ID (e.g. `AISDLC-68`), remove that worktree regardless of PR status. Useful for retries after a failed `/ai-sdlc execute` that left state behind.
+
+```bash
+TASK_ID_LOWER=$(echo "$ARGUMENTS" | tr '[:upper:]' '[:lower:]')
+WORKTREE_PATH=".worktrees/$TASK_ID_LOWER"
+if [ ! -d "$WORKTREE_PATH" ]; then
+  echo "No worktree at $WORKTREE_PATH — nothing to clean up."
+  exit 0
+fi
+
+# Capture the branch name before removing so we can remind the operator.
+BRANCH=$(git -C "$WORKTREE_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+git worktree remove --force "$WORKTREE_PATH"
+echo "Removed worktree $WORKTREE_PATH (was on branch $BRANCH)."
+
+# Branch deletion is destructive and may erase work — leave it to the operator.
+echo ""
+echo "The branch '$BRANCH' is still present locally and possibly on origin."
+echo "If you want to delete it: git branch -D '$BRANCH' && git push origin --delete '$BRANCH'"
+echo "(NOT done automatically — branch deletion is operator-controlled per CLAUDE.md.)"
+```
+
+## What this command DOES NOT do
+
+- **Never deletes branches.** Branch deletion is destructive (could lose unmerged work). The operator decides.
+- **Never closes or merges PRs.** Cleanup is local-state-only.
+- **Never touches `.worktrees/` directories that aren't standalone git worktrees.** If `git -C $wt rev-parse` fails, the entry is skipped with no message — could be a stray empty dir, the operator can rm it themselves.

--- a/ai-sdlc-plugin/commands/cleanup.test.mjs
+++ b/ai-sdlc-plugin/commands/cleanup.test.mjs
@@ -1,0 +1,79 @@
+/**
+ * Tests for the /ai-sdlc cleanup slash command definition.
+ *
+ * Verifies frontmatter shape and the body's two-mode contract (sweep vs
+ * force-remove) including the "never delete branches" guardrail.
+ *
+ * Run with: node --test ai-sdlc-plugin/commands/cleanup.test.mjs
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cmdFile = join(__dirname, 'cleanup.md');
+
+let frontmatter;
+let body;
+
+before(() => {
+  const content = readFileSync(cmdFile, 'utf-8');
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) throw new Error('No frontmatter in cleanup.md');
+
+  frontmatter = {};
+  for (const line of match[1].split('\n')) {
+    const kv = line.match(/^([\w-]+):\s*(.+)$/);
+    if (kv) frontmatter[kv[1]] = kv[2].trim();
+  }
+  body = match[2];
+});
+
+describe('/ai-sdlc cleanup frontmatter', () => {
+  it('declares the command name', () => {
+    assert.equal(frontmatter.name, 'cleanup');
+  });
+
+  it('argument is optional (defaults to merged-PR sweep)', () => {
+    assert.match(frontmatter['argument-hint'], /\[/);
+  });
+
+  it('only allows Bash + Read (no Task, no MCP — pure local cleanup)', () => {
+    assert.equal(frontmatter['allowed-tools'], 'Bash, Read');
+  });
+
+  it('inherits model from session', () => {
+    assert.equal(frontmatter.model, 'inherit');
+  });
+});
+
+describe('/ai-sdlc cleanup body contract', () => {
+  it('mode 1 (no args): scans .worktrees/ and uses gh pr list', () => {
+    assert.match(body, /\.worktrees\//);
+    assert.match(body, /gh pr list --head/);
+    assert.match(body, /merged/);
+  });
+
+  it('mode 1: only removes worktrees whose PR has merged', () => {
+    assert.match(body, /git worktree remove --force/);
+    assert.match(body, /MERGED_AT/);
+  });
+
+  it('mode 2 (with arg): force-removes a specific task worktree', () => {
+    assert.match(body, /TASK_ID_LOWER/);
+    assert.match(body, /WORKTREE_PATH=".worktrees\/\$TASK_ID_LOWER"/);
+  });
+
+  it('NEVER deletes branches automatically (CLAUDE.md governance)', () => {
+    assert.match(body, /Never deletes branches/i);
+    // Confirm the body suggests the deletion command but does NOT execute it.
+    assert.match(body, /NOT done automatically/i);
+  });
+
+  it('handles missing .worktrees/ directory gracefully', () => {
+    assert.match(body, /No \.worktrees\/ directory/);
+  });
+});

--- a/ai-sdlc-plugin/commands/execute.md
+++ b/ai-sdlc-plugin/commands/execute.md
@@ -1,0 +1,345 @@
+---
+name: execute
+description: Execute a backlog task end-to-end via subagents — worktree → developer → reviews → PR. Replaces the orchestrator-driven dogfood pipeline for backlog tasks.
+argument-hint: <task-id>
+allowed-tools: Read, Grep, Glob, Bash, Task, AskUserQuestion, mcp__backlog__task_view, mcp__backlog__task_edit, mcp__backlog__task_complete
+model: inherit
+---
+
+Execute backlog task `$ARGUMENTS` end-to-end. The flow runs entirely as Claude Code subagents — no orchestrator subprocess, no shadow auth/state. One task per invocation; compose with `/loop /ai-sdlc execute <task-id>` for batches.
+
+## Step 0 — Sweep merged worktrees (auto-cleanup)
+
+Before doing anything else, scan `.worktrees/` and remove any whose branch's PR has merged into `main`. This is the eventual-cleanup mechanism — running `/ai-sdlc execute` regularly keeps the worktree directory tidy without any manual intervention.
+
+```bash
+if [ -d .worktrees ]; then
+  for wt in .worktrees/*/; do
+    [ -d "$wt" ] || continue
+    WT_BRANCH=$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null)
+    [ -z "$WT_BRANCH" ] && continue
+    [ "$WT_BRANCH" = "HEAD" ] && continue   # detached, skip
+    # Check if a PR for this branch exists and is merged
+    MERGED_AT=$(gh pr list --head "$WT_BRANCH" --state merged --json mergedAt --jq '.[0].mergedAt' 2>/dev/null)
+    if [ -n "$MERGED_AT" ] && [ "$MERGED_AT" != "null" ]; then
+      echo "Sweeping merged worktree: $wt (branch $WT_BRANCH merged at $MERGED_AT)"
+      git worktree remove --force "$wt" 2>/dev/null || true
+    fi
+  done
+fi
+```
+
+This runs SILENTLY when nothing matches. If anything was swept, print one line per removal so the operator can see what happened.
+
+For ad-hoc / manual cleanup of a specific task without waiting for the next `/ai-sdlc execute`, use the `/ai-sdlc cleanup [<task-id>]` companion command.
+
+## Step 1 — Validate the task
+
+Find the task file and read its frontmatter:
+
+```bash
+TASK_ID="$ARGUMENTS"   # e.g. AISDLC-68
+TASK_ID_LOWER="$(echo "$TASK_ID" | tr '[:upper:]' '[:lower:]')"
+TASK_FILE=$(ls "backlog/tasks/${TASK_ID_LOWER} -"* 2>/dev/null | head -1)
+[ -z "$TASK_FILE" ] && { echo "ERROR: no task file for $TASK_ID"; exit 1; }
+```
+
+Read the task with `mcp__backlog__task_view` to render its full structure. Then verify:
+
+- **Status** is `To Do` or `In Progress` (not `Draft`, not `Done`). If `Done`, refuse — already shipped. If `Draft`, refuse — not ready.
+- **At least one acceptance criterion** exists. If none, refuse — task isn't actionable.
+- **Not all ACs already checked** while status is `In Progress` — that's a stale-Done shape; refuse and ask the user to triage.
+
+If validation fails, print the reason clearly and stop. Don't create a worktree.
+
+## Step 2 — Compute branch name
+
+The branch pattern lives in `.ai-sdlc/pipeline-backlog.yaml` under `branching.pattern`. Today it's `ai-sdlc/{issueIdLower}-{slug}` where `{slug}` is a kebab-cased version of the task title.
+
+```bash
+BRANCH_PATTERN=$(grep -A2 'branching:' .ai-sdlc/pipeline-backlog.yaml | grep 'pattern:' | sed -E "s/.*pattern: *'([^']+)'.*/\1/")
+TITLE=$(grep -E '^title:' "$TASK_FILE" | sed -E 's/title: *"?([^"]+)"?/\1/')
+SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-50)
+BRANCH=$(echo "$BRANCH_PATTERN" | sed "s|{issueIdLower}|$TASK_ID_LOWER|g; s|{slug}|$SLUG|g")
+WORKTREE_PATH=".worktrees/$TASK_ID_LOWER"
+```
+
+## Step 3 — Set up the worktree
+
+```bash
+git fetch origin main
+mkdir -p .worktrees
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" origin/main
+```
+
+If `git worktree add` fails because the branch already exists, the operator's prior run left state. Tell them: "Worktree branch `$BRANCH` already exists. Run `/ai-sdlc cleanup $TASK_ID` first, or pick a different task." Then stop.
+
+## Step 4 — Flip task to In Progress
+
+Use `mcp__backlog__task_edit` to set `status: 'In Progress'`. This makes the dashboard reflect that work has started.
+
+## Step 5 — Invoke the developer subagent
+
+Spawn the `developer` agent against the worktree. Build the prompt from the task content:
+
+```
+You are implementing backlog task $TASK_ID in worktree $WORKTREE_PATH.
+
+## Task title
+<title from frontmatter>
+
+## Description
+<body of the task file, between the AC list and the next ## section>
+
+## Acceptance criteria
+<numbered list from the task>
+
+## References
+<refs from frontmatter — read as needed via Read tool>
+
+## Permitted external paths (cross-repo writes)
+<permittedExternalPaths from frontmatter, or "none">
+
+## Verification commands (run before commit)
+- pnpm build
+- pnpm test
+- pnpm lint
+- pnpm format:check
+
+## Commit message template
+<conventional-commit type>: <subject> ($TASK_ID)
+
+<body>
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+
+## Branch
+You are on branch `$BRANCH` checked out at `$WORKTREE_PATH`.
+
+Return the JSON shape documented in your agent definition.
+```
+
+When invoking the Task tool for the developer agent:
+
+- `subagent_type: developer`
+- Set `AI_SDLC_ACTIVE_TASK_ID=$TASK_ID` in the environment so the PreToolUse hook honors `permittedExternalPaths` from the task frontmatter
+- The agent's cwd will be the worktree path
+
+Watch for `[ai-sdlc-progress]` lines in the agent's tool output and surface them to the user as they appear.
+
+## Step 6 — Parse developer return value
+
+The developer returns a JSON object. Parse it and check:
+
+- If `commitSha` is `null`, the developer couldn't complete the task. Print the `notes` field, revert the task to `To Do` via `mcp__backlog__task_edit`, leave the worktree on disk for inspection, and stop. Print: "Worktree preserved at `$WORKTREE_PATH`. To clean up: `/ai-sdlc cleanup $TASK_ID`."
+- If any of `verifications.{build,test,lint}` is `failed`, treat as developer failure (same rollback as above).
+- Otherwise proceed to review.
+
+## Step 7 — Run three reviews in parallel
+
+Build the review context once, share across all reviewers:
+
+```bash
+cd "$WORKTREE_PATH"
+git diff origin/main...HEAD > "/tmp/pr-diff-${TASK_ID}.txt"
+git diff --name-only origin/main...HEAD > "/tmp/pr-files-${TASK_ID}.txt"
+cd -
+```
+
+Detect Codex availability once (the reviewer agents declare `harness: codex`):
+
+```bash
+if which codex >/dev/null 2>&1; then
+  HARNESS_NOTE=""
+else
+  HARNESS_NOTE="⚠ INDEPENDENCE NOT ENFORCED (codex unavailable, fell back to claude-code)"
+fi
+```
+
+Spawn **three subagents in parallel** (single message, three Task tool calls):
+
+- `subagent_type: code-reviewer`
+- `subagent_type: test-reviewer`
+- `subagent_type: security-reviewer`
+
+Each prompt should contain:
+
+- The PR diff (from `/tmp/pr-diff-${TASK_ID}.txt`)
+- The task title, description, AC list
+- Contents of `.ai-sdlc/review-policy.md` if present (project-specific calibration)
+- The branch name + base (`main`)
+
+Each returns a verdict JSON: `{ approved, findings, summary }`.
+
+## Step 8 — Aggregate verdicts
+
+Combine the three verdicts:
+
+- Count findings by severity across all reviewers (`critical`, `major`, `minor`, `suggestion`).
+- If `HARNESS_NOTE` is non-empty, prepend it to the aggregated summary so the operator sees the independence warning every time it applies.
+- Compute the gate decision:
+  - **APPROVED**: all three reviewers approved AND no `critical`/`major` findings → proceed to PR (Step 10).
+  - **CHANGES REQUESTED**: any `critical` or `major` findings → enter the iteration loop (Step 9).
+
+Print the aggregation summary to the user before proceeding.
+
+## Step 9 — Iteration loop (max 2 dev iterations on review failure)
+
+Track iteration count starting at 1 (the first developer pass already ran).
+
+While `iteration_count < 2` AND there are still critical/major findings:
+
+1. Increment `iteration_count`.
+2. Re-spawn the `developer` subagent with the SAME task context PLUS a `## Reviewer feedback (round N)` section listing the findings as bullet items (file:line — message). Tell the developer to address them and re-run verification.
+3. Re-run the three parallel reviews against the updated diff.
+4. Re-aggregate; if approved, break out of the loop and proceed to PR (Step 10).
+
+After the loop, if there are STILL critical/major findings, do NOT abort. Open the PR anyway with the `[needs-human-attention]` flag in the body so the human can take it from there. The work is preserved, the human decides next steps.
+
+```
+PR title: feat: <task title> [needs-human-attention] (<task-id>)
+PR body opens with: > **⚠ This PR exceeded the auto-iteration cap (2 rounds) with unresolved review findings. Human review/intervention requested.**
+```
+
+Then collapse all three review verdicts (round-by-round if multiple iterations ran) into `<details>` blocks in the PR body.
+
+## Step 10 — Mark task Done + commit the file move (BEFORE push)
+
+This step lands the entire task lifecycle inside a single PR — Done state, file move, and the implementation work all merge atomically. Per CLAUDE.md (this command's authority): for tasks shipped via `/ai-sdlc execute`, **Done = "reviews-approved-and-PR-opened"**, not "merged."
+
+Skip this step entirely if the iteration cap was exceeded (the PR is `[needs-human-attention]` — let the human flip Done after they're satisfied via `/ai-sdlc complete <task-id>` or by hand).
+
+If reviews approved cleanly:
+
+1. **Build `acceptanceCriteriaCheck`** — list all AC indices `[1..N]` by default. If reviewers explicitly contested any AC ("AC #3 not actually met" wording), drop those indices.
+2. **Build `finalSummary`** — assemble per the CLAUDE.md template:
+   ```markdown
+   ## Summary
+   <developer's `summary` field>
+
+   ## Changes
+   <bullet list of files from developer's `filesChanged` with one-liner each>
+
+   ## Design decisions
+   <from developer's `notes` field, or "(none)" if empty>
+
+   ## Verification
+   - `pnpm build` — <developer.verifications.build>
+   - `pnpm test` — <developer.verifications.test>
+   - `pnpm lint` — <developer.verifications.lint>
+   - `pnpm format:check` — <developer.verifications.format>
+   - 3 parallel reviews approved (<HARNESS_NOTE if any>)
+
+   ## Follow-up
+   (none) | <anything from developer.notes>
+   ```
+3. **Call `mcp__backlog__task_edit`** with `id: $TASK_ID`, `status: 'Done'`, `acceptanceCriteriaCheck: [...]`, `finalSummary: '...'`.
+4. **Call `mcp__backlog__task_complete`** with `id: $TASK_ID` — this physically moves `backlog/tasks/<file>.md` → `backlog/completed/<file>.md`.
+5. **Stage and commit the move** in the worktree as a separate commit so the developer's commit stays clean:
+   ```bash
+   cd "$WORKTREE_PATH"
+   git add backlog/tasks backlog/completed
+   git commit -m "chore: mark $TASK_ID complete
+
+   Auto-generated by /ai-sdlc execute. Reviews approved; task lifecycle landed in this PR.
+
+   Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+   cd -
+   ```
+
+When the PR merges, the file is already in `backlog/completed/` on `main` — no race with the post-merge workflow.
+
+## Step 11 — Push and open PR
+
+```bash
+cd "$WORKTREE_PATH"
+git push -u origin "$BRANCH"
+```
+
+If push fails with non-fast-forward (someone else pushed to the same branch), abort with a clear message — the cleanup story is "delete the remote branch and rerun" but that's a destructive action so we ask the user first.
+
+Compose the PR title from `.ai-sdlc/pipeline-backlog.yaml` `pullRequest.titleTemplate` (today: `feat: {issueTitle} ({issueId})`).
+
+Compose the PR body from:
+- The developer's `summary` field
+- A list of changed files (`git diff --name-only origin/main...HEAD`)
+- A `<details>` block with the code-reviewer verdict
+- A footer: `References $TASK_ID` (NOT `Closes` — backlog tasks aren't auto-closed by GitHub PR merges; the `.github/workflows/backlog-task-complete.yml` workflow handles it)
+
+```bash
+gh pr create \
+  --title "<composed title>" \
+  --body "<composed body>" \
+  --base main \
+  --head "$BRANCH"
+```
+
+Print the PR URL. Capture it as `MAIN_PR_URL`.
+
+## Step 12 — Cross-repo PRs (siblings under permittedExternalPaths)
+
+If the developer reported `filesChangedExternal` (sibling-repo writes) AND the task's frontmatter has `permittedExternalPaths`, create one parallel PR per dirty sibling repo:
+
+For each entry in `developer.filesChangedExternal`:
+
+1. **Verify it's a git repo**:
+   ```bash
+   SIBLING="<dev-reported repo path>"
+   git -C "$SIBLING" rev-parse --show-toplevel >/dev/null 2>&1 || continue
+   ```
+2. **Check the dirty state matches what the developer claimed** (`git -C $SIBLING status --porcelain`). If empty, skip — nothing to push.
+3. **Confirm `gh` auth works for the sibling**:
+   ```bash
+   gh -R "$(gh -C $SIBLING repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" auth status >/dev/null 2>&1
+   ```
+   If it fails, skip with a clear warning: "⚠ Cannot create sibling PR for `$SIBLING` — gh auth not configured for that repo. Files left dirty for manual handling: <list>."
+4. **Create a parallel branch** in the sibling using the same task slug:
+   ```bash
+   SIBLING_BRANCH="ai-sdlc/${TASK_ID_LOWER}-sibling"
+   git -C "$SIBLING" checkout -b "$SIBLING_BRANCH"
+   git -C "$SIBLING" add -- <files reported by developer>
+   git -C "$SIBLING" commit -m "feat: <task title> — sibling for $TASK_ID
+
+   Companion changes for $MAIN_PR_URL.
+
+   Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+   git -C "$SIBLING" push -u origin "$SIBLING_BRANCH"
+   ```
+5. **Open the sibling PR** with a body that links back to the main PR:
+   ```bash
+   gh -R "<sibling repo>" pr create \
+     --title "feat: <task title> — sibling for $TASK_ID" \
+     --body "Companion PR for $MAIN_PR_URL ($TASK_ID).
+
+   <developer's summary>
+
+   Files changed: <list>" \
+     --base main \
+     --head "$SIBLING_BRANCH"
+   ```
+6. **Capture the sibling PR URL.**
+
+If any sibling PR creation fails partway, do NOT roll back the main PR — print the failure clearly and tell the operator to handle the sibling manually. Each sibling is independent.
+
+After all siblings:
+- Update the main PR body via `gh pr edit $MAIN_PR_URL --body "..."` to add a `## Sibling PRs` section listing each sibling URL.
+
+## Step 13 — Report
+
+Print a tight summary:
+
+- ✅ Task: `$TASK_ID` — `<title>`
+- ✅ Branch: `$BRANCH` (worktree at `$WORKTREE_PATH`)
+- ✅ Developer: `<N>` files, commit `<sha>`
+- ✅ Reviews: `<APPROVED | NEEDS HUMAN ATTENTION>` — `<N>` critical, `<N>` major, `<N>` minor across 3 reviewers (`<HARNESS_NOTE if any>`)
+- ✅ Iterations: `<N>` (capped at 2)
+- ✅ PR: `<url>`
+- ✅ Sibling PRs (if any): `<url>` for each
+- ℹ️  Worktree retained for inspection. Will be auto-removed on next `/ai-sdlc execute` once this PR merges.
+
+## What this command DOES NOT do (intentional)
+
+- **Never runs `gh pr merge`.** Per CLAUDE.md, only humans merge.
+- **Never runs `git push --force`.** If push fails, asks the operator.
+- **Never edits `.ai-sdlc/**` or `.github/workflows/**`.** PreToolUse hook blocks anyway, but the developer prompt makes this explicit.
+- **Does not yet** sweep merged worktrees on start (Step 7 of the larger plan). That lands in the next commit.

--- a/ai-sdlc-plugin/commands/execute.test.mjs
+++ b/ai-sdlc-plugin/commands/execute.test.mjs
@@ -1,0 +1,174 @@
+/**
+ * Tests for the /ai-sdlc execute slash command definition.
+ *
+ * Verifies frontmatter shape (allowed-tools include the orchestration tools)
+ * and that the body documents the contract the orchestrating model needs to
+ * follow (worktree creation, developer subagent invocation, governance rules).
+ *
+ * Run with: node --test ai-sdlc-plugin/commands/execute.test.mjs
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cmdFile = join(__dirname, 'execute.md');
+
+let frontmatter;
+let body;
+
+before(() => {
+  const content = readFileSync(cmdFile, 'utf-8');
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) throw new Error('No frontmatter in execute.md');
+
+  frontmatter = {};
+  for (const line of match[1].split('\n')) {
+    const kv = line.match(/^([\w-]+):\s*(.+)$/);
+    if (kv) frontmatter[kv[1]] = kv[2].trim();
+  }
+  body = match[2];
+});
+
+describe('/ai-sdlc execute frontmatter', () => {
+  it('declares the command name', () => {
+    assert.equal(frontmatter.name, 'execute');
+  });
+
+  it('declares an argument hint', () => {
+    assert.ok(frontmatter['argument-hint'], 'argument-hint should be present');
+    assert.match(frontmatter['argument-hint'], /task-id/, 'should reference task-id');
+  });
+
+  it('inherits the model from the orchestrating session', () => {
+    assert.equal(frontmatter.model, 'inherit');
+  });
+
+  it('allows the Task tool (for spawning developer + reviewers as subagents)', () => {
+    assert.match(frontmatter['allowed-tools'], /\bTask\b/);
+  });
+
+  it('allows Bash (worktree management, git operations, gh)', () => {
+    assert.match(frontmatter['allowed-tools'], /\bBash\b/);
+  });
+
+  it('allows the backlog task_edit MCP tool (for status flips)', () => {
+    assert.match(frontmatter['allowed-tools'], /mcp__backlog__task_edit/);
+  });
+
+  it('allows the backlog task_complete MCP tool (file move on Done)', () => {
+    assert.match(frontmatter['allowed-tools'], /mcp__backlog__task_complete/);
+  });
+
+  it('allows AskUserQuestion (for review-gate decisions)', () => {
+    assert.match(frontmatter['allowed-tools'], /AskUserQuestion/);
+  });
+});
+
+describe('/ai-sdlc execute body contract', () => {
+  it('walks through worktree creation', () => {
+    assert.match(body, /git worktree add/);
+    assert.match(body, /\.worktrees\//);
+  });
+
+  it('invokes the developer subagent', () => {
+    assert.match(body, /subagent_type:\s*developer/i);
+  });
+
+  it('exports AI_SDLC_ACTIVE_TASK_ID for the developer (PreToolUse hook reads it)', () => {
+    assert.match(body, /AI_SDLC_ACTIVE_TASK_ID/);
+  });
+
+  it('runs all three reviewers in parallel (code, test, security)', () => {
+    assert.match(body, /code-reviewer/);
+    assert.match(body, /test-reviewer/);
+    assert.match(body, /security-reviewer/);
+    assert.match(body, /three subagents in parallel/i);
+  });
+
+  it('detects Codex availability and emits visible fallback warning', () => {
+    assert.match(body, /which codex/);
+    assert.match(body, /INDEPENDENCE NOT ENFORCED/);
+  });
+
+  it('caps developer iterations at 2 on review failure', () => {
+    assert.match(body, /max 2 dev iterations/i);
+    assert.match(body, /iteration_count\s*<\s*2/);
+  });
+
+  it('escalates instead of aborting after the iteration cap', () => {
+    assert.match(body, /\[needs-human-attention\]/);
+    assert.match(body, /do NOT abort/);
+  });
+
+  it('feeds reviewer findings back into the developer on iteration', () => {
+    assert.match(body, /Reviewer feedback \(round N\)/);
+  });
+
+  it('marks task Done + runs task_complete BEFORE pushing the PR', () => {
+    // The Done flip and file move must land in the same PR as the work,
+    // sequenced after reviews approve and before push.
+    assert.match(body, /mark task Done.*BEFORE push/i);
+    assert.match(body, /mcp__backlog__task_complete/);
+  });
+
+  it('skips the Done flip when iteration cap was exceeded', () => {
+    assert.match(body, /Skip this step entirely if the iteration cap was exceeded/i);
+  });
+
+  it('commits the file move as a separate chore commit', () => {
+    assert.match(body, /chore: mark.*complete/);
+  });
+
+  it('builds finalSummary per CLAUDE.md template', () => {
+    assert.match(body, /finalSummary/);
+    assert.match(body, /## Summary/);
+    assert.match(body, /## Verification/);
+  });
+
+  it('creates parallel sibling PRs from filesChangedExternal', () => {
+    assert.match(body, /filesChangedExternal/);
+    assert.match(body, /sibling for \$TASK_ID/);
+    assert.match(body, /git -C "\$SIBLING"/);
+  });
+
+  it('skips siblings cleanly when gh auth is unavailable for that repo', () => {
+    assert.match(body, /gh auth not configured for that repo/);
+  });
+
+  it('does NOT roll back the main PR if a sibling PR creation fails', () => {
+    assert.match(body, /do NOT roll back the main PR/);
+  });
+
+  it('cross-links sibling PRs back into the main PR body', () => {
+    assert.match(body, /Sibling PRs/);
+    assert.match(body, /gh pr edit/);
+  });
+
+  it('opens a PR via gh pr create', () => {
+    assert.match(body, /gh pr create/);
+  });
+
+  it('uses References (not Closes) per backlog convention', () => {
+    assert.match(body, /References/);
+  });
+
+  it('explicitly forbids gh pr merge', () => {
+    assert.match(body, /Never runs `gh pr merge`/i);
+  });
+
+  it('explicitly forbids git push --force', () => {
+    assert.match(body, /Never runs `git push --force`/i);
+  });
+
+  it('rolls back task status on developer failure', () => {
+    assert.match(body, /revert.*task.*To Do/i);
+  });
+
+  it('preserves worktree for inspection on failure', () => {
+    assert.match(body, /Worktree preserved/);
+  });
+});

--- a/ai-sdlc-plugin/hooks/enforce-blocked-actions.js
+++ b/ai-sdlc-plugin/hooks/enforce-blocked-actions.js
@@ -1,18 +1,24 @@
 /**
  * AI-SDLC Action Enforcement Hook (PreToolUse)
  *
- * Reads blockedActions from .ai-sdlc/agent-role.yaml in the project directory
- * and checks the incoming Bash command against them.
+ * Enforces governance from .ai-sdlc/agent-role.yaml across three tool families:
  *
- * Returns a deny decision if the command matches a blocked pattern.
- * Fail-safe: allows everything on any error.
+ * 1. **Bash** — checks `tool_input.command` against `blockedActions` patterns.
+ * 2. **Write / Edit** — checks `tool_input.file_path` against `blockedPaths` globs
+ *    (relative to project root). Paths outside the project root are denied unless
+ *    they fall under `permittedExternalPaths` declared in the active task's
+ *    frontmatter (active task = `AI_SDLC_ACTIVE_TASK_ID` env var).
+ *
+ * Returns a deny decision when a tool call matches a guarded pattern.
+ * Fail-safe: allows everything on any error — never block a session because
+ * the policy file couldn't be parsed.
  */
 
-const { readFileSync } = require('fs');
-const { join } = require('path');
+const { readFileSync, existsSync, readdirSync } = require('fs');
+const { join, resolve, isAbsolute, relative, sep } = require('path');
 const { execSync } = require('child_process');
 
-// ── Read stdin (tool input JSON from Claude Code) ────────────────
+// ── Read stdin (tool input JSON from Claude Code) ────────────────────
 
 let input;
 try {
@@ -22,12 +28,10 @@ try {
   process.exit(0);
 }
 
-const command = input?.tool_input?.command;
-if (!command || typeof command !== 'string' || !command.trim()) {
-  process.exit(0);
-}
+const toolName = input?.tool_name;
+const toolInput = input?.tool_input || {};
 
-// ── Find project root and load agent-role.yaml ───────────────────
+// ── Find project root and load agent-role.yaml ───────────────────────
 
 const projectDir =
   process.env.CLAUDE_PROJECT_DIR ||
@@ -41,65 +45,187 @@ const projectDir =
 
 const agentRolePath = join(projectDir, '.ai-sdlc', 'agent-role.yaml');
 
-let blockedActions;
+let blockedActions = [];
+let blockedPaths = [];
 try {
   const yaml = readFileSync(agentRolePath, 'utf-8');
-  blockedActions = parseBlockedActions(yaml);
+  blockedActions = parseListField(yaml, 'blockedActions');
+  blockedPaths = parseListField(yaml, 'blockedPaths');
 } catch {
   process.exit(0);
 }
 
-if (!blockedActions || blockedActions.length === 0) {
-  process.exit(0);
-}
+// ── Dispatch by tool ─────────────────────────────────────────────────
 
-// ── Check command against blocked actions ─────────────────────────
-
-const trimmed = command.trim();
-
-for (const pattern of blockedActions) {
-  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
-  const regexStr = escaped.replace(/\*/g, '.*');
-  const regex = new RegExp(`^${regexStr}$`, 'i');
-
-  if (regex.test(trimmed)) {
-    const result = {
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: `Blocked by AI-SDLC governance policy: command matches blockedAction pattern '${pattern}'`,
-      },
-    };
-    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
-    process.exit(0);
-  }
+if (toolName === 'Bash' || (!toolName && toolInput.command)) {
+  enforceBash(toolInput.command);
+} else if (toolName === 'Write' || toolName === 'Edit') {
+  enforceWriteEdit(toolInput.file_path);
 }
 
 process.exit(0);
 
-// ── Simple YAML parser for blockedActions ─────────────────────────
+// ── Bash enforcement (unchanged behavior) ────────────────────────────
 
-function parseBlockedActions(yaml) {
-  const lines = yaml.split('\n');
-  const actions = [];
-  let inSection = false;
+function enforceBash(command) {
+  if (!command || typeof command !== 'string' || !command.trim()) return;
+  if (blockedActions.length === 0) return;
 
-  for (const line of lines) {
-    if (/^\s*blockedActions:\s*$/.test(line)) {
-      inSection = true;
-      continue;
+  const trimmed = command.trim();
+  for (const pattern of blockedActions) {
+    const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+    const regexStr = escaped.replace(/\*/g, '.*');
+    const regex = new RegExp(`^${regexStr}$`, 'i');
+    if (regex.test(trimmed)) {
+      deny(`command matches blockedAction pattern '${pattern}'`);
     }
+  }
+}
 
-    if (inSection) {
-      if (/^[a-zA-Z]/.test(line)) break;
-      if (/^\s*$/.test(line)) continue;
+// ── Write/Edit enforcement (new behavior) ────────────────────────────
 
-      const match = line.match(/^\s+-\s+['"]?(.+?)['"]?\s*$/);
-      if (match) {
-        actions.push(match[1]);
+function enforceWriteEdit(filePath) {
+  if (!filePath || typeof filePath !== 'string') return;
+
+  // Always work with absolute paths so both relative tool inputs and
+  // already-absolute ones get the same treatment.
+  const absPath = isAbsolute(filePath) ? resolve(filePath) : resolve(projectDir, filePath);
+
+  const projectAbs = resolve(projectDir);
+  const insideProject = absPath === projectAbs || absPath.startsWith(projectAbs + sep);
+
+  if (insideProject) {
+    // Path is inside the project root — check against blockedPaths globs.
+    // Relative path uses POSIX separators because globs do.
+    const relPath = relative(projectAbs, absPath).split(sep).join('/');
+    for (const glob of blockedPaths) {
+      if (matchGlob(glob, relPath)) {
+        deny(
+          `path '${relPath}' matches blocked path '${glob}'. ` +
+            `Configuration files under blockedPaths are out of scope for agent edits.`,
+        );
       }
+    }
+    return;
+  }
+
+  // Path is OUTSIDE the project root — only allowed if the active task's
+  // permittedExternalPaths covers it.
+  const allowed = loadPermittedExternalPaths(projectAbs);
+  for (const ext of allowed) {
+    const extAbs = resolve(projectAbs, ext);
+    if (absPath === extAbs || absPath.startsWith(extAbs + sep)) {
+      return; // explicit allow
     }
   }
 
-  return actions;
+  // No allowlist match — deny with a clear, actionable reason.
+  if (allowed.length === 0) {
+    deny(
+      `path '${absPath}' is outside the project root. ` +
+        `To permit cross-repo writes for this task, add 'permittedExternalPaths' to ` +
+        `the task frontmatter and set AI_SDLC_ACTIVE_TASK_ID before invoking the agent.`,
+    );
+  } else {
+    deny(
+      `path '${absPath}' is outside the project root and not under the active ` +
+        `task's permittedExternalPaths (${allowed.join(', ')}).`,
+    );
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function deny(reason) {
+  const result = {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: `Blocked by AI-SDLC governance policy: ${reason}`,
+    },
+  };
+  process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  process.exit(0);
+}
+
+function parseListField(yaml, field) {
+  const lines = yaml.split('\n');
+  const items = [];
+  let inSection = false;
+
+  for (const line of lines) {
+    if (new RegExp(`^\\s*${field}:\\s*$`).test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (inSection) {
+      if (/^[a-zA-Z]/.test(line)) break;
+      if (/^\s*$/.test(line)) continue;
+      const match = line.match(/^\s+-\s+['"]?(.+?)['"]?\s*$/);
+      if (match) items.push(match[1]);
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Convert a glob like `.ai-sdlc/**` or `.github/workflows/*.yml` to a regex.
+ * - `**` matches any sequence including `/`
+ * - `*` matches any sequence except `/`
+ * - other characters are matched literally
+ */
+function matchGlob(glob, path) {
+  const regexStr = glob
+    .split('')
+    .map((char, i, arr) => {
+      if (char === '*' && arr[i + 1] === '*') return '__DOUBLESTAR__';
+      if (char === '*' && arr[i - 1] === '*') return '';
+      if (char === '*') return '[^/]*';
+      if (/[.+?^${}()|[\]\\]/.test(char)) return '\\' + char;
+      return char;
+    })
+    .join('')
+    .replace(/__DOUBLESTAR__/g, '.*');
+
+  const regex = new RegExp(`^${regexStr}$`);
+  return regex.test(path);
+}
+
+/**
+ * Load permittedExternalPaths from the active task's frontmatter.
+ * Active task is identified by AI_SDLC_ACTIVE_TASK_ID env var (e.g. AISDLC-68).
+ * Returns [] when no env var, no matching task file, or no frontmatter field.
+ */
+function loadPermittedExternalPaths(projectAbs) {
+  const taskId = process.env.AI_SDLC_ACTIVE_TASK_ID;
+  if (!taskId) return [];
+
+  const tasksDir = join(projectAbs, 'backlog', 'tasks');
+  if (!existsSync(tasksDir)) return [];
+
+  let entries;
+  try {
+    entries = readdirSync(tasksDir);
+  } catch {
+    return [];
+  }
+
+  // Task files are named `<id-lower> - <slug>.md` (e.g. `aisdlc-68 - foo.md`).
+  // Match case-insensitively on the id prefix to be tolerant.
+  const idLower = taskId.toLowerCase();
+  const taskFile = entries.find((f) => f.toLowerCase().startsWith(idLower + ' '));
+  if (!taskFile) return [];
+
+  let content;
+  try {
+    content = readFileSync(join(tasksDir, taskFile), 'utf-8');
+  } catch {
+    return [];
+  }
+
+  const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fmMatch) return [];
+
+  return parseListField(fmMatch[1], 'permittedExternalPaths');
 }

--- a/ai-sdlc-plugin/hooks/enforce-blocked-actions.test.mjs
+++ b/ai-sdlc-plugin/hooks/enforce-blocked-actions.test.mjs
@@ -17,17 +17,25 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const hookScript = join(__dirname, 'enforce-blocked-actions.js');
 
-// Create a temp project dir with agent-role.yaml containing blocked actions
+// Create a temp project dir with agent-role.yaml containing blocked actions/paths.
 let tempDir;
+let siblingDir;
 
 before(() => {
   tempDir = join(tmpdir(), `enforce-blocked-test-${Date.now()}`);
+  siblingDir = join(tmpdir(), `enforce-blocked-sibling-${Date.now()}`);
   const aiSdlcDir = join(tempDir, '.ai-sdlc');
+  const tasksDir = join(tempDir, 'backlog', 'tasks');
   mkdirSync(aiSdlcDir, { recursive: true });
+  mkdirSync(tasksDir, { recursive: true });
+  mkdirSync(siblingDir, { recursive: true });
   writeFileSync(
     join(aiSdlcDir, 'agent-role.yaml'),
     `role: coding-agent
 goal: Test agent
+blockedPaths:
+  - '.github/workflows/**'
+  - '.ai-sdlc/**'
 blockedActions:
   - 'gh pr merge*'
   - 'git merge*'
@@ -39,19 +47,45 @@ blockedActions:
   - 'git reset --hard*'
 `,
   );
+
+  // A task file with permittedExternalPaths pointing at the sibling dir
+  // (relative path that resolves up out of the project root).
+  const siblingRelative = '../' + siblingDir.split('/').pop();
+  writeFileSync(
+    join(tasksDir, 'aisdlc-99 - test-task.md'),
+    `---
+id: AISDLC-99
+title: Test task
+permittedExternalPaths:
+  - '${siblingRelative}'
+---
+
+Body.
+`,
+  );
 });
 
 after(() => {
   rmSync(tempDir, { recursive: true, force: true });
+  rmSync(siblingDir, { recursive: true, force: true });
 });
 
 function runHook(command) {
-  const input = JSON.stringify({ tool_input: { command } });
+  const input = JSON.stringify({ tool_name: 'Bash', tool_input: { command } });
+  return runHookRaw(input);
+}
+
+function runHookFile(toolName, file_path, env = {}) {
+  const input = JSON.stringify({ tool_name: toolName, tool_input: { file_path } });
+  return runHookRaw(input, env);
+}
+
+function runHookRaw(input, extraEnv = {}) {
   try {
     const output = execFileSync('node', [hookScript], {
       input,
       encoding: 'utf-8',
-      env: { ...process.env, CLAUDE_PROJECT_DIR: tempDir },
+      env: { ...process.env, CLAUDE_PROJECT_DIR: tempDir, ...extraEnv },
       timeout: 5000,
     });
     return { output: output.trim(), exitCode: 0 };
@@ -132,5 +166,88 @@ describe('ai-sdlc-plugin enforce-blocked-actions hook', () => {
       parsed.hookSpecificOutput.permissionDecisionReason.includes('gh pr merge'),
       'reason should mention the blocked pattern',
     );
+  });
+});
+
+describe('ai-sdlc-plugin enforce-blocked-actions hook (Write/Edit)', () => {
+  it('blocks Write to .ai-sdlc/foo.yaml (matches .ai-sdlc/** glob)', () => {
+    const result = runHookFile('Write', join(tempDir, '.ai-sdlc', 'foo.yaml'));
+    assert.ok(isDenied(result), 'should deny write under .ai-sdlc/');
+  });
+
+  it('blocks Edit to .github/workflows/ci.yml (matches .github/workflows/** glob)', () => {
+    const result = runHookFile('Edit', join(tempDir, '.github', 'workflows', 'ci.yml'));
+    assert.ok(isDenied(result), 'should deny edit under .github/workflows/');
+  });
+
+  it('blocks Write to nested .ai-sdlc/sub/dir/file (recursive glob match)', () => {
+    const result = runHookFile('Write', join(tempDir, '.ai-sdlc', 'sub', 'dir', 'file.md'));
+    assert.ok(isDenied(result), 'should deny nested write under .ai-sdlc/');
+  });
+
+  it('allows Write to src/foo.ts (not in any blockedPaths glob)', () => {
+    const result = runHookFile('Write', join(tempDir, 'src', 'foo.ts'));
+    assert.ok(!isDenied(result), 'should allow write under src/');
+    assert.equal(result.output, '', 'no output');
+  });
+
+  it('allows Edit to README.md at the project root', () => {
+    const result = runHookFile('Edit', join(tempDir, 'README.md'));
+    assert.ok(!isDenied(result), 'should allow edit at project root');
+  });
+
+  it('blocks Write outside the project root when no AI_SDLC_ACTIVE_TASK_ID is set', () => {
+    const result = runHookFile('Write', join(siblingDir, 'foo.txt'));
+    assert.ok(isDenied(result), 'should deny external write without active task');
+    const parsed = JSON.parse(result.output);
+    assert.ok(
+      parsed.hookSpecificOutput.permissionDecisionReason.includes('outside the project root'),
+      'reason should mention outside project root',
+    );
+  });
+
+  it('blocks Write outside the project root when active task does not list the path', () => {
+    const otherSibling = join(tmpdir(), 'some-other-dir');
+    const result = runHookFile('Write', join(otherSibling, 'foo.txt'), {
+      AI_SDLC_ACTIVE_TASK_ID: 'AISDLC-99',
+    });
+    assert.ok(isDenied(result), 'should deny path not in permittedExternalPaths');
+  });
+
+  it('allows Write outside the project root when path is in permittedExternalPaths', () => {
+    const result = runHookFile('Write', join(siblingDir, 'allowed.txt'), {
+      AI_SDLC_ACTIVE_TASK_ID: 'AISDLC-99',
+    });
+    assert.ok(!isDenied(result), 'should allow write under permittedExternalPaths');
+  });
+
+  it('allows nested Write under permittedExternalPaths', () => {
+    const result = runHookFile('Write', join(siblingDir, 'sub', 'nested.txt'), {
+      AI_SDLC_ACTIVE_TASK_ID: 'AISDLC-99',
+    });
+    assert.ok(!isDenied(result), 'should allow nested write under permittedExternalPaths');
+  });
+
+  it('handles missing file_path gracefully (allows)', () => {
+    const result = runHookFile('Write', '');
+    assert.ok(!isDenied(result), 'should not deny on empty file_path');
+  });
+
+  it('treats non-existent active task ID as no permittedExternalPaths', () => {
+    const result = runHookFile('Write', join(siblingDir, 'foo.txt'), {
+      AI_SDLC_ACTIVE_TASK_ID: 'AISDLC-9999',
+    });
+    assert.ok(isDenied(result), 'should deny when task ID is not found');
+  });
+
+  it('does not block Bash tools when toolName is Write/Edit (no cross-tool leakage)', () => {
+    // Even with a Bash command in tool_input, if tool_name is Write the Bash
+    // blocked-actions logic should NOT fire (only file_path enforcement applies).
+    const input = JSON.stringify({
+      tool_name: 'Write',
+      tool_input: { command: 'gh pr merge 42', file_path: join(tempDir, 'src', 'foo.ts') },
+    });
+    const result = runHookRaw(input);
+    assert.ok(!isDenied(result), 'should not apply Bash rules to Write tool');
   });
 });

--- a/ai-sdlc-plugin/hooks/subagent-start.js
+++ b/ai-sdlc-plugin/hooks/subagent-start.js
@@ -1,0 +1,123 @@
+/**
+ * AI-SDLC SubagentStart Hook
+ *
+ * Reads .ai-sdlc/agent-role.yaml from the project directory and emits
+ * governance context as additionalContext, which Claude Code injects into
+ * the spawned subagent's session.
+ *
+ * Why this exists separately from session-start.js: SessionStart hooks do NOT
+ * fire for subagents (verified in claude-code source: runAgent.ts:532-543
+ * dispatches executeSubagentStartHooks instead of processSessionStartHooks).
+ * Without this hook the developer subagent and reviewers would run with no
+ * governance context at all.
+ *
+ * Fail-safe: exits silently on any error.
+ */
+
+const { readFileSync, existsSync } = require('fs');
+const { join } = require('path');
+const { execSync } = require('child_process');
+
+// ── Read stdin ───────────────────────────────────────────────────────
+
+try {
+  readFileSync('/dev/stdin', 'utf-8');
+} catch {
+  process.exit(0);
+}
+
+// ── Find project root ────────────────────────────────────────────────
+
+const projectDir =
+  process.env.CLAUDE_PROJECT_DIR ||
+  (() => {
+    try {
+      return execSync('git rev-parse --show-toplevel', { encoding: 'utf-8' }).trim();
+    } catch {
+      return process.cwd();
+    }
+  })();
+
+// ── Load agent-role.yaml ─────────────────────────────────────────────
+
+const agentRolePath = join(projectDir, '.ai-sdlc', 'agent-role.yaml');
+if (!existsSync(agentRolePath)) {
+  process.exit(0);
+}
+
+let yaml;
+try {
+  yaml = readFileSync(agentRolePath, 'utf-8');
+} catch {
+  process.exit(0);
+}
+
+const blockedActions = parseListField(yaml, 'blockedActions');
+const blockedPaths = parseListField(yaml, 'blockedPaths');
+
+// ── Build subagent governance context ────────────────────────────────
+//
+// Subagents get a TIGHTER prompt than the main session — they don't drive
+// the lifecycle (no pre-commit checklist, no PR creation), they just do their
+// stage. The hard rules are the same.
+
+let context = `## AI-SDLC Governance (subagent context)
+
+You are running as a Claude Code subagent. The orchestrating command will
+gate your output (reviews, PR creation). Stay focused on your assigned task.
+
+### Hard rules — NEVER violate
+- **Never merge PRs** (\`gh pr merge\`)
+- **Never force-push** (\`git push --force\`/\`-f\`)
+- **Never close PRs or issues** (\`gh pr close\`, \`gh issue close\`)
+- **Never delete branches** (\`git branch -D\`/\`-d\`)
+- **Never run destructive git** (\`git reset --hard\`, \`git checkout -- .\`, \`git restore .\`)`;
+
+if (blockedPaths.length > 0) {
+  context += `\n\n### Blocked paths (PreToolUse hook enforces — no edits)
+${blockedPaths.map((p) => `- \`${p}\``).join('\n')}`;
+}
+
+if (blockedActions.length > 0) {
+  context += `\n\n### Blocked Bash actions (PreToolUse hook enforces — no execution)
+${blockedActions.map((a) => `- \`${a}\``).join('\n')}`;
+}
+
+context += `\n\n### Cross-repo writes
+If you have \`AI_SDLC_ACTIVE_TASK_ID\` set, the active task's \`permittedExternalPaths\`
+in its frontmatter allowlists writes to sibling repos. The PreToolUse hook honors
+this — writes outside your cwd that aren't in the allowlist will be denied.`;
+
+// ── Output ───────────────────────────────────────────────────────────
+
+const result = {
+  hookSpecificOutput: {
+    additionalContext: context,
+  },
+};
+
+process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+process.exit(0);
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function parseListField(yaml, field) {
+  const lines = yaml.split('\n');
+  const items = [];
+  let inSection = false;
+
+  for (const line of lines) {
+    if (new RegExp(`^\\s*${field}:\\s*$`).test(line)) {
+      inSection = true;
+      continue;
+    }
+    if (inSection) {
+      if (/^[a-zA-Z]/.test(line)) break;
+      if (/^\s*$/.test(line)) continue;
+      const match = line.match(/^\s+-\s+['"]?(.+?)['"]?\s*$/);
+      if (match) items.push(match[1]);
+    }
+  }
+
+  return items;
+}

--- a/ai-sdlc-plugin/hooks/subagent-start.sh
+++ b/ai-sdlc-plugin/hooks/subagent-start.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# AI-SDLC SubagentStart Hook
+#
+# Injects governance context into spawned subagents (developer, reviewers, etc.).
+# SessionStart does NOT fire for subagents (verified in claude-code source:
+# runAgent.ts:532-543 calls executeSubagentStartHooks, not processSessionStartHooks),
+# so this hook is the only place governance context reaches a subagent.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$SCRIPT_DIR/subagent-start.js"
+
+if [ ! -f "$SCRIPT" ]; then
+  exit 0
+fi
+
+exec node "$SCRIPT"

--- a/ai-sdlc-plugin/hooks/subagent-start.test.mjs
+++ b/ai-sdlc-plugin/hooks/subagent-start.test.mjs
@@ -1,0 +1,119 @@
+/**
+ * Tests for the AI-SDLC plugin subagent-start hook.
+ *
+ * Run with: node --test ai-sdlc-plugin/hooks/subagent-start.test.mjs
+ * Uses Node.js built-in test runner (no Vitest needed).
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const hookScript = join(__dirname, 'subagent-start.js');
+
+let tempDirWithConfig;
+let tempDirEmpty;
+
+before(() => {
+  tempDirWithConfig = join(tmpdir(), `subagent-start-config-${Date.now()}`);
+  const aiSdlcDir = join(tempDirWithConfig, '.ai-sdlc');
+  mkdirSync(aiSdlcDir, { recursive: true });
+  writeFileSync(
+    join(aiSdlcDir, 'agent-role.yaml'),
+    `role: coding-agent
+goal: Fix bugs and implement small features
+blockedPaths:
+  - '.github/workflows/**'
+  - '.ai-sdlc/**'
+blockedActions:
+  - 'gh pr merge*'
+  - 'git push --force*'
+  - 'gh pr close*'
+`,
+  );
+
+  tempDirEmpty = join(tmpdir(), `subagent-start-empty-${Date.now()}`);
+  mkdirSync(tempDirEmpty, { recursive: true });
+});
+
+after(() => {
+  rmSync(tempDirWithConfig, { recursive: true, force: true });
+  rmSync(tempDirEmpty, { recursive: true, force: true });
+});
+
+function runHook(projectDir) {
+  const input = JSON.stringify({
+    hook_event_name: 'SubagentStart',
+    agent_id: 'test-subagent-456',
+  });
+  try {
+    const output = execFileSync('node', [hookScript], {
+      input,
+      encoding: 'utf-8',
+      env: { ...process.env, CLAUDE_PROJECT_DIR: projectDir },
+      timeout: 5000,
+    });
+    return { output: output.trim(), exitCode: 0 };
+  } catch (err) {
+    return { output: err.stdout?.trim() || '', exitCode: err.status };
+  }
+}
+
+describe('ai-sdlc-plugin subagent-start hook', () => {
+  it('emits additionalContext with subagent governance when agent-role.yaml exists', () => {
+    const result = runHook(tempDirWithConfig);
+    assert.ok(result.output, 'should produce output');
+    const parsed = JSON.parse(result.output);
+    const ctx = parsed.hookSpecificOutput?.additionalContext;
+    assert.ok(ctx, 'should have additionalContext');
+    assert.ok(ctx.includes('AI-SDLC Governance (subagent context)'), 'subagent header');
+    assert.ok(ctx.includes('Never merge PRs'), 'merge hard rule');
+    assert.ok(ctx.includes('Never force-push'), 'force-push hard rule');
+    assert.ok(ctx.includes('Never close PRs or issues'), 'close hard rule');
+  });
+
+  it('lists blocked paths from agent-role.yaml', () => {
+    const result = runHook(tempDirWithConfig);
+    const parsed = JSON.parse(result.output);
+    const ctx = parsed.hookSpecificOutput?.additionalContext;
+    assert.ok(ctx.includes('.github/workflows/**'), 'workflows blocked path');
+    assert.ok(ctx.includes('.ai-sdlc/**'), 'ai-sdlc blocked path');
+  });
+
+  it('lists blocked actions from agent-role.yaml', () => {
+    const result = runHook(tempDirWithConfig);
+    const parsed = JSON.parse(result.output);
+    const ctx = parsed.hookSpecificOutput?.additionalContext;
+    assert.ok(ctx.includes('gh pr merge*'), 'merge blocked action');
+    assert.ok(ctx.includes('git push --force*'), 'force-push blocked action');
+  });
+
+  it('mentions permittedExternalPaths cross-repo allowlist', () => {
+    const result = runHook(tempDirWithConfig);
+    const parsed = JSON.parse(result.output);
+    const ctx = parsed.hookSpecificOutput?.additionalContext;
+    assert.ok(ctx.includes('permittedExternalPaths'), 'documents external-paths allowlist');
+    assert.ok(ctx.includes('AI_SDLC_ACTIVE_TASK_ID'), 'documents env var name');
+  });
+
+  it('exits silently when no agent-role.yaml exists', () => {
+    const result = runHook(tempDirEmpty);
+    assert.equal(result.output, '', 'should produce no output');
+    assert.equal(result.exitCode, 0, 'should exit code 0');
+  });
+
+  it('does NOT include the main-session pre-commit checklist (subagent-tightened prompt)', () => {
+    const result = runHook(tempDirWithConfig);
+    const parsed = JSON.parse(result.output);
+    const ctx = parsed.hookSpecificOutput?.additionalContext;
+    assert.ok(
+      !ctx.includes('Pre-Commit Checklist'),
+      'subagent should not get the lifecycle checklist',
+    );
+  });
+});

--- a/ai-sdlc-plugin/plugin.json
+++ b/ai-sdlc-plugin/plugin.json
@@ -23,6 +23,17 @@
         ]
       }
     ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/subagent-start.sh\"",
+            "statusMessage": "Injecting AI-SDLC governance into subagent..."
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",
@@ -32,6 +43,16 @@
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/enforce-blocked-actions.sh\"",
             "if": "Bash(*)",
             "statusMessage": "Checking action policy..."
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/enforce-blocked-actions.sh\"",
+            "statusMessage": "Checking write policy..."
           }
         ]
       }

--- a/backlog/tasks/aisdlc-68 - Documentation-consolidation-ai-sdlc-docs-↔-ai-sdlc-io-content.md
+++ b/backlog/tasks/aisdlc-68 - Documentation-consolidation-ai-sdlc-docs-↔-ai-sdlc-io-content.md
@@ -14,6 +14,8 @@ references:
   - /Users/dominique/Documents/dev/ai-sdlc/ai-sdlc-io/content/
   - >-
     /Users/dominique/Documents/dev/ai-sdlc/ai-sdlc/spec/rfcs/RFC-0010-parallel-execution-worktree-pooling.md
+permittedExternalPaths:
+  - '../ai-sdlc-io/'
 priority: medium
 ---
 

--- a/backlog/tasks/aisdlc-71 - Replace-orchestrator-driven-dogfood-pipeline-with-ai-sdlc-execute-plugin-command.md
+++ b/backlog/tasks/aisdlc-71 - Replace-orchestrator-driven-dogfood-pipeline-with-ai-sdlc-execute-plugin-command.md
@@ -1,0 +1,98 @@
+---
+id: AISDLC-71
+title: >-
+  Replace orchestrator-driven dogfood pipeline with /ai-sdlc execute plugin
+  command
+status: In Progress
+assignee: []
+created_date: '2026-04-27 21:57'
+updated_date: '2026-04-27 21:58'
+labels:
+  - plugin
+  - dogfood
+  - architecture
+  - refactor
+dependencies: []
+references:
+  - spec/rfcs/RFC-0010-parallel-execution-worktree-pooling.md
+  - .ai-sdlc/pipeline-backlog.yaml
+  - .ai-sdlc/agent-role.yaml
+  - ai-sdlc-plugin/agents/code-reviewer.md
+  - ai-sdlc-plugin/agents/test-reviewer.md
+  - ai-sdlc-plugin/agents/security-reviewer.md
+  - ai-sdlc-plugin/commands/triage.md
+  - ai-sdlc-plugin/commands/review.md
+  - ai-sdlc-plugin/hooks/enforce-blocked-actions.sh
+  - ai-sdlc-plugin/plugin.json
+  - >-
+    /Users/dominique/Documents/dev/ai-sdlc/claude-code/src/tools/AgentTool/runAgent.ts
+  - .github/workflows/backlog-task-complete.yml
+  - CLAUDE.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Context
+
+The current dogfood pipeline runs the orchestrator (TypeScript Node service) as a subprocess from inside a Claude Code session. The orchestrator re-implements session/auth/cwd/tool-gating that Claude Code already provides natively. The past 24h shipped 5 PRs (#69-74) patching surface bugs in this layer (untracked-file sweep, branch-side-effects, validate-output guardrail blindness, cross-repo wandering, branch template propagation, unicode pathspec, staged-diff invisibility). Each layer of duplication produces the same class of bug at a different surface.
+
+This task replaces the dogfood path with a Claude Code plugin command (`/ai-sdlc execute <task-id>`) that drives subagents per stage. The orchestrator stays in the repo for the GitHub-issue / programmatic / CI path — just isn't called for backlog tasks anymore.
+
+## Architecture (locked-in design — see plan in commit history / chat transcript)
+
+- **`/ai-sdlc execute <task-id>`**: slash command, one task per invocation. Composes with `/loop` for batch.
+- **Hybrid orchestration**: command body drives stages; developer runs as subagent (context isolation); reviewers run as 3 parallel `Agent` calls in main thread.
+- **Worktree isolation**: `git worktree add .worktrees/<task-id>/` per run; auto-removed on next `/ai-sdlc execute` invocation if the branch's PR has merged; standalone `/ai-sdlc cleanup` companion command for ad-hoc.
+- **Cross-repo writes**: `permittedExternalPaths` field in task frontmatter explicitly allowlists sibling-repo write targets; PreToolUse hook enforces. After main PR opens, command auto-creates parallel branches/PRs in any dirty sibling repos.
+- **Validation guardrails**: extended PreToolUse hook on Write/Edit (not just Bash) that blocks writes to `.ai-sdlc/**`, `.github/workflows/**` per `agent-role.yaml`, honoring `permittedExternalPaths` for the active task.
+- **Governance for subagents**: SubagentStart hook in plugin.json (NOT SessionStart — confirmed via claude-code source: SessionStart does not fire for subagents) injects governance context.
+- **Task lifecycle**: command flips status to `In Progress` at start. After reviews approve, before PR push, command flips status to `Done` + runs `task_complete` (file moves `tasks/` → `completed/`) + commits the move as `chore: mark <id> complete`. The whole task lifecycle lands in the same PR.
+- **Review iteration**: cap at 2 dev iterations on review failure. After cap, auto-open PR with `[needs-human-attention]` flag and full review verdicts in body.
+- **Reviewer harness fallback**: when Codex unavailable, fall back to claude-code with a visible `INDEPENDENCE NOT ENFORCED` warning per verdict (per RFC-0010 §13.13 v13).
+- **Progress visibility**: developer agent emits `[ai-sdlc-progress] <stage>: <one-line status>` per major stage; main session surfaces these as they appear.
+- **Cost**: subscription-only; no shadow-cost tracking.
+
+## Files to create / modify
+
+**New**
+- `ai-sdlc-plugin/commands/execute.md` — the slash command body (orchestrates the full flow per the design)
+- `ai-sdlc-plugin/commands/cleanup.md` — companion command for ad-hoc worktree cleanup
+- `ai-sdlc-plugin/agents/developer.md` — dev subagent definition (frontmatter + system prompt; mirrors reviewer agent shape)
+- `ai-sdlc-plugin/hooks/subagent-start.sh` — governance injector for subagents
+- `ai-sdlc-plugin/commands/execute.test.mjs`, `cleanup.test.mjs`, `agents/developer.test.mjs` row in `agents.test.mjs`
+- `ai-sdlc-plugin/hooks/subagent-start.test.mjs`
+
+**Modify**
+- `ai-sdlc-plugin/hooks/enforce-blocked-actions.{sh,js}` — extend matcher from Bash-only to also handle Write and Edit tool inputs against blocked-paths from `agent-role.yaml`; honor `permittedExternalPaths` from active task frontmatter via `AI_SDLC_ACTIVE_TASK_ID` env var
+- `ai-sdlc-plugin/hooks/enforce-blocked-actions.test.mjs` — add cases for Write/Edit blocked-path enforcement and external-path allowlist
+- `ai-sdlc-plugin/plugin.json` — register SubagentStart hook + extend PreToolUse matcher to `Bash|Write|Edit`
+- `CLAUDE.md` — add "Backlog dogfood loop" section documenting `/ai-sdlc execute <task-id>` as canonical local path; clarify Done = "reviews-approved-and-PR-opened"; document `permittedExternalPaths` task frontmatter convention; note `cli-watch` remains for unattended/CI use
+- `.github/workflows/backlog-task-complete.yml` — make it idempotent (no-op when task file already in `completed/`) so it stays useful as fallback for non-`/ai-sdlc execute` PRs
+- `backlog/tasks/aisdlc-68 - *.md` (or its successor) — add `permittedExternalPaths: ['../ai-sdlc-io/']` as the dogfood test case
+
+**No edits to** `orchestrator/src/`. The command is fully decoupled at runtime.
+
+## Dogfood verification
+
+The acceptance criterion isn't "tests pass" — it's "we used `/ai-sdlc execute AISDLC-68` (or successor) and it shipped a clean PR end-to-end." Until that happens, this task isn't done.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `/ai-sdlc execute <task-id>` slash command exists, validates task shape (status, ACs), creates `.worktrees/<task-id>/`, flips task to `In Progress`, invokes developer subagent, runs 3 parallel reviewer subagents, gates on findings (auto-open if approved, AskUserQuestion if critical/major after 2 iterations), marks task Done + commits the file move, opens PR via `gh pr create`
+- [ ] #2 Developer subagent (`ai-sdlc-plugin/agents/developer.md`) defined with proper frontmatter (allowed-tools, disallowed-tools), embedded hard rules (never merge, never force-push, never edit blocked paths), and emits `[ai-sdlc-progress]` lines per major stage
+- [ ] #3 PreToolUse hook extended to fire on Write and Edit (not only Bash); blocks writes to paths matching `agent-role.yaml` blockedPaths unless path falls under `permittedExternalPaths` in the active task's frontmatter; covered by tests for both block and allowlist paths
+- [ ] #4 SubagentStart hook in `plugin.json` injects governance context for any spawned subagent (verified by reading claude-code source: SessionStart does not fire for subagents)
+- [ ] #5 Cross-repo PR creation: after main PR opens, command iterates sibling git repos under `permittedExternalPaths`, creates a parallel branch + PR per dirty sibling with linked title (`<task-title> — sibling for <id>`), prints both PR URLs at end
+- [ ] #6 Worktree cleanup: at `/ai-sdlc execute` start, sweeps `.worktrees/` and removes any whose branch's PR has merged on `main`; standalone `/ai-sdlc cleanup [<task-id>]` command exists for explicit cleanup
+- [ ] #7 Reviewer harness fallback: when Codex unavailable, reviews fall back to claude-code with visible `INDEPENDENCE NOT ENFORCED (codex unavailable)` warning per verdict; aggregated review summary surfaces the warning prominently
+- [ ] #8 Review iteration cap: dev runs at most 2 iterations on review failure; after cap, command auto-opens PR with `[needs-human-attention]` in body and all review verdicts (collapsed) without aborting the work
+- [ ] #9 Done-on-PR-open lifecycle: command runs `mcp__backlog__task_edit Done + acceptanceCriteriaCheck + finalSummary` and `mcp__backlog__task_complete` (file moves to `completed/`), commits the move as `chore: mark <id> complete`, then pushes — all in the same PR
+- [ ] #10 `.github/workflows/backlog-task-complete.yml` made idempotent (no-op when file already in `completed/`)
+- [ ] #11 CLAUDE.md updated: documents `/ai-sdlc execute` as canonical local execution path, defines Done as `reviews-approved-and-PR-opened`, documents `permittedExternalPaths` frontmatter convention, retains `cli-watch` reference for unattended/CI path
+- [ ] #12 Dogfood verification: `/ai-sdlc execute AISDLC-68` (or replacement task) successfully ships an end-to-end PR with no manual intervention beyond review-gate decisions; cite the PR URL in finalSummary
+- [ ] #13 No imports of `@ai-sdlc/orchestrator` from any new plugin file; command is fully decoupled at runtime
+- [ ] #14 All new code: 80%+ patch coverage, `pnpm build && pnpm test && pnpm lint && pnpm format:check` clean
+<!-- AC:END -->

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,7 @@ export default tseslint.config(
       '.claude/hooks/',
       'ai-sdlc-plugin/hooks/',
       'ai-sdlc-plugin/agents/',
+      'ai-sdlc-plugin/commands/',
       '**/coverage/',
     ],
   },


### PR DESCRIPTION
## Summary

Replaces the orchestrator-driven dogfood pipeline with a Claude Code plugin command that runs entirely as in-session subagents. Resolves the surface-bug class from PRs #69-74 by deleting the layer that produced them.

The orchestrator stays in the repo for the GitHub-issue / programmatic / CI path; this command supersedes it for backlog (AISDLC-*) tasks shipped from a Claude Code session.

## What's new

### `/ai-sdlc execute <task-id>` (commands/execute.md)
Full pipeline as one slash command:
- Sweep merged worktrees (auto-cleanup)
- Validate task shape (status, ACs, references)
- Compute branch from `pipeline-backlog.yaml` template
- `git worktree add .worktrees/<id-lower>` (kills the HEAD-restoration bug class)
- Flip task to `In Progress`
- Spawn `developer` subagent with `AI_SDLC_ACTIVE_TASK_ID` exported (PreToolUse hook honors it)
- 3 parallel reviewer subagents (code/test/security)
- Codex-fallback handling: visible "INDEPENDENCE NOT ENFORCED" warning when codex unavailable
- Iteration loop capped at 2 rounds; after cap, opens PR with `[needs-human-attention]` rather than aborting
- Mark Done + `task_complete` (file moves to `completed/`) + chore commit BEFORE push — entire task lifecycle in one PR
- `gh pr create` for main repo
- Auto-create parallel sibling PRs in any dirty repos under `permittedExternalPaths`
- Never runs `gh pr merge` / `git push --force` (CLAUDE.md governance)

### `/ai-sdlc cleanup [<task-id>]` (commands/cleanup.md)
Companion: sweep merged worktrees (no args) or force-remove a specific one. Never deletes branches automatically.

### `agents/developer.md`
New developer subagent with embedded hard-rules + `[ai-sdlc-progress]` line convention for stage visibility.

### `hooks/subagent-start.{sh,js}`
SessionStart does not fire for subagents (verified in claude-code source: `runAgent.ts:532-543` dispatches `executeSubagentStartHooks` instead). New SubagentStart hook injects governance into every spawned subagent.

### `hooks/enforce-blocked-actions.js` extension
Now handles `Write` and `Edit` (not just `Bash`):
- `file_path` matched against `agent-role.yaml` `blockedPaths` globs (relative to project root)
- Paths outside the project root denied unless under task frontmatter `permittedExternalPaths` (resolved via `AI_SDLC_ACTIVE_TASK_ID` env var)
- `plugin.json` extends PreToolUse matcher to `Bash|Write|Edit`

### CLAUDE.md
- Canonical-execution-paths table (when to use `/ai-sdlc execute` vs `cli-watch`)
- Done semantics: `/ai-sdlc execute` flips Done before PR push (atomic with implementation); other paths still flip Done post-merge
- `permittedExternalPaths` frontmatter convention documented

## Files

**New** (4 plugin files + 4 tests):
- `ai-sdlc-plugin/commands/execute.md` + `execute.test.mjs`
- `ai-sdlc-plugin/commands/cleanup.md` + `cleanup.test.mjs`
- `ai-sdlc-plugin/agents/developer.md`
- `ai-sdlc-plugin/hooks/subagent-start.{sh,js}` + `subagent-start.test.mjs`

**Modified**:
- `ai-sdlc-plugin/hooks/enforce-blocked-actions.js` — Write/Edit + permittedExternalPaths
- `ai-sdlc-plugin/hooks/enforce-blocked-actions.test.mjs` — +12 tests for new behavior
- `ai-sdlc-plugin/agents/agents.test.mjs` — +4 tests for developer agent
- `ai-sdlc-plugin/plugin.json` — register SubagentStart + extend PreToolUse to Write|Edit
- `CLAUDE.md` — execution paths, Done semantics, permittedExternalPaths
- `.github/workflows/backlog-task-complete.yml` — comment documenting existing idempotency
- `eslint.config.mjs` — ignore `ai-sdlc-plugin/commands/` (consistent with hooks/agents)
- `backlog/tasks/aisdlc-68 - *.md` — flipped back to To Do, added `permittedExternalPaths: ['../ai-sdlc-io/']` for the dogfood test

**No edits to** `orchestrator/src/`. The command is fully decoupled at runtime.

## Test plan

- [x] `node --test ai-sdlc-plugin/{commands,hooks,agents}/*.test.mjs` — 105/105 pass
- [x] `pnpm test` (full workspace) — 4500+ tests, all green across 8 packages
- [x] `pnpm build && pnpm lint && pnpm format:check` — clean
- [ ] **Dogfood verification (after merge)**: run `/ai-sdlc execute AISDLC-68` and confirm it ships an end-to-end PR. AC #12 of AISDLC-71 is gated on this.

## Acceptance criteria coverage (AISDLC-71)

ACs #1-11 + #13-14 implemented and tested in this PR. AC #12 (dogfood verification) waits until this PR merges so the plugin command is discoverable. AISDLC-71 stays In Progress until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)