### PR TITLE
feat(orchestrator): self-heal parent repo state at Step 0 (AISDLC-137)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ __pycache__/
 build/
 *.pyz
 orchestrator/.gitignore
+.worktrees/

--- a/.husky/post-rewrite
+++ b/.husky/post-rewrite
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Husky post-rewrite hook (AISDLC-137).
+#
+# Fires after `git rebase` (and `git commit --amend`). When a worktree rebases
+# onto origin/main, that's the moment we just consumed the latest main, so it's
+# the cheapest moment to also update the orchestrator parent's local
+# refs/heads/main to match — avoiding the "main 10↓" stale state in editors.
+#
+# Non-blocking: if the parent's ref update fails (e.g. concurrent op, parent
+# missing) we log but don't fail the rebase.
+
+set -uo pipefail
+
+# Only act on rebase rewrites (the most common case where origin/main moved)
+if [ "${1:-}" != "rebase" ]; then
+  exit 0
+fi
+
+# Resolve the parent (orchestrator) repo. git-common-dir is always the parent's
+# .git when invoked from inside a worktree.
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
+if [ -z "$GIT_COMMON_DIR" ]; then
+  exit 0
+fi
+
+GIT_COMMON_DIR_ABS=$(cd "$GIT_COMMON_DIR" 2>/dev/null && pwd)
+if [ -z "$GIT_COMMON_DIR_ABS" ]; then
+  exit 0
+fi
+
+PARENT_ROOT=$(dirname "$GIT_COMMON_DIR_ABS")
+
+# Try to update parent's refs/heads/main to match origin/main.
+# Use git -C to operate in the parent without changing this hook's cwd.
+ORIGIN_MAIN=$(git -C "$PARENT_ROOT" rev-parse refs/remotes/origin/main 2>/dev/null || echo "")
+if [ -z "$ORIGIN_MAIN" ]; then
+  exit 0
+fi
+
+LOCAL_MAIN=$(git -C "$PARENT_ROOT" rev-parse refs/heads/main 2>/dev/null || echo "")
+if [ "$LOCAL_MAIN" = "$ORIGIN_MAIN" ]; then
+  exit 0  # already current
+fi
+
+# Update — fast-forward only via update-ref (atomic).
+if git -C "$PARENT_ROOT" update-ref refs/heads/main "$ORIGIN_MAIN" 2>/dev/null; then
+  echo "[post-rewrite] parent refs/heads/main updated: ${LOCAL_MAIN:0:7} -> ${ORIGIN_MAIN:0:7}"
+fi
+
+exit 0

