### PR TITLE
chore: remove orphan Stop hook in .claude/settings.json (AISDLC-108 cleanup chain)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,17 +35,6 @@
         ]
       }
     ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"$CLAUDE_PROJECT_DIR/ai-sdlc-plugin/hooks/quality-gate-stop.sh\"",
-            "statusMessage": "Verifying governance compliance..."
-          }
-        ]
-      }
-    ],
     "PermissionRequest": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Summary

Removes the Stop hook block in `.claude/settings.json` that still references `ai-sdlc-plugin/hooks/quality-gate-stop.sh` — the script was deleted by AISDLC-108, both plugin.json variants had their references purged in AISDLC-120, but this one was missed.

Result of the orphan: every Stop event in any Claude Code session against this repo silently invokes a shell hook that fails immediately because the target doesn't exist. No user-visible error, but the bash exec runs every turn.

## Verification

- `ls ai-sdlc-plugin/hooks/quality-gate-stop*` → no matches (confirmed deleted)
- `node -e "JSON.parse(...)" .claude/settings.json` → valid JSON post-edit
- `grep '"Stop"' .claude/settings.json` → no matches post-edit
- `grep '"Stop"' ai-sdlc-plugin/plugin.json ai-sdlc-plugin/.claude-plugin/plugin.json` → both still present (intentional — they call `deferred-coverage-check.sh` which serves a different purpose and stays)

## No restart required

Claude Code re-reads `.claude/settings.json` on each event, so the orphan hook stops firing as soon as this lands. (For sessions already loaded, the cached config in-memory will keep firing until session restart — but the cost is silent + minimal.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)