### PR TITLE
docs(backlog): close AISDLC-124 as superseded by PR #152

### DIFF
--- a/backlog/completed/aisdlc-124 - CI-side-attestor-must-sign-v3-envelopes-currently-signs-v1-→-verifier-rejects-post-AISDLC-103.md
+++ b/backlog/completed/aisdlc-124 - CI-side-attestor-must-sign-v3-envelopes-currently-signs-v1-→-verifier-rejects-post-AISDLC-103.md
@@ -3,7 +3,7 @@ id: AISDLC-124
 title: >-
   CI-side attestor must sign v3 envelopes (currently signs v1 → verifier rejects
   post-AISDLC-103)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-01 21:24'
 labels:
@@ -46,3 +46,27 @@ CI-attestor / verifier schema-version mismatch causing `ai-sdlc/attestation` sta
 - [ ] #4 New chore/docs PR opened post-fix shows ai-sdlc/attestation: SUCCESS (verified by re-running the workflow)
 - [ ] #5 CLAUDE.md "CI-side attestor (AISDLC-87)" section updated to reflect v3 schema
 <!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+## Outcome: SUPERSEDED — diagnosis was incorrect
+
+Closed without separate implementation work. PR #152 actually fixed the symptom (`ai-sdlc/attestation` red on chore/docs PRs) via a different root cause than this task described.
+
+## What this task got wrong
+
+This task asserted the CI-attestor was signing v1 envelopes. That's incorrect. Both signing scripts (`scripts/ci-sign-attestation.mjs` and `ai-sdlc-plugin/scripts/sign-attestation.mjs`) ALREADY emit v3 envelopes correctly via the shared `buildPredicate` at `orchestrator/src/runtime/attestations.ts:886` (hardcoded `schemaVersion: 'v3'`).
+
+## Actual root cause + fix (PR #152)
+
+The verifier (`scripts/verify-attestation.mjs:707-711`) scans ALL envelopes in `.ai-sdlc/attestations/` and surfaces the "closest mismatch" reason when no envelope matches the PR's expected predicate. The repo carried 48 v1 envelopes from pre-AISDLC-103 commits — these never matched current PRs but DID surface as the closest-mismatch reason `schemaVersion 'v1' not in allowlist [v3]` whenever a PR lacked a fresh local v3 envelope.
+
+PR #152 deletes the 48 stale v1 envelopes (preserving the 6 legitimate post-AISDLC-103 v3 ones).
+
+## Follow-up worth filing separately
+
+The verifier behavior of "scan all envelopes, surface any mismatch as closest-match" means a single bad envelope (introduced accidentally or maliciously in a future commit) can poison the gate even after this cleanup. A defensive hardening worth considering: skip envelopes whose `schemaVersion` is outside the allowlist during the closest-match selection rather than including them as candidates. That would isolate the gate from envelope-noise in the attestations directory.
+
+If anyone picks that up, file as a new task (rather than reopening this one).
+<!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Summary

Closes AISDLC-124 (filed in PR #151) as superseded. The task's diagnosis was incorrect — the CI-attestor was NOT signing v1 envelopes; both scripts already emit v3 via the shared `buildPredicate`. The actual root cause (48 stale v1 envelopes from pre-AISDLC-103 commits) was fixed by PR #152.

Marks the task Done with finalSummary documenting the corrected diagnosis and a defensible verifier-hardening follow-up (skip non-allowlisted-version envelopes during closest-match selection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)