### PR TITLE
docs(rfc-0015): Engineering + Operator sign-off; lifecycle Draft → Ready for Review

### DIFF
--- a/spec/rfcs/RFC-0015-autonomous-pipeline-orchestrator.md
+++ b/spec/rfcs/RFC-0015-autonomous-pipeline-orchestrator.md
@@ -2,7 +2,7 @@
 id: RFC-0015
 title: Autonomous Pipeline Orchestrator
 status: Draft
-lifecycle: Draft
+lifecycle: Ready for Review
 author: dominique@reliablegenius.io
 created: 2026-05-01
 updated: 2026-05-01
@@ -19,7 +19,7 @@ requiresDocs: []
 
 **Document type:** Normative (draft)
 **Status:** Draft (initial seed; structure may shift; open questions in §13)
-**Lifecycle:** Draft
+**Lifecycle:** Ready for Review
 **Author:** dominique@reliablegenius.io (with Claude assist)
 **Created:** 2026-05-01
 **Updated:** 2026-05-01
@@ -29,9 +29,9 @@ requiresDocs: []
 
 ## Sign-Off
 
-- [ ] Engineering owner — dominique@reliablegenius.io (pending)
+- [x] Engineering owner — dominique@reliablegenius.io (2026-05-02)
 - [ ] Product owner — Alex (pending)
-- [ ] Operator owner — dominique@reliablegenius.io (pending)
+- [x] Operator owner — dominique@reliablegenius.io (2026-05-02)
 
 ## Revision History
 


### PR DESCRIPTION
## Summary
RFC-0015 (Autonomous Pipeline Orchestrator) sign-off pass:
- ✅ **Engineering** (dominique@reliablegenius.io, 2026-05-02)
- ⏳ **Product** (Alex, pending)
- ✅ **Operator** (dominique@reliablegenius.io, 2026-05-02)

Lifecycle frontmatter: `Draft` → `Ready for Review` per AISDLC-118 convention (transitions to `Signed Off` only when all 3 owners have signed).

## Context
RFC-0015 design session (2026-05-01) resolved all 12 open questions across two batched walkthroughs. Doc is structurally complete; design is locked from Engineering + Operator perspectives. Product sign-off from Alex remains.

## Verification
- `scripts/check-rfc-docs.mjs` — RFC-0015 `status: Draft` (kept for back-compat with the docs gate; lifecycle is the new authoritative field)
- Both frontmatter `lifecycle:` and the body `**Lifecycle:**` line updated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)