### PR TITLE
chore: bump ai-sdlc plugin to v0.7.1 (release AISDLC-75 mcp-server bundle)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "ai-sdlc",
       "source": "./ai-sdlc-plugin",
       "description": "AI-SDLC governance framework for Claude Code — action enforcement, telemetry, quality gates, review agents, and MCP tools",
-      "version": "0.7.0"
+      "version": "0.7.1"
     }
   ]
 }

--- a/ai-sdlc-plugin/.claude-plugin/plugin.json
+++ b/ai-sdlc-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdlc",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "AI-SDLC governance framework for Claude Code — action enforcement, telemetry, quality gates, and review agents",
   "author": {
     "name": "AI-SDLC Framework",

--- a/ai-sdlc-plugin/mcp-server/package.json
+++ b/ai-sdlc-plugin/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-sdlc/plugin-mcp-server",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "MCP server for the AI-SDLC Claude Code plugin — governance tools for Claude",
   "license": "Apache-2.0",
   "repository": {

--- a/ai-sdlc-plugin/plugin.json
+++ b/ai-sdlc-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdlc",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "AI-SDLC governance framework for Claude Code — action enforcement, telemetry, quality gates, and review agents",
   "author": {
     "name": "AI-SDLC Framework",


### PR DESCRIPTION
## Summary

Bumps the ai-sdlc plugin from `0.7.0` → `0.7.1` across the four manifests that the marketplace reads, so caching contributors actually receive the AISDLC-75 mcp-server bundle fix.

## Why

The plugin marketplace caches installs by version. Without bumping, users on cached `v0.7.0` continue to get the broken pre-bundle install reported in AISDLC-75 (mcp-server `dist/` and `node_modules/` missing → all governance hooks silently fail). The bundle is on `main` but the plugin still claims version 0.7.0; cache stays stale.

## Changes (4-line diff)

- `ai-sdlc-plugin/plugin.json`: `0.7.0` → `0.7.1`
- `ai-sdlc-plugin/.claude-plugin/plugin.json`: `0.7.0` → `0.7.1`
- `.claude-plugin/marketplace.json`: `0.7.0` → `0.7.1`
- `ai-sdlc-plugin/mcp-server/package.json`: `0.7.0` → `0.7.1`

All four files must move together — the marketplace reads marketplace.json + plugin.json, the plugin loader reads .claude-plugin/plugin.json, the mcp-server's own package metadata is referenced by tooling.

## Post-merge expected behavior

1. Marketplace sees new version, invalidates cache for ai-sdlc plugin
2. Re-fetches source tree at the latest main
3. Picks up the committed `ai-sdlc-plugin/mcp-server/dist/bin.js` bundle from PR #82
4. SessionStart, PreToolUse, PostToolUse hooks + `/ai-sdlc:*` MCP tools start working again on cached installs

## Follow-up — AISDLC-77 (filed separately)

This bump is manual today because `ai-sdlc-plugin` isn't tracked by release-please (only `reference`, `orchestrator`, `sdk-typescript`, `mcp-advisor`, `conformance/runner` are). AISDLC-77 adds release-please tracking with `extra-files` config so future merges of `fix:`/`feat:` commits touching the plugin auto-bump the version across all 4 files.

## Test plan

- [x] All 4 files now show `0.7.1`
- [x] No other workspace packages affected (4-line diff)
- [x] `pnpm build && pnpm test` clean (verified locally — 4575/4575)
- [ ] CI Build & Test pass on this PR
- [ ] After merge, `/reload-plugins` (or restart) on a cached install picks up the bundle (`/ai-sdlc:status` returns real data, not skill text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)