### PR TITLE
chore(ci): auto-enable auto-merge on every new PR (rebase strategy)

### DIFF
--- a/.github/workflows/auto-enable-auto-merge.yml
+++ b/.github/workflows/auto-enable-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Auto-enable auto-merge on PR open
+
+# Enables GitHub's auto-merge on every new PR from a branch in this repo,
+# using rebase strategy. Once required checks pass and required reviews
+# are satisfied, GitHub merges the PR automatically — no human click needed.
+#
+# Why a workflow (vs the per-PR button): the repo-level "Allow auto-merge"
+# setting just enables the BUTTON. It doesn't actually opt PRs into auto-merge.
+# This workflow does the opt-in step automatically at PR creation.
+#
+# External (fork) PRs are excluded by the head-repo guard — they still
+# require manual approval before any merge can happen, which is correct
+# (drive-by malicious PRs shouldn't be granted auto-merge automatically).
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Enable auto-merge (rebase)
+        run: gh pr merge --auto --rebase "${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Closes the auto-merge story. The repo's "Allow auto-merge" setting only enables the per-PR button — each PR still required a human click. This workflow does the click automatically at PR open via `gh pr merge --auto --rebase <pr-number>`. GitHub then merges the PR the moment all required checks pass + required reviews are satisfied.

Strategy: **rebase** (per operator preference — keeps linear history, no merge commits).

## Safety

- **External fork PRs excluded**: `if: github.event.pull_request.head.repo.full_name == github.repository` — fork PRs still need manual approval before any merge can happen. Drive-by malicious PRs cannot be silently merged.
- **Draft PRs excluded**: `if: github.event.pull_request.draft == false` — explicitly draft work doesn't auto-merge.
- **Permissions scoped to `pull-requests: write` + `contents: write`** (the latter required by GitHub for auto-merge enablement).

## Verification path

After this merges:
1. Open any new non-draft PR
2. Workflow fires within seconds → enables auto-merge
3. Once required checks (`CI OK`, `Post Review Results`, `codecov/patch`) all pass → GitHub merges automatically

## Self-test

This PR itself can't benefit from the workflow (the workflow doesn't exist yet on main when it opens). After merge, future PRs will get auto-merge automatically. **Click "Enable auto-merge" on this one manually**, or merge it directly.