### PR TITLE
chore: land 11 missing backlog task files (snapshot drift recovery)

### DIFF
--- a/backlog/tasks/aisdlc-115 - RFC-0011-Definition-of-Ready-Gate-for-Pipeline-Admission.md
+++ b/backlog/tasks/aisdlc-115 - RFC-0011-Definition-of-Ready-Gate-for-Pipeline-Admission.md
@@ -1,0 +1,73 @@
+---
+id: AISDLC-115
+title: 'RFC-0011: Definition-of-Ready Gate for Pipeline Admission'
+status: To Do
+assignee: []
+created_date: '2026-05-01 16:22'
+labels:
+  - rfc-0011
+  - architecture
+  - dor
+  - pipeline-admission
+milestone: m-3
+dependencies: []
+references:
+  - spec/rfcs/RFC-0011-definition-of-ready-gate.md
+  - backlog/docs/ppa-product-signoff-rfc0011.md
+  - ai-sdlc-plugin/agents/refinement-reviewer.md
+  - .ai-sdlc/dor-config.yaml
+  - spec/schemas/refinement-verdict.v1.schema.json
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Context
+
+Parent task for RFC-0011 implementation. Splits the 9-phase plan from RFC §12 into trackable sub-tasks (AISDLC-115.1 through 115.9). Sequential phases; each ships behind feature flag `AI_SDLC_DOR_GATE`. Total wall-clock ~5-6 weeks (Phase 7 soak duration is corpus-driven, not calendar-driven per maintainer directive).
+
+## Sign-off status
+
+- ✅ Engineering owner — Dom (2026-04-30, RFC v3)
+- ✅ Operator owner — Dom (2026-04-30, RFC v3)
+- ✅ Product owner — Alex (2026-05-01, see backlog/docs/ppa-product-signoff-rfc0011.md)
+
+Two non-blocking additions requested by Product:
+1. Auto-pass for signal-pipeline-generated issues (defer to Phase 4)
+2. Shard naming for tessellated platforms (defer to Phase 7)
+
+## Phase breakdown (per RFC §12)
+
+| Sub-task | Phase | Wall-clock | Depends on |
+|---|---|---|---|
+| AISDLC-115.1 | Phase 1: Schema + status | 1 wk | — |
+| AISDLC-115.2 | Phase 2a: Deterministic Stage A + corpus | 1 wk | 115.1 |
+| AISDLC-115.3 | Phase 2b: Refinement-reviewer agent (Stage B) | 1-2 wk | 115.2 |
+| AISDLC-115.4 | Phase 3: Orchestration + comment loop | 1 wk | 115.3 |
+| AISDLC-115.5 | Phase 4: PPA composition + execute refusal + signal-pipeline auto-pass (Alex's Addition 1) | 0.5 wk | 115.4 |
+| AISDLC-115.6 | Phase 5: Metrics + observability | 1 wk | 115.5 |
+| AISDLC-115.7 | Phase 6: Bypass mechanism + escalation | 0.5 wk | 115.6 |
+| AISDLC-115.8 | Phase 7: Soak + tune + tessellated-platform shard naming (Alex's Addition 2) | corpus-driven, target ≤2 wk | 115.7 |
+| AISDLC-115.9 | Phase 8: Enforce | — | 115.8 |
+
+Critical path: 115.1 → 115.2 → 115.3 → 115.4 → 115.5 → 115.6 → 115.7 → 115.8 → 115.9. Sequential because each phase consumes the prior phase's artifacts.
+
+## Soak policy — corpus-driven, NOT calendar-driven
+
+Per maintainer directive (2026-05-01): RFC-0011 phases must NOT be gated by arbitrary calendar windows. Phase 7 (soak) ships when:
+- False-positive rate < 10% per gate against test corpus + shadow-mode eval, AND
+- No outstanding override-rate anomalies in the calibration log.
+
+Whichever comes first. Calendar duration is a side-effect, not a gate.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 9 phase sub-tasks (AISDLC-115.1 through 115.9) reach Done status
+- [ ] #2 Feature flag `AI_SDLC_DOR_GATE` promoted from `warn-only` → `enforce` after Phase 7 soak validates < 10% per-gate false-positive rate (NOT time-gated; corpus-validated)
+- [ ] #3 Dogfood pipeline runs with DoR gate ENFORCING for at least one full week of real issue stream without operator override-rate spike
+- [ ] #4 Both Alex's additions delivered: signal-pipeline auto-pass (in Phase 4) + tessellated-platform shard naming (in Phase 7)
+- [ ] #5 DoR calibration log written to `$ARTIFACTS_DIR/_dor/calibration.jsonl` (Section 5.5 of RFC) and feeds the metrics dashboard
+- [ ] #6 Operator runbook extended with DoR-specific failure modes (refusal flow, bypass mechanism, escalation paths)
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-115.2 - Phase-2a-Deterministic-Stage-A-test-corpus.md
+++ b/backlog/tasks/aisdlc-115.2 - Phase-2a-Deterministic-Stage-A-test-corpus.md
@@ -1,0 +1,39 @@
+---
+id: AISDLC-115.2
+title: 'Phase 2a: Deterministic Stage A + test corpus'
+status: To Do
+assignee: []
+created_date: '2026-05-01 16:25'
+labels:
+  - rfc-0011
+  - phase-2a
+  - deterministic
+  - corpus
+milestone: m-3
+dependencies:
+  - AISDLC-115.1
+references:
+  - >-
+    spec/rfcs/RFC-0011-definition-of-ready-gate.md#44-deterministic-first-evaluation-order
+  - spec/rfcs/RFC-0011-definition-of-ready-gate.md#56-corpus
+  - spec/dor-corpus/
+parent_task_id: AISDLC-115
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Deterministic Stage A: regex / structural / link-check evaluators that catch ~40-60% of unready issues at zero LLM cost (per RFC §4.4 + Q10 cost analysis). Ships with the test corpus that becomes the ongoing regression gate. Per RFC §12 Phase 2a.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Stage A modules implemented per RFC §4.4: regex/link-check/structural validation for each of the 7 gates that have a deterministic component
+- [ ] #2 Test corpus seeded at `spec/dor-corpus/`: 30 ready + 35 needs-clarification + 10 edge-case fixtures (matches RFC §5.6 spec)
+- [ ] #3 Resolver registry (`resolveReference`) ships with 3 resolvers: github-issue, file-existence, URL HEAD (per Q2 resolution)
+- [ ] #4 CI gate enforces 100% Stage A correctness against the corpus (any drift fails CI)
+- [ ] #5 Stage A runs in <100ms per issue (perf budget per RFC §12 Phase 2a)
+- [ ] #6 Stage A ships standalone — issues passing Stage A are admitted as `ready` until Phase 2b lands the LLM Stage B
+- [ ] #7 New code reaches 80%+ patch coverage
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-115.3 - Phase-2b-Refinement-reviewer-agent-Stage-B-LLM-evaluator.md
+++ b/backlog/tasks/aisdlc-115.3 - Phase-2b-Refinement-reviewer-agent-Stage-B-LLM-evaluator.md
@@ -1,0 +1,39 @@
+---
+id: AISDLC-115.3
+title: 'Phase 2b: Refinement-reviewer agent (Stage B LLM evaluator)'
+status: To Do
+assignee: []
+created_date: '2026-05-01 16:25'
+labels:
+  - rfc-0011
+  - phase-2b
+  - agent
+  - llm
+  - review
+milestone: m-3
+dependencies:
+  - AISDLC-115.2
+references:
+  - spec/rfcs/RFC-0011-definition-of-ready-gate.md#5-the-dor-reviewer-agent
+  - ai-sdlc-plugin/agents/refinement-reviewer.md
+parent_task_id: AISDLC-115
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+LLM-backed Stage B evaluator: handles the gates that need semantic judgment (e.g., "is the AC actually testable?", "is the done-state describable?"). Composed with Stage A from Phase 2a — Stage A runs first, Stage B only fires for gates Stage A couldn't decide. Per RFC §12 Phase 2b.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 New plugin agent at `ai-sdlc-plugin/agents/refinement-reviewer.md` with binary-yes/no prompt per Stage B gate
+- [ ] #2 Structured verdict output combining Stage A + Stage B per `refinement-verdict.v1.schema.json`
+- [ ] #3 Confidence tiering: high|medium|low per Q4 resolution (medium = act-but-spot-check; low = escalate)
+- [ ] #4 Agent achieves ≥90% Stage B match against test corpus
+- [ ] #5 End-to-end (Stage A + B) achieves ≥95% match against test corpus
+- [ ] #6 Calibration log writes to `$ARTIFACTS_DIR/_dor/calibration.jsonl` per RFC §5.5
+- [ ] #7 Shadow-mode eval against last 4 weeks of real issues shows <5% disagreement vs Stage-A-only baseline (validates LLM isn't introducing noise)
+- [ ] #8 New code reaches 80%+ patch coverage
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-115.4 - Phase-3-Orchestration-comment-loop-ingress-shims-idempotent-posting.md
+++ b/backlog/tasks/aisdlc-115.4 - Phase-3-Orchestration-comment-loop-ingress-shims-idempotent-posting.md
@@ -1,0 +1,39 @@
+---
+id: AISDLC-115.4
+title: 'Phase 3: Orchestration + comment loop (ingress shims + idempotent posting)'
+status: To Do
+assignee: []
+created_date: '2026-05-01 16:25'
+labels:
+  - rfc-0011
+  - phase-3
+  - orchestration
+  - comments
+milestone: m-3
+dependencies:
+  - AISDLC-115.3
+references:
+  - spec/rfcs/RFC-0011-definition-of-ready-gate.md#52-ingress-shims
+  - >-
+    spec/rfcs/RFC-0011-definition-of-ready-gate.md#62-comment-format-and-idempotency
+parent_task_id: AISDLC-115
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Wires Stage A+B verdicts into the actual issue lifecycle via two ingress shims (GitHub Action + Claude Code subagent). Per RFC §12 Phase 3 + §5.2 + §6.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 GitHub Action ingress shim wired to `issues.opened` + `issues.edited` + `pull_request` events touching `backlog/tasks/*.md`
+- [ ] #2 Claude Code subagent ingress shim (refinement-reviewer) invokable from `/ai-sdlc execute` when a backlog task is created in-session
+- [ ] #3 Status transitions: `Draft` → `To Do` triggers DoR; failed DoR → `Needs Clarification`; author edit → re-check → admit on pass
+- [ ] #4 Comment posting is idempotent (HTML marker `<!-- ai-sdlc:dor-comment -->` per RFC §6.2)
+- [ ] #5 Dual-fanout per Q5: comments go to author channel AND optional dedicated channel simultaneously
+- [ ] #6 Two-stage staleness per Q6: warn at 14d, auto-close at 28d (configurable via `dor-config.yaml`)
+- [ ] #7 E2E test: vague issue created → DoR comment posted → author edits → re-check → admitted as ready
+- [ ] #8 New code reaches 80%+ patch coverage
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-115.5 - Phase-4-PPA-composition-execute-refusal-signal-pipeline-auto-pass.md
+++ b/backlog/tasks/aisdlc-115.5 - Phase-4-PPA-composition-execute-refusal-signal-pipeline-auto-pass.md
@@ -1,0 +1,37 @@
+---
+id: AISDLC-115.5
+title: 'Phase 4: PPA composition + execute refusal + signal-pipeline auto-pass'
+status: To Do
+assignee: []
+created_date: '2026-05-01 16:25'
+labels:
+  - rfc-0011
+  - phase-4
+  - ppa-integration
+  - auto-pass
+milestone: m-3
+dependencies:
+  - AISDLC-115.4
+references:
+  - spec/rfcs/RFC-0011-definition-of-ready-gate.md#7-pipeline-integration
+  - backlog/docs/ppa-product-signoff-rfc0011.md
+  - spec/rfcs/RFC-0008-ppa-triad-integration-final-combined.md
+parent_task_id: AISDLC-115
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Wires DoR verdicts into the existing pipeline boundaries: PPA admission + `/ai-sdlc execute` start gate. Folds in Alex's Addition 1 (signal-pipeline auto-pass) per Product sign-off. Per RFC §12 Phase 4.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 PPA admission step amended to skip issues in `Needs Clarification` (no scoring effort wasted on unready issues)
+- [ ] #2 `/ai-sdlc execute <task-id>` refuses to start when task is in `Needs Clarification`, with a clear error message + link to the DoR comment
+- [ ] #3 Signal-pipeline auto-pass per Alex's Addition 1: new `kind: signal-pipeline-generated` rule in `dor-config.yaml` autoPassRules; gates 1, 4, 5, 6 skipped; gates 2, 3, 7 retained
+- [ ] #4 `evaluateIssue()` interface accepts a `gatesSkipped` parameter (or equivalent shape per Alex's note to Dom)
+- [ ] #5 Existing tests pass; new tests cover the refusal paths + the signal-pipeline auto-pass path
+- [ ] #6 New code reaches 80%+ patch coverage
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-115.6 - Phase-5-Metrics-observability-calibration-log-Slack-digest.md
+++ b/backlog/tasks/aisdlc-115.6 - Phase-5-Metrics-observability-calibration-log-Slack-digest.md
@@ -1,0 +1,36 @@
+---
+id: AISDLC-115.6
+title: 'Phase 5: Metrics + observability (calibration log + Slack digest)'
+status: To Do
+assignee: []
+created_date: '2026-05-01 16:25'
+labels:
+  - rfc-0011
+  - phase-5
+  - observability
+  - metrics
+milestone: m-3
+dependencies:
+  - AISDLC-115.5
+references:
+  - spec/rfcs/RFC-0011-definition-of-ready-gate.md#8-metrics-and-observability
+  - spec/rfcs/RFC-0011-definition-of-ready-gate.md#55-calibration-log
+parent_task_id: AISDLC-115
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Observability surface for DoR. The calibration log is what Phase 7 soak measures false-positive rate against. Without this, Phase 7 can't decide when to promote `warn-only` → `enforce`. Per RFC §12 Phase 5 + §8 + §5.5.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Calibration log writer writes JSONL to `$ARTIFACTS_DIR/_dor/calibration.jsonl` (per-issue verdict + per-gate breakdown + confidence + author + timestamp)
+- [ ] #2 Per-author and per-gate aggregation queryable (e.g., `cli-dor-stats --by-author --by-gate`)
+- [ ] #3 Weekly Slack digest entry summarising: pass rate, top failing gates, override rate, false-positive trend
+- [ ] #4 Override events log to the same calibration log so Phase 7 soak can compute false-positive rate
+- [ ] #5 Metrics dashboard renders the first weekly digest end-to-end
+- [ ] #6 New code reaches 80%+ patch coverage
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-115.7 - Phase-6-Bypass-mechanism-escalation-dor-bypass-label-3-round-escalation.md
+++ b/backlog/tasks/aisdlc-115.7 - Phase-6-Bypass-mechanism-escalation-dor-bypass-label-3-round-escalation.md
@@ -1,0 +1,36 @@
+---
+id: AISDLC-115.7
+title: 'Phase 6: Bypass mechanism + escalation (dor-bypass label + 3-round escalation)'
+status: To Do
+assignee: []
+created_date: '2026-05-01 16:26'
+labels:
+  - rfc-0011
+  - phase-6
+  - bypass
+  - escalation
+milestone: m-3
+dependencies:
+  - AISDLC-115.6
+references:
+  - spec/rfcs/RFC-0011-definition-of-ready-gate.md#74-bypass-mechanism
+  - spec/rfcs/RFC-0011-definition-of-ready-gate.md#63-escalation
+parent_task_id: AISDLC-115
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Operator escape hatch + escalation safety net. Bypass for cases where DoR is wrong; escalation for cases where the author has gone quiet. Per RFC §12 Phase 6 + §7.4 + §6.3.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Maintainer-only `dor-bypass` label handler: label applied → issue admitted regardless of DoR verdict; bypass reason logged to calibration log with `override` event type
+- [ ] #2 Trusted-reviewer-role check (RFC-0009): only contributors in `.ai-sdlc/trusted-reviewers.yaml` can apply the label
+- [ ] #3 3-round escalation per RFC §6.3: if author hasn't responded after 3 clarification rounds, route to a configured human triager (Slack mention or GitHub team ping)
+- [ ] #4 Low-confidence verdicts (per Q4) auto-escalate via the same path — no auto-act on low confidence
+- [ ] #5 Escalation routing target configurable in `dor-config.yaml` (`escalation.triager`)
+- [ ] #6 New code reaches 80%+ patch coverage
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-115.8 - Phase-7-Soak-tune-tessellated-platform-shard-naming.md
+++ b/backlog/tasks/aisdlc-115.8 - Phase-7-Soak-tune-tessellated-platform-shard-naming.md
@@ -1,0 +1,37 @@
+---
+id: AISDLC-115.8
+title: 'Phase 7: Soak + tune + tessellated-platform shard naming'
+status: To Do
+assignee: []
+created_date: '2026-05-01 16:26'
+labels:
+  - rfc-0011
+  - phase-7
+  - soak
+  - tune
+  - shard-naming
+milestone: m-3
+dependencies:
+  - AISDLC-115.7
+references:
+  - spec/rfcs/RFC-0011-definition-of-ready-gate.md#12-implementation-plan
+  - backlog/docs/ppa-product-signoff-rfc0011.md
+parent_task_id: AISDLC-115
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Soak + tune phase. Folds in Alex's Addition 2 (tessellated-platform shard naming). Per maintainer directive 2026-05-01, the exit criterion is corpus-driven (false-positive rate threshold), NOT calendar-driven. Whichever comes first — calendar duration is a side-effect, not a gate. Per RFC §12 Phase 7.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Run DoR in `warn-only` mode against real issue stream (no blocking); collect false-positive data to calibration log per Phase 5
+- [ ] #2 Tune Stage B agent prompt + per-gate severity based on observed false-positives
+- [ ] #3 Tessellated-platform shard naming per Alex's Addition 2: when project's DID is a Tessellated DID with >1 shard, Gate 5 also requires shard identification; clarification message lists shard names
+- [ ] #4 Single-shard / non-tessellated platforms unaffected by the new check (regression test)
+- [ ] #5 Phase 7 EXIT CRITERION (corpus-driven, NOT calendar-driven per maintainer directive 2026-05-01): false-positive rate < 10% per gate AND override-rate plateau in calibration log
+- [ ] #6 New code reaches 80%+ patch coverage
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-115.9 - Phase-8-Enforce-flip-AI_SDLC_DOR_GATE-warn-only-→-enforce.md
+++ b/backlog/tasks/aisdlc-115.9 - Phase-8-Enforce-flip-AI_SDLC_DOR_GATE-warn-only-→-enforce.md
@@ -1,0 +1,35 @@
+---
+id: AISDLC-115.9
+title: 'Phase 8: Enforce (flip AI_SDLC_DOR_GATE warn-only → enforce)'
+status: To Do
+assignee: []
+created_date: '2026-05-01 16:26'
+labels:
+  - rfc-0011
+  - phase-8
+  - enforce
+  - promotion
+milestone: m-3
+dependencies:
+  - AISDLC-115.8
+references:
+  - spec/rfcs/RFC-0011-definition-of-ready-gate.md#10-backward-compatibility
+parent_task_id: AISDLC-115
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Final phase. Flips the feature flag from warn-only to enforce in the dogfood project's `dor-config.yaml`. After this, the pipeline rejects Needs Clarification issues at PPA admission. Per RFC §12 Phase 8.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Feature flag `AI_SDLC_DOR_GATE` flipped from `warn-only` → `enforce` in the dogfood project's `dor-config.yaml`
+- [ ] #2 Pipeline now REJECTS `Needs Clarification` issues at PPA admission + `/ai-sdlc execute` start (no longer just warns)
+- [ ] #3 Metrics dashboard live with weekly digest entries
+- [ ] #4 AISDLC-115 (parent) AC #2 + AC #3 marked complete in this PR's chore commit; parent task closes
+- [ ] #5 spec/rfcs/RFC-0011-definition-of-ready-gate.md revision history extended with v4 entry: 'Promoted from warn-only to enforce in dogfood project DDDD-MM-DD'
+- [ ] #6 CHANGELOG.md gets an entry under Unreleased > Added
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-118 - RFC-lifecycle-convention-commit-RFCs-to-main-as-drafts-dont-gate-on-sign-off.md
+++ b/backlog/tasks/aisdlc-118 - RFC-lifecycle-convention-commit-RFCs-to-main-as-drafts-dont-gate-on-sign-off.md
@@ -1,0 +1,65 @@
+---
+id: AISDLC-118
+title: >-
+  RFC lifecycle convention: commit RFCs to main as drafts (don't gate on
+  sign-off)
+status: To Do
+assignee: []
+created_date: '2026-05-01 16:35'
+labels:
+  - process
+  - rfc-lifecycle
+  - documentation
+  - stakeholder-comms
+dependencies: []
+references:
+  - spec/rfcs/README.md
+  - spec/rfcs/RFC-0001-template.md
+  - CLAUDE.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Context
+
+Today RFCs live on feature branches until full sign-off, then merge to main. This means:
+
+- **Stakeholders can't reference them**: Alex needed to read RFC-0011 v3 to sign off; if it had been on main, he could have linked to `https://github.com/.../spec/rfcs/RFC-0011-...md`. Instead, the draft lived on a branch and required dev tooling to view.
+- **Drafts get lost**: RFC-0011 + RFC-0012 currently exist locally but not on main. Anyone joining the project sees an incomplete RFC index. The implementation work for those RFCs has begun (AISDLC-115, AISDLC-100.x) but the design rationale is invisible.
+- **Sign-off blocks visibility, not the other way**: the current convention conflates "is this signed off?" with "should this be in the repo?" These are orthogonal questions.
+
+## Why this matters
+
+RFCs are signaling documents. Their value is highest when stakeholders can see them DURING design, not just after. Hiding drafts until sign-off destroys the feedback loop the RFC process is supposed to create.
+
+## Proposed lifecycle
+
+| Lifecycle | Meaning | Sign-off state |
+|---|---|---|
+| **Draft** | Initial brainstorm; structure may shift | Sign-off boxes empty |
+| **Ready for Review** | Structure stable; ready for owner sign-off | At least one owner signed; awaiting others |
+| **Signed Off** | All owners signed; design locked | All owner boxes checked |
+| **Implemented** | Corresponding milestone reached Done | n/a (post-sign-off state) |
+| **Superseded** | Replaced by newer RFC | Header notes the successor |
+
+Drafts MUST land on main as soon as the author considers them shareable (probably after the first internal pass). Subsequent edits go through normal PR review like any other doc.
+
+## Acceptance criteria expanded in checklist below.
+
+## Why this is high-priority
+
+The RFC visibility gap blocks stakeholder review (Alex example today) and creates onboarding friction. The fix is small (convention update + index + lifecycle field). Ship now so future RFCs benefit.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 spec/rfcs/README.md documents the new RFC lifecycle: Draft → Ready for Review → Signed Off → Implemented → Superseded
+- [ ] #2 RFC frontmatter gains a `Lifecycle:` field with the status (separate from sign-off, which stays as the per-owner checklist)
+- [ ] #3 spec/rfcs/RFC-0001-template.md updated with the new Lifecycle field + brief explanation that drafts SHOULD land on main early so stakeholders can link to the canonical URL
+- [ ] #4 CLAUDE.md gets a brief subsection under 'RFCs' explaining the new lifecycle (Draft = brainstorm, Ready for Review = ready for sign-off, Signed Off = all owners signed, Implemented = corresponding milestone closed, Superseded = replaced by newer RFC)
+- [ ] #5 All currently-local RFCs (RFC-0011, RFC-0012) get landed on main with appropriate Lifecycle status (Signed Off for RFC-0011, Draft or Ready-for-Review for RFC-0012)
+- [ ] #6 spec/rfcs/README.md index table shows Lifecycle column so stakeholders see the state at a glance
+- [ ] #7 Optional Phase 2 (filed separate if needed): `pnpm rfc:check` validates Lifecycle field is present + matches sign-off state (e.g., Signed Off lifecycle requires all owners to have signed)
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-119 - Tighten-backlog-drift-husky-pre-commit-hook-to-FAIL-on-errors-not-advisory.md
+++ b/backlog/tasks/aisdlc-119 - Tighten-backlog-drift-husky-pre-commit-hook-to-FAIL-on-errors-not-advisory.md
@@ -1,0 +1,65 @@
+---
+id: AISDLC-119
+title: Tighten backlog-drift husky pre-commit hook to FAIL on errors (not advisory)
+status: To Do
+assignee: []
+created_date: '2026-05-01 16:47'
+labels:
+  - backlog-drift
+  - husky
+  - ci
+  - tooling
+  - task-quality
+dependencies: []
+references:
+  - .husky/pre-commit
+  - 'https://github.com/ReliableGenius/backlog.md-drift'
+  - >-
+    backlog/tasks/aisdlc-117 -
+    Compute-backlog-task-dependency-graph-integrate-into-dispatch-frontier.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Context
+
+The `.husky/pre-commit` hook already runs `npx backlog-drift hook-run` (line 5). It's been in place — but `hook-run` is an advisory mode that warns without exiting non-zero. Result: 223 drift issues accumulated across 152 tasks despite the hook running on every commit (incl. all 12 task creations I did this morning for AISDLC-110-118 + AISDLC-115.x).
+
+## Why this matters
+
+Operator (and Claude) productivity is bottlenecked on accurate task references. Every drift-creating commit costs:
+- Future automation cycles (e.g., dependency graph computer in AISDLC-117 needs accurate refs)
+- Stakeholder confusion (Alex couldn't find RFC-0011 → because RFCs themselves had drift)
+- Operator triage cycles (this morning I duplicated AISDLC-104 dispatch because the dep graph wasn't computed)
+
+A strict pre-commit hook would have failed each of my morning's commits with a clear "fix this" message, forcing me to clean up at the moment of creation rather than accumulating debt.
+
+## Implementation hints
+
+- `backlog-drift check --task <id>` is the strict-mode equivalent of `hook-run` (per CLI help). Use `git diff --cached --name-only --diff-filter=AM 'backlog/tasks/*.md'` to find newly-added/modified task files in the staging area.
+- Iterate over each staged task; run `check --task <id>` per task; aggregate exit codes.
+- The CI gate (separate from pre-commit) runs `backlog-drift check` on the FULL backlog so post-merge drift is caught at PR time.
+
+## Two follow-up tasks (filed separately when this lands)
+
+- **One-time cleanup of the existing 223 drift issues** — needs human review since some "deleted references" are intentional annotations (e.g., `pipeline-cli/README.md (new)` was a forward-looking placeholder in AISDLC-100.7).
+- **Sync project-root bare-repo snapshot to origin/main** — the underlying issue causing many false-positive drift reports today (local snapshot at HEAD `296b7d5` predates many merged PRs).
+
+## Why high-priority
+
+This is the kind of meta-tooling that compounds. Every day without it adds new drift. The fix is small (~10 lines of bash in the husky hook + a CI step) but the leverage is enormous.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `.husky/pre-commit` runs `backlog-drift check` (or equivalent strict mode) on staged backlog/tasks/*.md changes — NOT just `hook-run` advisory mode
+- [ ] #2 Hook FAILS the commit (exit non-zero) when a newly-staged or modified task has dangling references (path doesn't exist), invalid dependency IDs, or orphan annotations like `(new)` placeholders that were never replaced
+- [ ] #3 Hook output gives a clear actionable error message + the auto-fix command (`backlog-drift fix --task <id>`) so the operator can resolve in one shot
+- [ ] #4 Hook performance budget: < 500ms for typical 1-task commit (full repo scan only on `pre-push` or CI, not pre-commit)
+- [ ] #5 False-positive escape hatch: `git commit --no-verify` still works (existing behavior); operator can also disable via env var `AI_SDLC_SKIP_DRIFT_GATE=1` for emergencies
+- [ ] #6 Add a CI step (in `.github/workflows/ci.yml`) that runs `backlog-drift check` against the FULL backlog so PRs that introduce drift via merge conflicts also fail
+- [ ] #7 Existing 223-issue drift backlog requires a one-time human cleanup pass first (file as separate follow-up task; this hook only prevents NEW drift)
+- [ ] #8 Documentation in CLAUDE.md `Backlog Workflow` section explaining the hook's strict mode + escape hatches
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

Bare-repo loose snapshot drift bug exposed: tasks created today via `mcp__backlog__task_create` went into the local project-root snapshot but were never included in this morning's PRs (which only carried files explicitly copied into worktrees).

## Files landed

| ID | Title |
|---|---|
| AISDLC-115 | RFC-0011: Definition-of-Ready Gate (parent) |
| AISDLC-115.2 | Phase 2a: Deterministic Stage A + corpus |
| AISDLC-115.3 | Phase 2b: Refinement-reviewer agent |
| AISDLC-115.4 | Phase 3: Orchestration + comment loop |
| AISDLC-115.5 | Phase 4: PPA composition + signal-pipeline auto-pass |
| AISDLC-115.6 | Phase 5: Metrics + observability |
| AISDLC-115.7 | Phase 6: Bypass + escalation |
| AISDLC-115.8 | Phase 7: Soak + tune |
| AISDLC-115.9 | Phase 8: Enforce |
| AISDLC-118 | RFC lifecycle convention |
| AISDLC-119 | Tighten backlog-drift hook to FAIL on errors |

## Why this happened

The project root at `/Users/dominique/Documents/dev/ai-sdlc/ai-sdlc` is a bare-ish repo (`git rev-parse --is-inside-work-tree` returns false). Worktrees attach via `git worktree add`. `mcp__backlog__task_create` writes to the LOCAL snapshot (project-root `backlog/tasks/`), but those files don't get propagated to feature branches unless explicitly copied. AISDLC-119 (tighten backlog-drift hook) addresses this class of bug at commit time; an even deeper fix (re-init project root as a proper worktree so `git pull` works) is implicit in the `git rev-parse --is-inside-work-tree: false` observation today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)