### PR TITLE
fix(plugin): active-task sentinel file (env vars don't propagate mid-session)

### DIFF
--- a/ai-sdlc-plugin/commands/cleanup.md
+++ b/ai-sdlc-plugin/commands/cleanup.md
@@ -10,9 +10,13 @@ Companion to `/ai-sdlc execute`. Two modes:
 
 ## Mode 1 — Sweep all merged worktrees (no arguments)
 
-When `$ARGUMENTS` is empty, do exactly what `/ai-sdlc execute` does at start: walk `.worktrees/`, check each branch's PR status via `gh pr list`, remove any whose PR has merged.
+When `$ARGUMENTS` is empty, do exactly what `/ai-sdlc execute` does at start: walk `.worktrees/`, check each branch's PR status via `gh pr list`, remove any whose PR has merged. Also remove a stale `.worktrees/.active-task` sentinel (an `/ai-sdlc execute` run that aborted without cleanup leaves it behind, which would block cross-repo writes for the next non-execute Edit/Write).
 
 ```bash
+# Clear stale sentinel — safe even if no run is in flight, since /ai-sdlc execute
+# rewrites it at start of every invocation.
+rm -f .worktrees/.active-task
+
 if [ ! -d .worktrees ]; then
   echo "No .worktrees/ directory — nothing to sweep."
   exit 0

--- a/ai-sdlc-plugin/commands/cleanup.test.mjs
+++ b/ai-sdlc-plugin/commands/cleanup.test.mjs
@@ -76,4 +76,8 @@ describe('/ai-sdlc cleanup body contract', () => {
   it('handles missing .worktrees/ directory gracefully', () => {
     assert.match(body, /No \.worktrees\/ directory/);
   });
+
+  it('removes the .active-task sentinel during sweep (defensive cleanup)', () => {
+    assert.match(body, /rm -f \.worktrees\/\.active-task/);
+  });
 });

--- a/ai-sdlc-plugin/commands/execute.md
+++ b/ai-sdlc-plugin/commands/execute.md
@@ -74,9 +74,20 @@ git worktree add "$WORKTREE_PATH" -b "$BRANCH" origin/main
 
 If `git worktree add` fails because the branch already exists, the operator's prior run left state. Tell them: "Worktree branch `$BRANCH` already exists. Run `/ai-sdlc cleanup $TASK_ID` first, or pick a different task." Then stop.
 
-## Step 4 — Flip task to In Progress
+## Step 4 — Flip task to In Progress + write active-task sentinel
 
 Use `mcp__backlog__task_edit` to set `status: 'In Progress'`. This makes the dashboard reflect that work has started.
+
+Then write the active-task sentinel file so the PreToolUse hook can resolve `permittedExternalPaths` for cross-repo writes:
+
+```bash
+mkdir -p .worktrees
+echo "$TASK_ID" > .worktrees/.active-task
+```
+
+The sentinel is the canonical source of truth for "which task is currently active in this session." The hook reads it on every Write/Edit; without it, cross-repo writes are denied. CRITICAL: this file MUST be deleted at end of run (Step 13) regardless of success/failure, otherwise the next `/ai-sdlc execute` invocation inherits the stale active task. Treat it as a try/finally — if anything fails between here and Step 13, still delete.
+
+> **Single-task limitation**: only one `/ai-sdlc execute` may run at a time. Parallel runs would race on the sentinel. v2 may add per-worktree sentinels.
 
 ## Step 5 — Invoke the developer subagent
 
@@ -122,8 +133,8 @@ Return the JSON shape documented in your agent definition.
 When invoking the Task tool for the developer agent:
 
 - `subagent_type: developer`
-- Set `AI_SDLC_ACTIVE_TASK_ID=$TASK_ID` in the environment so the PreToolUse hook honors `permittedExternalPaths` from the task frontmatter
 - The agent's cwd will be the worktree path
+- The PreToolUse hook will read the active task ID from `.worktrees/.active-task` (written in Step 4) to resolve `permittedExternalPaths` for cross-repo writes
 
 Watch for `[ai-sdlc-progress]` lines in the agent's tool output and surface them to the user as they appear.
 
@@ -324,9 +335,17 @@ If any sibling PR creation fails partway, do NOT roll back the main PR — print
 After all siblings:
 - Update the main PR body via `gh pr edit $MAIN_PR_URL --body "..."` to add a `## Sibling PRs` section listing each sibling URL.
 
-## Step 13 — Report
+## Step 13 — Cleanup sentinel + Report
 
-Print a tight summary:
+Always remove the active-task sentinel — the hook would otherwise see a stale active task on the next invocation:
+
+```bash
+rm -f .worktrees/.active-task
+```
+
+Run this whether the run succeeded, failed, was rolled back, or escalated. It's the closing bracket of the implicit try/finally started at Step 4.
+
+Then print a tight summary:
 
 - ✅ Task: `$TASK_ID` — `<title>`
 - ✅ Branch: `$BRANCH` (worktree at `$WORKTREE_PATH`)

--- a/ai-sdlc-plugin/commands/execute.test.mjs
+++ b/ai-sdlc-plugin/commands/execute.test.mjs
@@ -78,8 +78,11 @@ describe('/ai-sdlc execute body contract', () => {
     assert.match(body, /subagent_type:\s*developer/i);
   });
 
-  it('exports AI_SDLC_ACTIVE_TASK_ID for the developer (PreToolUse hook reads it)', () => {
-    assert.match(body, /AI_SDLC_ACTIVE_TASK_ID/);
+  it('PreToolUse hook resolves the active task via .worktrees/.active-task sentinel', () => {
+    // env-var approach was abandoned because mid-session env mutations don't
+    // propagate to the hook subprocess; the sentinel file is the canonical
+    // signal now (see Step 4).
+    assert.match(body, /\.worktrees\/\.active-task/);
   });
 
   it('runs all three reviewers in parallel (code, test, security)', () => {
@@ -146,6 +149,22 @@ describe('/ai-sdlc execute body contract', () => {
   it('cross-links sibling PRs back into the main PR body', () => {
     assert.match(body, /Sibling PRs/);
     assert.match(body, /gh pr edit/);
+  });
+
+  it('writes the .worktrees/.active-task sentinel at Step 4', () => {
+    // The PreToolUse hook reads this sentinel — env vars don't propagate
+    // mid-session, so the sentinel file is the canonical active-task signal.
+    assert.match(body, /\.worktrees\/\.active-task/);
+    assert.match(body, /echo "\$TASK_ID" > \.worktrees\/\.active-task/);
+  });
+
+  it('cleans up the sentinel at end of run regardless of outcome', () => {
+    assert.match(body, /rm -f \.worktrees\/\.active-task/);
+    assert.match(body, /whether the run succeeded, failed, was rolled back, or escalated/i);
+  });
+
+  it('documents the single-task limitation', () => {
+    assert.match(body, /Single-task limitation/);
   });
 
   it('opens a PR via gh pr create', () => {

--- a/ai-sdlc-plugin/hooks/enforce-blocked-actions.js
+++ b/ai-sdlc-plugin/hooks/enforce-blocked-actions.js
@@ -170,6 +170,24 @@ function parseListField(yaml, field) {
 }
 
 /**
+ * Read the active task ID. Prefers the sentinel file `.worktrees/.active-task`
+ * (written by `/ai-sdlc execute`); falls back to `AI_SDLC_ACTIVE_TASK_ID` env
+ * var so the hook stays testable from a normal shell.
+ */
+function readActiveTaskId(projectAbs) {
+  const sentinelPath = join(projectAbs, '.worktrees', '.active-task');
+  if (existsSync(sentinelPath)) {
+    try {
+      const id = readFileSync(sentinelPath, 'utf-8').trim();
+      if (id) return id;
+    } catch {
+      // fall through to env var
+    }
+  }
+  return process.env.AI_SDLC_ACTIVE_TASK_ID || null;
+}
+
+/**
  * Convert a glob like `.ai-sdlc/**` or `.github/workflows/*.yml` to a regex.
  * - `**` matches any sequence including `/`
  * - `*` matches any sequence except `/`
@@ -194,11 +212,18 @@ function matchGlob(glob, path) {
 
 /**
  * Load permittedExternalPaths from the active task's frontmatter.
- * Active task is identified by AI_SDLC_ACTIVE_TASK_ID env var (e.g. AISDLC-68).
- * Returns [] when no env var, no matching task file, or no frontmatter field.
+ *
+ * Active task is identified by reading `.worktrees/.active-task` (a sentinel
+ * file written by `/ai-sdlc execute` at start, deleted at end). The env-var
+ * approach (AI_SDLC_ACTIVE_TASK_ID) does not work mid-session — the hook runs
+ * in a fresh subprocess of the Claude Code parent, which can't have its env
+ * mutated from a slash command. The env var is still honored as a fallback so
+ * users can invoke the hook in tests / external tooling.
+ *
+ * Returns [] when no active task, no matching task file, or no frontmatter field.
  */
 function loadPermittedExternalPaths(projectAbs) {
-  const taskId = process.env.AI_SDLC_ACTIVE_TASK_ID;
+  const taskId = readActiveTaskId(projectAbs);
   if (!taskId) return [];
 
   const tasksDir = join(projectAbs, 'backlog', 'tasks');

--- a/ai-sdlc-plugin/hooks/enforce-blocked-actions.test.mjs
+++ b/ai-sdlc-plugin/hooks/enforce-blocked-actions.test.mjs
@@ -240,6 +240,60 @@ describe('ai-sdlc-plugin enforce-blocked-actions hook (Write/Edit)', () => {
     assert.ok(isDenied(result), 'should deny when task ID is not found');
   });
 
+  it('reads active task from .worktrees/.active-task sentinel file (preferred over env)', () => {
+    // Slash command writes this sentinel at start of /ai-sdlc execute.
+    // The env-var path is a fallback; the file is the canonical source of truth.
+    const sentinelDir = join(tempDir, '.worktrees');
+    const sentinelPath = join(sentinelDir, '.active-task');
+    mkdirSync(sentinelDir, { recursive: true });
+    writeFileSync(sentinelPath, 'AISDLC-99\n');
+    try {
+      const result = runHookFile('Write', join(siblingDir, 'allowed.txt'));
+      assert.ok(!isDenied(result), 'should allow when sentinel file points at AISDLC-99');
+    } finally {
+      rmSync(sentinelPath, { force: true });
+      rmSync(sentinelDir, { recursive: true, force: true });
+    }
+  });
+
+  it('sentinel file takes precedence over env var when both set', () => {
+    const sentinelDir = join(tempDir, '.worktrees');
+    const sentinelPath = join(sentinelDir, '.active-task');
+    mkdirSync(sentinelDir, { recursive: true });
+    writeFileSync(sentinelPath, 'AISDLC-99\n');
+    try {
+      // env var points at a non-existent task; sentinel points at the real one
+      const result = runHookFile('Write', join(siblingDir, 'allowed.txt'), {
+        AI_SDLC_ACTIVE_TASK_ID: 'AISDLC-9999',
+      });
+      assert.ok(!isDenied(result), 'sentinel wins over env var');
+    } finally {
+      rmSync(sentinelPath, { force: true });
+      rmSync(sentinelDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to env var when sentinel file is missing', () => {
+    const result = runHookFile('Write', join(siblingDir, 'allowed.txt'), {
+      AI_SDLC_ACTIVE_TASK_ID: 'AISDLC-99',
+    });
+    assert.ok(!isDenied(result), 'env var fallback works for tests / external tooling');
+  });
+
+  it('handles empty sentinel file gracefully (treats as no active task)', () => {
+    const sentinelDir = join(tempDir, '.worktrees');
+    const sentinelPath = join(sentinelDir, '.active-task');
+    mkdirSync(sentinelDir, { recursive: true });
+    writeFileSync(sentinelPath, '');
+    try {
+      const result = runHookFile('Write', join(siblingDir, 'foo.txt'));
+      assert.ok(isDenied(result), 'empty sentinel = no allowlist = deny');
+    } finally {
+      rmSync(sentinelPath, { force: true });
+      rmSync(sentinelDir, { recursive: true, force: true });
+    }
+  });
+
   it('does not block Bash tools when toolName is Write/Edit (no cross-tool leakage)', () => {
     // Even with a Bash command in tool_input, if tool_name is Write the Bash
     // blocked-actions logic should NOT fire (only file_path enforcement applies).


### PR DESCRIPTION
## Summary

Replaces the broken env-var approach (`AI_SDLC_ACTIVE_TASK_ID`) with a file-based sentinel. Surfaced during AISDLC-68 dogfood test — cross-repo writes were silently denied because the env var never reached the hook.

## Why the env var didn't work

Each Bash invocation from a Claude Code session spawns a fresh shell. The PreToolUse hook runs as a subprocess of the Claude Code parent process. Neither inherits env mutations made by other tool calls during the session — so `export AI_SDLC_ACTIVE_TASK_ID=AISDLC-68` in one shell was invisible to the hook in the next.

## Fix

- `/ai-sdlc execute` writes `.worktrees/.active-task` (containing the task ID) at Step 4
- Hook reads the file on every Write/Edit; falls back to env var for external tooling/tests
- `/ai-sdlc execute` deletes the sentinel at Step 13 regardless of outcome (success / failure / escalation)
- `/ai-sdlc cleanup` also removes a stale sentinel defensively (so an aborted run doesn't poison the next plain Edit)

## Limitations

Single-task-at-a-time. Parallel `/ai-sdlc execute` would race the sentinel; documented. v2 could add per-worktree sentinels for parallel support.

## Test plan

- [x] 113/113 plugin tests pass (was 105 → +4 sentinel tests + 3 command-body tests + 1 cleanup test)
- [x] `pnpm test` (full workspace) green
- [x] `pnpm lint && pnpm format:check` clean
- [ ] Re-run `/ai-sdlc execute AISDLC-68` end-to-end after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)