### PR TITLE
fix(test): isolate init-workspace test from host git origin (AISDLC-134)

### DIFF
--- a/backlog/completed/aisdlc-134 - init-workspace.test.ts-falls-back-to-your-org-placeholder-is-git-origin-sensitive-fails-inside-any-worktree-with-a-real-origin.md
+++ b/backlog/completed/aisdlc-134 - init-workspace.test.ts-falls-back-to-your-org-placeholder-is-git-origin-sensitive-fails-inside-any-worktree-with-a-real-origin.md
@@ -1,0 +1,53 @@
+---
+id: AISDLC-134
+title: >-
+  init-workspace.test.ts > 'falls back to your-org placeholder' is
+  git-origin-sensitive — fails inside any worktree with a real origin
+status: To Do
+assignee: []
+created_date: '2026-05-02 03:20'
+labels:
+  - test-isolation
+  - orchestrator
+  - flake
+  - follow-up
+dependencies: []
+references:
+  - orchestrator/src/cli/commands/init-workspace.test.ts
+  - orchestrator/src/cli/commands/git-remote.ts
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+**Caught during AISDLC-115.6 dispatch (PR #168).** The `init — single-repo (AISDLC-78 git-remote fallback) > falls back to your-org placeholder when git origin is missing` test in `orchestrator/src/cli/commands/init-workspace.test.ts` fails when executed from inside a git worktree that has a real `origin` remote configured.
+
+**Symptom:**
+```
+AssertionError: expected 'apiVersion: ai-sdlc.io/v1alpha1\nkind…' to contain 'org: your-org'
+- Expected: org: your-org
++ Received: ...config: org: ai-sdlc-framework
+```
+
+**Root cause:** the test exercises the "no git origin" fallback by relying on the test's working directory not having an origin. Inside `.worktrees/<task>/` (which is a real git worktree of this repo), the origin IS configured, so the function under test returns the real org instead of the `your-org` placeholder.
+
+**Impact:** every `/ai-sdlc execute` run that lands in a worktree fails the husky pre-push coverage gate on this test alone, forcing operators to skip the gate (`AI_SDLC_SKIP_COVERAGE_GATE=1`). This silently disables the rest of the gate for that push — a real regression elsewhere in the workspace would also slip through.
+
+**Fix candidates (decide in PR):**
+- A) Use `tmpdir()` + `git init` (no remote) inside the test's `beforeEach` so the test always sees a clean repo with no origin
+- B) Mock the git-remote resolver to deterministically return null for this test, regardless of cwd
+- C) Add a `process.env.AI_SDLC_FORCE_NO_ORIGIN=1` escape that the test sets, that the resolver checks first
+
+A is canonical — actually exercise the fallback path with realistic state. B is fragile (mocks drift from real behavior). C adds a test-only env var to production code.
+
+**Verification:** run the orchestrator test suite from `.worktrees/<any>/` and confirm `init-workspace.test.ts > falls back to your-org placeholder` passes without env-var skipping.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 init-workspace.test.ts > 'falls back to your-org placeholder' passes when run from inside a worktree with a configured origin
+- [ ] #2 Other init-workspace tests still pass (no regression on the happy-path test)
+- [ ] #3 No new test-only escape hatches added to production code in orchestrator/src/cli/commands/git-remote.ts (Option A or B preferred over C)
+- [ ] #4 pnpm test:coverage from a worktree completes without skipping the coverage gate
+<!-- AC:END -->

--- a/orchestrator/src/cli/commands/init-workspace.test.ts
+++ b/orchestrator/src/cli/commands/init-workspace.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, existsSync, rmSync, realpathSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -29,14 +29,23 @@ import { tmpdir } from 'node:os';
  * a valid repository, and on a developer laptop where the test is invoked
  * from inside the ai-sdlc-framework checkout, that walk-up silently
  * resolves to the host repo's origin and breaks the fallback assertion.
+ *
+ * AISDLC-134: belt-and-braces — also assert the `.git/config` file
+ * actually exists after init so a silently failing `git` (e.g. broken
+ * PATH, sandbox restrictions, exec returning code 0 without writing)
+ * surfaces here instead of as a confusing org-bleed assertion later.
  */
 function initBareRepo(dir: string): void {
   execSync('git init --quiet', { cwd: dir, stdio: 'ignore' });
+  if (!existsSync(join(dir, '.git', 'config'))) {
+    throw new Error(`initBareRepo: \`git init\` did not create .git/config in ${dir}`);
+  }
 }
 
 let tmpDir: string;
 let prevCwd: string;
 let prevHome: string | undefined;
+let prevCeiling: string | undefined;
 let consoleSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
@@ -46,6 +55,21 @@ beforeEach(() => {
   // in the real ~/.cursor on a developer laptop and contaminate output.
   prevHome = process.env.HOME;
   process.env.HOME = tmpDir;
+  // AISDLC-134: defense-in-depth against host-repo origin bleed when these
+  // tests run from inside a worktree whose `.git/config` has a real origin
+  // (e.g. /Users/.../ai-sdlc/.worktrees/<task>/). detectGitRemote already
+  // guards via `git -C <cwd> rev-parse --show-toplevel` (AISDLC-104), but
+  // that check only fires when `--show-toplevel` reports an ANCESTOR. If
+  // the production check is ever weakened or sidestepped, this ceiling pin
+  // ensures git physically cannot walk above the OS tmpdir to reach the
+  // host repo. Semantics: GIT_CEILING_DIRECTORIES blocks walk-up THROUGH
+  // (not into) listed dirs — pinning to the realpath of the OS tmpdir
+  // means git stops at the per-test mkdtemp dir rather than continuing
+  // up to the worktree root. realpath() is required because macOS aliases
+  // /tmp to /private/tmp and the per-test tmpdir is reported under the
+  // /private/var/... canonical form by git.
+  prevCeiling = process.env.GIT_CEILING_DIRECTORIES;
+  process.env.GIT_CEILING_DIRECTORIES = realpathSync(tmpdir());
   consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
   process.exitCode = undefined;
 });
@@ -54,6 +78,8 @@ afterEach(() => {
   process.chdir(prevCwd);
   if (prevHome === undefined) delete process.env.HOME;
   else process.env.HOME = prevHome;
+  if (prevCeiling === undefined) delete process.env.GIT_CEILING_DIRECTORIES;
+  else process.env.GIT_CEILING_DIRECTORIES = prevCeiling;
   rmSync(tmpDir, { recursive: true, force: true });
   consoleSpy.mockRestore();
   process.exitCode = undefined;


### PR DESCRIPTION
Closes the recurring coverage-gate flake that's been forcing `AI_SDLC_SKIP_COVERAGE_GATE=1` on every push today. Test-side defense-in-depth: pins `GIT_CEILING_DIRECTORIES` to OS tmpdir realpath per-test + asserts `.git/config` exists post-`git init`. No production changes.

## Verification
- 8/8 tests pass from worktree with real origin
- 3 reviews APPROVED — 0c/0M/0m/4s (⚠ INDEPENDENCE NOT ENFORCED)

References AISDLC-134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)