### PR TITLE
fix(ci): support GitHub merge queue (merge_group event)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/merge-queue-passthrough.yml
+++ b/.github/workflows/merge-queue-passthrough.yml
@@ -1,0 +1,29 @@
+name: Merge Queue Passthrough
+
+# Required-status-check passthrough for the GitHub merge queue.
+#
+# When a PR is added to the merge queue, GitHub creates a temporary merge
+# commit on a `gh-readonly-queue/<branch>/...` ref and fires `merge_group:`
+# events. The merge queue won't merge until every required status check
+# reports SUCCESS on that merge commit.
+#
+# `ci.yml` triggers on `merge_group` and produces the `CI OK` check.
+# `ai-sdlc-review.yml` does NOT (it heavily uses `github.event.pull_request.*`
+# fields which are null on merge_group). To unblock the queue without
+# refactoring that workflow, this file emits the `Post Review Results`
+# check name on merge_group as a passthrough.
+#
+# Justification: review already ran on the PR head before the queue accepted
+# it. Re-running the LLM review on the merge commit would be wasteful and
+# probabilistic. The merge commit's content is `PR head + main` — the only
+# new code is the merge resolution (handled by ci.yml's lint/build/test).
+
+on:
+  merge_group:
+
+jobs:
+  post-review:
+    name: Post Review Results
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "merge_group passthrough — review already ran on PR head"


### PR DESCRIPTION
## Why

PR #88 is currently stuck in the merge queue at `AWAITING_CHECKS` indefinitely. Root cause: no workflow triggers on `merge_group:`, so the required status checks (`CI OK`, `Post Review Results`, `codecov/patch`) never run on the queue's temporary merge commit.

## Changes

1. **`ci.yml`**: add `merge_group:` to triggers. `CI OK` will run and report success on merge commits. Other jobs are event-agnostic; `integration-tests` skips (its `if:` clause excludes merge_group), which `CI OK` correctly handles (skipped + success pass; only failure/cancelled fail).

2. **NEW `merge-queue-passthrough.yml`**: emits the `Post Review Results` check name on merge_group as a passthrough. `ai-sdlc-review.yml` can't add merge_group support directly because its analyze job uses `github.event.pull_request.*` fields (body, base.sha, head.sha, number) which are null on merge_group. Review already ran on the PR head before the queue accepted it — re-running the LLM review on the merge commit would be wasteful and probabilistic.

The third required check (`codecov/patch`) is set by the codecov bot and should fire on the merge commit naturally.

## To unblock PR #88

This PR itself can't go through the merge queue (chicken-and-egg). Options:

1. **Bypass-merge this PR** as admin (you're in `bypass_pull_request_allowances`) → after it lands, #88 and all future PRs queue cleanly
2. **Temporarily drop the 3 required checks from queue requirements**, merge this PR + #88 + #89, re-add the checks

Recommend option 1 — single bypass click on this small change.

## Verification

After this PR merges:
- Add any small PR to merge queue → `CI OK` and `Post Review Results` should fire on the merge_group commit and report success
- `ai-sdlc/attestation` will be missing on the merge commit but it's not required for queue
- `codecov/patch` should fire automatically via codecov bot

References AISDLC-81 follow-up (parallel-runs unblock surfaced this gap)