--- a/ai-sdlc-plugin/commands/execute.md
+++ b/ai-sdlc-plugin/commands/execute.md
@@ -40,9 +40,23 @@ Step 4 below writes the active-task sentinel at `<worktree>/.active-task` (per-w
 
 If you find yourself trying to write `.worktrees/.active-task` at the project root, stop — that's the wrong path and would race with parallel runs.
 
-## Step 0 — Sweep merged worktrees (auto-cleanup)
+## Step 0 — Self-heal orchestrator state + sweep merged worktrees
 
-Before doing anything else, scan `.worktrees/` and remove any whose branch's PR has merged into `main`. This is the eventual-cleanup mechanism — running `/ai-sdlc execute` regularly keeps the worktree directory tidy without any manual intervention.
+First, ensure the parent (orchestrator) repo is in the right state for worktree creation. The parent's working tree on `main` is **read-only** by Pattern C contract (project memory `project_orchestrator_repo_layout.md`) — all edits happen in `.worktrees/<task-id>/`. This makes it safe to auto-sync the parent to current `origin/main` at the start of every dispatch.
+
+```bash
+./scripts/check-orchestrator-state.sh
+```
+
+The script (AISDLC-137):
+- Auto-corrects `core.bare=true` → `false` (some local editor extensions flip it back periodically)
+- Fetches `origin/main`
+- If parent's working tree is clean: `git reset --hard origin/main` (untracked files like `.worktrees/` survive)
+- If parent's working tree is dirty: warns + skips (operator-protective; never destroys in-progress work)
+
+Skip with `AI_SDLC_SKIP_ORCHESTRATOR_STATE_CHECK=1` (rare — only when you intentionally want a stale parent for debugging).
+
+Then scan `.worktrees/` and remove any whose branch's PR has merged into `main`. This is the eventual-cleanup mechanism — running `/ai-sdlc execute` regularly keeps the worktree directory tidy without any manual intervention.
 
 ```bash
 if [ -d .worktrees ]; then

--- a/backlog/completed/aisdlc-137 - Orchestrator-repo-state-hardening-Step-0-auto-asserts-core-bare-false-syncs-parent-main-husky-post-rewrite-hook.md
+++ b/backlog/completed/aisdlc-137 - Orchestrator-repo-state-hardening-Step-0-auto-asserts-core-bare-false-syncs-parent-main-husky-post-rewrite-hook.md
@@ -1,0 +1,127 @@
+---
+id: AISDLC-137
+title: >-
+  Orchestrator repo state hardening — Step 0 auto-asserts core.bare=false +
+  syncs parent main; husky post-rewrite hook
+status: Done
+assignee: []
+created_date: '2026-05-02 16:46'
+labels:
+  - ci
+  - infrastructure
+  - orchestrator
+  - follow-up
+dependencies: []
+references:
+  - ai-sdlc-plugin/commands/execute.md
+  - .husky/post-rewrite
+  - scripts/check-orchestrator-state.sh
+  - 'memory: project_orchestrator_repo_layout.md'
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+**Caught when the parent repo at `/Users/dominique/Documents/dev/ai-sdlc/ai-sdlc/` was found 10 commits behind origin/main and `core.bare=true` (preventing `git status`).** This is the recurring problem the operator flagged 2026-05-02: every few sessions, an editor extension or external tool flips `core.bare` back to `true`, the parent's working tree falls out of sync, and worktree creation starts from a stale base.
+
+**Contract** (saved as memory `project_orchestrator_repo_layout.md`): the parent dir at the orchestrator root uses Pattern C — non-bare with worktrees, parent's working tree on main is **read-only**. All edits happen in `.worktrees/<task-id>/`. This makes it safe to auto-sync the parent's working tree to current `origin/main` because nobody edits there directly.
+
+**Three pieces to ship:**
+
+1. **`scripts/check-orchestrator-state.sh`** (new) — runs the assertion + auto-correction:
+   - If `core.bare=true`: log warning, set `core.bare=false`
+   - `git fetch origin main`
+   - `git update-ref refs/heads/main origin/main`
+   - If the working tree is CLEAN (no uncommitted modifications and no untracked files outside `.worktrees/` + `backlog/tasks/`): `git reset --hard origin/main`
+   - If working tree is DIRTY: log a clear warning naming the dirty files but DO NOT reset (operator-protective; they may have intentional work-in-progress)
+   - Idempotent; safe to run repeatedly
+   - Hermetic test at `scripts/check-orchestrator-state.test.mjs`
+
+2. **`ai-sdlc-plugin/commands/execute.md` Step 0 update** — invoke `scripts/check-orchestrator-state.sh` before the existing worktree sweep so every dispatch self-heals the parent state.
+
+3. **`.husky/post-rewrite` hook** — fires after any rebase in a worktree (which is the moment the worktree consumed the latest `origin/main`). The hook calls `git -C "$(git rev-parse --git-common-dir)/.." update-ref refs/heads/main origin/main` to keep the parent's local `main` ref current. Non-blocking: failures (e.g. parent unreachable, ref already up-to-date) log but don't fail the rebase.
+
+4. **`.gitignore`** — add `.worktrees/` defensively (it's currently NOT in .gitignore; a future careless `git add .` could try to track worktree directories).
+
+**Why this is high-priority:**
+The recurring bare-flip + main-staleness has now caused 3 visible incidents (PR #172 conflict from a stale-base race, today's "main 10↓" status, and earlier worktree creation from stale main). Auto-healing eliminates the manual re-correction every time it recurs.
+
+**Out of scope for this task:**
+- Identifying which editor extension flips `core.bare` (operator-machine-specific; can investigate per-machine if it persists)
+- Pattern B → Pattern A migration documentation (the contract is already saved as memory)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 scripts/check-orchestrator-state.sh exists; runs from any cwd inside the project; idempotent on a clean state
+- [x] #2 Script auto-corrects core.bare=true → false with a warning log line
+- [x] #3 Script updates refs/heads/main to origin/main after fetch
+- [x] #4 Script runs git reset --hard origin/main ONLY when working tree is clean (no uncommitted tracked changes; only known-untracked items like .worktrees/ allowed)
+- [x] #5 Script aborts gracefully with a clear warning when working tree is dirty (lists what's dirty)
+- [x] #6 Hermetic test at scripts/check-orchestrator-state.test.mjs covers: clean reset path, dirty-abort path, bare-correction path, ref-already-current no-op
+- [x] #7 .husky/post-rewrite hook fires after every rebase in a worktree and updates parent's refs/heads/main to origin/main (non-blocking)
+- [x] #8 ai-sdlc-plugin/commands/execute.md Step 0 invokes the new script before the worktree sweep
+- [x] #9 .worktrees/ added to .gitignore
+- [x] #10 pnpm test passes including the new hermetic test
+<!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+## Summary
+Three pieces of orchestrator-state hardening shipped: a `scripts/check-orchestrator-state.sh` self-heal script (auto-corrects core.bare, syncs parent main, never destroys dirty work), a husky `post-rewrite` hook that updates the parent's main ref after every worktree rebase, and `.gitignore` defensive add for `.worktrees/`. Step 0 of `/ai-sdlc execute` invokes the new script before the worktree sweep.
+
+## Changes
+- `scripts/check-orchestrator-state.sh` (new) — self-heal: bare-correction + fetch + reset-if-clean / warn-if-dirty
+- `scripts/check-orchestrator-state.test.mjs` (new) — 8 hermetic tests covering all branches
+- `.husky/post-rewrite` (new) — non-blocking parent main-ref update after worktree rebase
+- `.gitignore` — added `.worktrees/`
+- `ai-sdlc-plugin/commands/execute.md` — Step 0 now invokes the new script first
+- `package.json` — wired `test:orchestrator-state-gate` into `pnpm test`
+
+## Design decisions
+- **Reset --hard ONLY when working tree is clean** (operator-protective; never destroy in-progress work). Dirty = warn + skip with file list.
+- **`reset --hard origin/main` instead of `update-ref + reset HEAD`** — single op, atomic, also moves refs/heads/main since HEAD is the symref. Simpler logic.
+- **post-rewrite uses `git -C "$PARENT_ROOT" update-ref`** — non-blocking: ref-update failure logs but doesn't fail the rebase. Operator's rebase always succeeds even if the parent ref update races.
+- **Untracked files ALWAYS preserved** by `reset --hard` (it only touches tracked files). `.worktrees/` + in-flight task drafts survive.
+
+## Verification
+- `pnpm test:orchestrator-state-gate` — 8/8 pass (hermetic temp-repo tests)
+- `pnpm test` (full workspace) — green
+- Real-world verified earlier today via the same pattern (running the script's logic by hand corrected the parent state from 10 commits behind + core.bare=true to current main, no destruction)
+
+## Follow-up (deferred)
+- Identify which editor extension flips `core.bare` back (operator-machine-specific; not in any committed file per grep)
+- Optionally: add the same self-heal to a daily cron via GitHub Action (low priority; the per-dispatch invocation handles the common case)
+<!-- SECTION:FINAL_SUMMARY:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+## Summary
+Three pieces of orchestrator-state hardening shipped: a `scripts/check-orchestrator-state.sh` self-heal script (auto-corrects core.bare, syncs parent main, never destroys dirty work), a husky `post-rewrite` hook that updates the parent's main ref after every worktree rebase, and `.gitignore` defensive add for `.worktrees/`. Step 0 of `/ai-sdlc execute` invokes the new script before the worktree sweep.
+
+## Changes
+- `scripts/check-orchestrator-state.sh` (new) — bare-correction + fetch + reset-if-clean / warn-if-dirty
+- `scripts/check-orchestrator-state.test.mjs` (new) — 8 hermetic tests covering all branches
+- `.husky/post-rewrite` (new) — non-blocking parent main-ref update after worktree rebase
+- `.gitignore` — added `.worktrees/`
+- `ai-sdlc-plugin/commands/execute.md` — Step 0 invokes the new script first
+- `package.json` — wired `test:orchestrator-state-gate` into `pnpm test`
+
+## Design decisions
+- Reset --hard ONLY when working tree is clean (operator-protective; never destroy in-progress work). Dirty = warn + skip with file list.
+- `reset --hard origin/main` instead of `update-ref + reset HEAD` — single op, atomic, also moves refs/heads/main since HEAD is the symref.
+- post-rewrite uses `git -C parent update-ref` non-blocking — failures log but don't fail the rebase.
+- Untracked files always preserved by reset --hard (only touches tracked files).
+
+## Verification
+- `pnpm test:orchestrator-state-gate` — 8/8 pass
+- `pnpm test` — green
+- Real-world verified earlier today: same script logic corrected the parent state from 10-commits-behind + core.bare=true to current main without destruction
+
+## Follow-up (deferred)
+- Identify which editor extension flips core.bare back (operator-machine-specific; not in any committed file per grep)
+- Optionally: daily cron via GH Action (low priority; per-dispatch handles common case)
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "typecheck": "pnpm -r --parallel exec tsc --noEmit",
     "build": "pnpm -r build",
-    "test": "pnpm -r test && pnpm docs:test && pnpm docs:check && pnpm test:publishable && pnpm rfc:test && pnpm rfc:check && pnpm test:drift-gate && pnpm test:attestation-sign-gate",
+    "test": "pnpm -r test && pnpm docs:test && pnpm docs:check && pnpm test:publishable && pnpm rfc:test && pnpm rfc:check && pnpm test:drift-gate && pnpm test:attestation-sign-gate && pnpm test:orchestrator-state-gate",
     "test:coverage": "pnpm -r test:coverage",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -27,6 +27,7 @@
     "test:publishable": "node --test scripts/check-publishable-package-configs.test.mjs",
     "test:drift-gate": "node --test scripts/check-backlog-drift.test.mjs",
     "test:attestation-sign-gate": "node --test scripts/check-attestation-sign.test.mjs",
+    "test:orchestrator-state-gate": "node --test scripts/check-orchestrator-state.test.mjs",
     "rfc:check": "node scripts/check-rfc-docs.mjs",
     "rfc:test": "node --test scripts/check-rfc-docs.test.mjs",
     "prepare": "husky"

--- a/scripts/check-orchestrator-state.sh
+++ b/scripts/check-orchestrator-state.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# AISDLC-137: orchestrator-repo state hardening.
+#
+# Idempotent self-heal for the parent repo's bare-flag + main-branch staleness.
+# Runs at the start of every /ai-sdlc execute dispatch (Step 0) so the
+# orchestrator state is correct before any worktree is created.
+#
+# Pattern C contract (memory: project_orchestrator_repo_layout.md):
+#   - Parent dir = non-bare, has main checked out
+#   - Parent's working tree on main is READ-ONLY by contract
+#   - All edits happen in .worktrees/<task-id>/
+#
+# Because parent is read-only, it's safe to git-reset --hard to origin/main
+# whenever a sync is needed — but only when the working tree is verifiably
+# clean. If the operator (or a tool) has uncommitted modifications, abort
+# with a clear warning and let them resolve manually.
+#
+# Skip with: AI_SDLC_SKIP_ORCHESTRATOR_STATE_CHECK=1
+
+set -euo pipefail
+
+if [ "${AI_SDLC_SKIP_ORCHESTRATOR_STATE_CHECK:-}" = "1" ]; then
+  echo "[orchestrator-state] skipped (AI_SDLC_SKIP_ORCHESTRATOR_STATE_CHECK=1)"
+  exit 0
+fi
+
+# Resolve the parent (orchestrator) repo root. May be invoked from any
+# worktree; the common .git dir's parent is the orchestrator root.
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
+if [ -z "$GIT_COMMON_DIR" ]; then
+  echo "[orchestrator-state] not in a git repo; skipping"
+  exit 0
+fi
+
+# Make the path absolute (it may be `.git` when invoked from the parent itself,
+# or an absolute path to .git when invoked from a worktree).
+GIT_COMMON_DIR_ABS=$(cd "$GIT_COMMON_DIR" 2>/dev/null && pwd)
+if [ -z "$GIT_COMMON_DIR_ABS" ]; then
+  echo "[orchestrator-state] cannot resolve git-common-dir; skipping"
+  exit 0
+fi
+
+PARENT_ROOT=$(dirname "$GIT_COMMON_DIR_ABS")
+cd "$PARENT_ROOT"
+
+# 1. Auto-correct core.bare if it's true. Some local editor extensions / tools
+#    flip this back periodically; we re-correct it on every dispatch.
+BARE=$(git config --get core.bare 2>/dev/null || echo "false")
+if [ "$BARE" = "true" ]; then
+  echo "[orchestrator-state] WARN: core.bare=true detected; auto-correcting to false"
+  git config core.bare false
+  # When transitioning from bare→non-bare, we also need HEAD pointing at main
+  # so the working tree can be materialized.
+  git symbolic-ref HEAD refs/heads/main 2>/dev/null || true
+fi
+
+# 2. Fetch latest main + update the local main ref. update-ref is atomic;
+#    failures (network, etc.) leave the previous ref intact.
+if ! git fetch --quiet origin main 2>/dev/null; then
+  echo "[orchestrator-state] WARN: git fetch origin main failed; skipping sync"
+  exit 0
+fi
+
+ORIGIN_MAIN=$(git rev-parse refs/remotes/origin/main 2>/dev/null || echo "")
+HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || echo "")
+
+if [ -z "$ORIGIN_MAIN" ]; then
+  echo "[orchestrator-state] WARN: cannot resolve origin/main; skipping sync"
+  exit 0
+fi
+
+# Already up-to-date — nothing to do.
+if [ "$HEAD_SHA" = "$ORIGIN_MAIN" ]; then
+  exit 0
+fi
+
+# 3. Sync needed. Check working tree cleanliness BEFORE any destructive op.
+#    "Clean" = no tracked files modified/staged/deleted. Untracked files are
+#    allowed (reset --hard preserves them) — they include .worktrees/ +
+#    in-flight backlog task drafts.
+DIRTY_TRACKED=$(git status --porcelain 2>/dev/null | grep -vE "^\?\?" | head -1 || true)
+if [ -n "$DIRTY_TRACKED" ]; then
+  echo "[orchestrator-state] WARN: parent working tree has uncommitted tracked changes; skipping reset"
+  echo "[orchestrator-state]       ${PARENT_ROOT}"
+  git status --porcelain | grep -vE "^\?\?" | head -10 | sed 's/^/[orchestrator-state]         /'
+  echo "[orchestrator-state] Resolve manually: stash, commit, or discard. Then re-run."
+  exit 0
+fi
+
+# Reset HEAD + working tree in one op (also moves refs/heads/main since HEAD
+# is the symref pointing at it). Untracked files survive.
+echo "[orchestrator-state] resetting parent working tree: $HEAD_SHA -> $ORIGIN_MAIN"
+git reset --hard "$ORIGIN_MAIN" >/dev/null
+echo "[orchestrator-state] parent now at $(git rev-parse --short HEAD)"
+
+exit 0

--- a/scripts/check-orchestrator-state.test.mjs
+++ b/scripts/check-orchestrator-state.test.mjs
@@ -1,0 +1,185 @@
+// AISDLC-137: hermetic tests for scripts/check-orchestrator-state.sh.
+//
+// Each test sets up a temp git repo + tmp "remote" repo + invokes the script
+// via execFileSync, asserting exit code + post-state. Mirrors the pattern in
+// check-attestation-sign.test.mjs / check-coverage.sh tests.
+
+import { describe, it, before, after, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(__dirname, 'check-orchestrator-state.sh');
+
+function sh(cmd, opts = {}) {
+  return execFileSync('bash', ['-c', cmd], { encoding: 'utf8', ...opts }).trim();
+}
+
+function setupRepoPair() {
+  const root = mkdtempSync(join(tmpdir(), 'ai-sdlc-orchestrator-state-'));
+  const remote = join(root, 'remote.git');
+  const local = join(root, 'local');
+  mkdirSync(remote);
+  mkdirSync(local);
+
+  // Init bare remote
+  sh(`git init --bare -b main "${remote}"`);
+
+  // Init local + first commit on main
+  sh(`git init -b main "${local}"`);
+  sh(`git -C "${local}" config user.email t@t.t && git -C "${local}" config user.name t`);
+  sh(`git -C "${local}" config commit.gpgsign false`);
+  writeFileSync(join(local, 'README.md'), 'initial\n');
+  sh(`git -C "${local}" add README.md && git -C "${local}" commit -q -m initial`);
+  sh(`git -C "${local}" remote add origin "${remote}"`);
+  sh(`git -C "${local}" push -q -u origin main`);
+
+  return { root, remote, local };
+}
+
+function runScript(cwd, env = {}) {
+  try {
+    const out = execFileSync('bash', [SCRIPT], {
+      cwd,
+      env: { ...process.env, ...env },
+      encoding: 'utf8',
+    });
+    return { status: 0, stdout: out, stderr: '' };
+  } catch (e) {
+    return {
+      status: e.status ?? 1,
+      stdout: (e.stdout ?? '').toString(),
+      stderr: (e.stderr ?? '').toString(),
+    };
+  }
+}
+
+describe('check-orchestrator-state.sh', () => {
+  let env;
+
+  beforeEach(() => {
+    env = setupRepoPair();
+  });
+
+  afterEach(() => {
+    rmSync(env.root, { recursive: true, force: true });
+  });
+
+  it('no-op on clean state with main already current', () => {
+    const r = runScript(env.local);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    // No reset / no update messages expected
+    assert.ok(!r.stdout.includes('resetting parent working tree'));
+    assert.ok(!r.stdout.includes('updating refs/heads/main'));
+  });
+
+  it('auto-corrects core.bare=true to false', () => {
+    sh(`git -C "${env.local}" config core.bare true`);
+    const r = runScript(env.local);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(r.stdout, /core\.bare=true detected; auto-correcting/);
+    assert.equal(sh(`git -C "${env.local}" config --get core.bare`), 'false');
+  });
+
+  it('updates refs/heads/main when origin/main has moved', () => {
+    // Simulate sibling commit on the remote by cloning, committing, pushing
+    const sibling = join(env.root, 'sibling');
+    sh(`git clone -q "${env.remote}" "${sibling}"`);
+    sh(`git -C "${sibling}" config user.email s@s.s && git -C "${sibling}" config user.name s`);
+    sh(`git -C "${sibling}" config commit.gpgsign false`);
+    writeFileSync(join(sibling, 'sibling.txt'), 'sibling\n');
+    sh(`git -C "${sibling}" add sibling.txt && git -C "${sibling}" commit -q -m sibling`);
+    sh(`git -C "${sibling}" push -q origin main`);
+
+    const beforeMain = sh(`git -C "${env.local}" rev-parse refs/heads/main`);
+
+    const r = runScript(env.local);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    // reset --hard implicitly moves refs/heads/main since HEAD is the symref
+    assert.match(r.stdout, /resetting parent working tree/);
+
+    // refs/heads/main should now match origin/main
+    const afterMain = sh(`git -C "${env.local}" rev-parse refs/heads/main`);
+    const originMain = sh(`git -C "${env.local}" rev-parse refs/remotes/origin/main`);
+    assert.equal(afterMain, originMain);
+    assert.notEqual(beforeMain, afterMain);
+
+    // Working tree updated — sibling.txt should now exist
+    assert.ok(existsSync(join(env.local, 'sibling.txt')));
+  });
+
+  it('aborts gracefully when working tree has uncommitted tracked changes', () => {
+    // Move origin/main forward so the script needs to sync (otherwise it
+    // short-circuits as already-up-to-date before reaching the dirty check).
+    const sibling = join(env.root, 'sibling-dirty');
+    sh(`git clone -q "${env.remote}" "${sibling}"`);
+    sh(`git -C "${sibling}" config user.email s@s.s && git -C "${sibling}" config user.name s`);
+    sh(`git -C "${sibling}" config commit.gpgsign false`);
+    writeFileSync(join(sibling, 'sibling.txt'), 'sibling\n');
+    sh(`git -C "${sibling}" add sibling.txt && git -C "${sibling}" commit -q -m sibling`);
+    sh(`git -C "${sibling}" push -q origin main`);
+
+    // NOW dirty the local tracked file
+    writeFileSync(join(env.local, 'README.md'), 'modified\n');
+
+    const r = runScript(env.local);
+    // Exit 0 (gracefully skip), don't fail the script
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(r.stdout, /uncommitted tracked changes; skipping reset/);
+    assert.match(r.stdout, /Resolve manually/);
+
+    // README.md must NOT be reverted
+    assert.equal(sh(`cat "${join(env.local, 'README.md')}"`), 'modified');
+  });
+
+  it('skips entire check when AI_SDLC_SKIP_ORCHESTRATOR_STATE_CHECK=1', () => {
+    sh(`git -C "${env.local}" config core.bare true`);
+    const r = runScript(env.local, { AI_SDLC_SKIP_ORCHESTRATOR_STATE_CHECK: '1' });
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /skipped/);
+    // core.bare should NOT have been corrected
+    assert.equal(sh(`git -C "${env.local}" config --get core.bare`), 'true');
+  });
+
+  it('idempotent: second invocation is a no-op', () => {
+    // First invocation may do work; second should be silent
+    runScript(env.local);
+    const r2 = runScript(env.local);
+    assert.equal(r2.status, 0);
+    assert.ok(!r2.stdout.includes('resetting parent working tree'));
+    assert.ok(!r2.stdout.includes('updating refs/heads/main'));
+    assert.ok(!r2.stdout.includes('auto-correcting'));
+  });
+
+  it('handles fetch failure gracefully (no remote)', () => {
+    // Remove the origin remote so fetch fails
+    sh(`git -C "${env.local}" remote remove origin`);
+    const r = runScript(env.local);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(r.stdout, /git fetch origin main failed/);
+  });
+
+  it('allows untracked files in the parent (does not block reset)', () => {
+    // Add untracked file (simulates .worktrees/ or in-flight task draft)
+    writeFileSync(join(env.local, 'untracked.txt'), 'untracked\n');
+
+    // Move main forward to force a reset
+    const sibling = join(env.root, 'sibling');
+    sh(`git clone -q "${env.remote}" "${sibling}"`);
+    sh(`git -C "${sibling}" config user.email s@s.s && git -C "${sibling}" config user.name s`);
+    sh(`git -C "${sibling}" config commit.gpgsign false`);
+    writeFileSync(join(sibling, 'sibling.txt'), 'sibling\n');
+    sh(`git -C "${sibling}" add sibling.txt && git -C "${sibling}" commit -q -m sibling`);
+    sh(`git -C "${sibling}" push -q origin main`);
+
+    const r = runScript(env.local);
+    assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+    assert.match(r.stdout, /resetting parent working tree/);
+    // Untracked file must SURVIVE the reset
+    assert.ok(existsSync(join(env.local, 'untracked.txt')), 'untracked file should survive reset');
+  });
+});


### PR DESCRIPTION
## Summary
Closes the recurring orchestrator-state issues ("main 10↓" stale local main, `fatal: this operation must be run in a work tree` from `core.bare=true` flipping back, parent dir stale by 10+ commits). Self-heals on every `/ai-sdlc execute` dispatch + after every worktree rebase.

## Pattern C contract
Parent dir = non-bare with `main` checked out, **READ-ONLY by contract**. All edits happen in `.worktrees/<task-id>/`. This makes it safe to `git reset --hard origin/main` on the parent because nobody edits there directly. Saved as memory `project_orchestrator_repo_layout.md`.

## What changed
- `scripts/check-orchestrator-state.sh` (new) — auto-corrects `core.bare=true → false`, fetches origin/main, resets parent working tree if clean / warns + skips if dirty (operator-protective; never destroys WIP)
- `scripts/check-orchestrator-state.test.mjs` (new) — 8 hermetic temp-repo tests covering clean reset, dirty abort, bare correction, fetch failure, idempotency, untracked-file preservation, env-var skip
- `.husky/post-rewrite` (new) — non-blocking parent main-ref update after every worktree rebase
- `.gitignore` — added `.worktrees/` defensively
- `ai-sdlc-plugin/commands/execute.md` — Step 0 invokes the new script before the worktree sweep
- `package.json` — wired `test:orchestrator-state-gate` into `pnpm test`

## Verification
- `pnpm test:orchestrator-state-gate` — 8/8 pass
- Real-world: same logic corrected the parent state from 10-commits-behind + core.bare=true to current main without destruction (operator confirmed earlier today)

## Failure modes (intentional)
- Parent has uncommitted tracked changes → script logs warning + skips reset (does NOT clobber WIP)
- Network/fetch failure → script logs warning + exits cleanly
- Already up-to-date → silent no-op

## Why authored manually (not /ai-sdlc execute)
Pre-existing Hard Rule 5 + PreToolUse hook block edits to `.husky/`, so the developer subagent can't ship hooks. Operator authority granted.

References AISDLC-137, AISDLC-92 (ASCII filenames), memory `project_orchestrator_repo_layout.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)