### PR TITLE
chore: bootstrap trusted reviewer — add maintainer signing key

### DIFF
--- a/.ai-sdlc/trusted-reviewers.yaml
+++ b/.ai-sdlc/trusted-reviewers.yaml
@@ -37,4 +37,12 @@
 # match. If you need a richer YAML feature, add a real YAML lib to the
 # verify-attestation workflow's install step first.
 
-reviewers: []
+reviewers:
+  - identity: 'dominique@reliablegenius.io'
+    machine: 'doms-macbook'
+    addedAt: '2026-04-28'
+    addedBy: 'deefactorial'
+    pubkey: |
+      -----BEGIN PUBLIC KEY-----
+      MCowBQYDK2VwAyEA7RfNqQjnRnt7dG0gjIWIkqyfvn+/aMycmbaEbq7lS7E=
+      -----END PUBLIC KEY-----


### PR DESCRIPTION
## Summary

First entry in `.ai-sdlc/trusted-reviewers.yaml`. Bootstrap step for the AISDLC-74 review attestation system that just merged.

## Why this PR exists

`.ai-sdlc/trusted-reviewers.yaml` shipped with `reviewers: []` — by design, a chicken-and-egg state. Until at least one pubkey lives there, every `/ai-sdlc execute` attestation gets correctly marked `invalid (signature did not match any trusted reviewer pubkey)` and CI runs its own duplicate review (the safe fallback path, which is what's been happening).

This PR adds my pubkey. After merge, the next `/ai-sdlc execute` produces an attestation CI accepts and skips the duplicate review.

## What's in the diff

A single 9-line YAML block following the documented format (single-quoted scalars, `pubkey:` as `|` block scalar with 6-space indent — matches what `verify-attestation.mjs`'s hand-rolled parser expects):

```yaml
  - identity: 'dominique@reliablegenius.io'
    machine: 'doms-macbook'
    addedAt: '2026-04-28'
    addedBy: 'deefactorial'
    pubkey: |
      -----BEGIN PUBLIC KEY-----
      MCowBQYDK2VwAyEA7RfNqQjnRnt7dG0gjIWIkqyfvn+/aMycmbaEbq7lS7E=
      -----END PUBLIC KEY-----
```

Pubkey generated via `/ai-sdlc init-signing-key` on doms-macbook. Matching ed25519 private key lives at `~/.ai-sdlc/signing-key.pem` (mode 0600), never leaves the machine, never committed.

## Test plan

- [x] Generated key locally; format matches the parser's strict requirements
- [ ] CI build & test pass (no logic changed — just an entry added to a config file)
- [ ] After merge, run `/ai-sdlc execute <next-task>` and confirm `verify-attestation` workflow sets `ai-sdlc/attestation: valid` instead of `invalid`
- [ ] Confirm `Post Review Results` workflow short-circuits cleanly with the notice instead of running its own review

🤖 Generated with [Claude Code](https://claude.com/claude-code)