### PR TITLE
chore(docs): resolve 21 wildcard refs in completed task frontmatter (partial AISDLC-125)

### DIFF
--- a/backlog/completed/aisdlc-101 - Verifier-Phase-2-drop-diffHash-require-contentHash-bump-schema-v2.md
+++ b/backlog/completed/aisdlc-101 - Verifier-Phase-2-drop-diffHash-require-contentHash-bump-schema-v2.md
@@ -17,7 +17,7 @@ references:
   - scripts/ci-sign-attestation.mjs
   - orchestrator/src/runtime/attestations.ts
   - .ai-sdlc/schemas/attestation.v1.schema.json
-  - backlog/completed/aisdlc-94*
+  - backlog/completed/aisdlc-94 - Verifier-diffHash-should-be-rebase-tolerant-hash-post-apply-tree-state-not-literal-diff-text.md
 priority: medium
 ---
 

--- a/backlog/completed/aisdlc-102 - Pre-sign-rebase-conditional-re-review-lower-attestation-invalidation-rate.md
+++ b/backlog/completed/aisdlc-102 - Pre-sign-rebase-conditional-re-review-lower-attestation-invalidation-rate.md
@@ -13,8 +13,8 @@ labels:
   - pipeline
 dependencies: []
 references:
-  - backlog/completed/aisdlc-94*
-  - backlog/completed/aisdlc-93*
+  - backlog/completed/aisdlc-94 - Verifier-diffHash-should-be-rebase-tolerant-hash-post-apply-tree-state-not-literal-diff-text.md
+  - backlog/completed/aisdlc-93 - ai-sdlc-review.yml-skip-attestation-valid-path-must-re-post-bot-approval-after-force-push.md
   - spec/rfcs/RFC-0012-two-tier-pipeline-architecture.md
   - ai-sdlc-plugin/commands/execute.md
   - ai-sdlc-plugin/scripts/sign-attestation.mjs

--- a/backlog/completed/aisdlc-103 - Verifier-Phase-3-—-30-day-soak-then-drop-diffHash-contentHash-bump-schema-to-v3.md
+++ b/backlog/completed/aisdlc-103 - Verifier-Phase-3-—-30-day-soak-then-drop-diffHash-contentHash-bump-schema-to-v3.md
@@ -23,8 +23,8 @@ references:
   - scripts/ci-sign-attestation.mjs
   - orchestrator/src/runtime/attestations.ts
   - .ai-sdlc/schemas/attestation.v1.schema.json
-  - backlog/completed/aisdlc-94*
-  - backlog/completed/aisdlc-101*
+  - backlog/completed/aisdlc-94 - Verifier-diffHash-should-be-rebase-tolerant-hash-post-apply-tree-state-not-literal-diff-text.md
+  - backlog/completed/aisdlc-101 - Verifier-Phase-2-drop-diffHash-require-contentHash-bump-schema-v2.md
 priority: medium
 ---
 

--- a/backlog/completed/aisdlc-111 - ai-sdlc-review.yml-CI-attestor-re-sign-attestation-reliably-on-rebase.md
+++ b/backlog/completed/aisdlc-111 - ai-sdlc-review.yml-CI-attestor-re-sign-attestation-reliably-on-rebase.md
@@ -16,8 +16,8 @@ references:
   - scripts/ci-sign-attestation.mjs
   - .github/workflows/verify-attestation.yml
   - ai-sdlc-plugin/scripts/sign-attestation.mjs
-  - backlog/completed/aisdlc-87*
-  - backlog/completed/aisdlc-93*
+  - backlog/completed/aisdlc-87 - CI-side-attestor-GH-Action-signs-attestation-after-duplicate-review-approves-unblocks-remote-agents-external-contributor-PRs.md
+  - backlog/completed/aisdlc-93 - ai-sdlc-review.yml-skip-attestation-valid-path-must-re-post-bot-approval-after-force-push.md
 priority: high
 ---
 

--- a/backlog/completed/aisdlc-120 - Remove-redundant-agent-type-Stop-hook-from-ai-sdlc-plugin-plugin.json-AISDLC-108-follow-up.md
+++ b/backlog/completed/aisdlc-120 - Remove-redundant-agent-type-Stop-hook-from-ai-sdlc-plugin-plugin.json-AISDLC-108-follow-up.md
@@ -15,7 +15,7 @@ dependencies: []
 references:
   - ai-sdlc-plugin/plugin.json
   - .claude/settings.json
-  - backlog/completed/aisdlc-108*
+  - backlog/completed/aisdlc-108 - Delete-redundant-quality-gate-stop-Claude-hook-husky-pre-push-already-gates-verification.md
 priority: medium
 ---
 

--- a/backlog/completed/aisdlc-90 - Fix-execute-orchestrator-agent-frontmatter-Task-Agent-rename-MCP-namespace.md
+++ b/backlog/completed/aisdlc-90 - Fix-execute-orchestrator-agent-frontmatter-Task-Agent-rename-MCP-namespace.md
@@ -15,7 +15,7 @@ references:
   - ai-sdlc-plugin/.claude-plugin/plugin.json
   - ai-sdlc-plugin/agents/developer.md
   - ai-sdlc-plugin/agents/agents.test.mjs
-  - backlog/completed/aisdlc-82*
+  - backlog/completed/aisdlc-82 - Refactor-ai-sdlc-execute-to-a-self-contained-orchestrator-subagent-so-parallel-runs-are-first-class.md
 priority: high
 ---
 

--- a/backlog/completed/aisdlc-91 - Plugin-agents-cannot-spawn-nested-Agent-calls-deeper-than-Grep-Glob-filter.md
+++ b/backlog/completed/aisdlc-91 - Plugin-agents-cannot-spawn-nested-Agent-calls-deeper-than-Grep-Glob-filter.md
@@ -18,7 +18,7 @@ references:
   - /Users/dominique/Documents/dev/ai-sdlc/claude-code/src/constants/tools.ts
   - /Users/dominique/Documents/dev/ai-sdlc/claude-code/src/loadPluginAgents.ts
   - ai-sdlc-plugin/agents/execute-orchestrator.md
-  - backlog/tasks/aisdlc-90 - *
+  - backlog/completed/aisdlc-90 - Fix-execute-orchestrator-agent-frontmatter-Task-Agent-rename-MCP-namespace.md
 priority: high
 ---
 

--- a/backlog/completed/aisdlc-92 - Verifier-core.quotepath-backlog-tool-ASCII-filename-sanitization.md
+++ b/backlog/completed/aisdlc-92 - Verifier-core.quotepath-backlog-tool-ASCII-filename-sanitization.md
@@ -13,8 +13,8 @@ labels:
 dependencies: []
 references:
   - scripts/verify-attestation.mjs
-  - backlog/completed/aisdlc-85*
-  - backlog/completed/aisdlc-84*
+  - backlog/completed/aisdlc-85 - Verifier-compute-diffHash-from-envelope-subject-SHA-not-PR-head-chore-commit-on-top-regression-from-AISDLC-84.md
+  - backlog/completed/aisdlc-84 - Make-attestation-verifier-rebase-stable-—-match-by-predicate-content-not-by-commit-SHA.md
   - 'https://github.com/MrLesk/Backlog.md'
 priority: high
 ---

--- a/backlog/completed/aisdlc-93 - ai-sdlc-review.yml-skip-attestation-valid-path-must-re-post-bot-approval-after-force-push.md
+++ b/backlog/completed/aisdlc-93 - ai-sdlc-review.yml-skip-attestation-valid-path-must-re-post-bot-approval-after-force-push.md
@@ -16,9 +16,9 @@ dependencies: []
 references:
   - .github/workflows/ai-sdlc-review.yml
   - .github/workflows/auto-enable-auto-merge.yml
-  - backlog/completed/aisdlc-74*
-  - backlog/completed/aisdlc-84*
-  - backlog/completed/aisdlc-87*
+  - backlog/completed/aisdlc-74 - Cryptographic-review-attestations-skip-duplicate-CI-review-runs-when-local-ai-sdlc-execute-reviews-are-signed.md
+  - backlog/completed/aisdlc-84 - Make-attestation-verifier-rebase-stable-—-match-by-predicate-content-not-by-commit-SHA.md
+  - backlog/completed/aisdlc-87 - CI-side-attestor-GH-Action-signs-attestation-after-duplicate-review-approves-unblocks-remote-agents-external-contributor-PRs.md
 priority: high
 ---
 

--- a/backlog/completed/aisdlc-94 - Verifier-diffHash-should-be-rebase-tolerant-hash-post-apply-tree-state-not-literal-diff-text.md
+++ b/backlog/completed/aisdlc-94 - Verifier-diffHash-should-be-rebase-tolerant-hash-post-apply-tree-state-not-literal-diff-text.md
@@ -18,8 +18,8 @@ references:
   - scripts/sign-attestation.mjs
   - orchestrator/src/runtime/buildPredicate.ts
   - .ai-sdlc/schemas/attestation.v1.schema.json
-  - backlog/completed/aisdlc-84*
-  - backlog/completed/aisdlc-85*
+  - backlog/completed/aisdlc-84 - Make-attestation-verifier-rebase-stable-—-match-by-predicate-content-not-by-commit-SHA.md
+  - backlog/completed/aisdlc-85 - Verifier-compute-diffHash-from-envelope-subject-SHA-not-PR-head-chore-commit-on-top-regression-from-AISDLC-84.md
 priority: high
 ---
 

--- a/backlog/completed/aisdlc-97 - Investigate-why-publishConfig-was-lost-from-mcp-server-package.json-on-main.md
+++ b/backlog/completed/aisdlc-97 - Investigate-why-publishConfig-was-lost-from-mcp-server-package.json-on-main.md
@@ -17,7 +17,7 @@ references:
   - ai-sdlc-plugin/mcp-server/package.json
   - release-please-config.json
   - .release-please-manifest.json
-  - backlog/completed/aisdlc-75*
+  - backlog/completed/aisdlc-75 - Fix-ai-sdlc-plugin-distribution-mcp-server-ships-without-dist-node_modules-breaks-all-governance-hooks-on-cached-install.md
 priority: medium
 ---
 

--- a/backlog/completed/aisdlc-98 - Revert-AISDLC-82-—-move-ai-sdlc-execute-pipeline-back-inline-nested-Agent-calls-dont-work-in-plugin-agents.md
+++ b/backlog/completed/aisdlc-98 - Revert-AISDLC-82-—-move-ai-sdlc-execute-pipeline-back-inline-nested-Agent-calls-dont-work-in-plugin-agents.md
@@ -17,8 +17,8 @@ references:
   - ai-sdlc-plugin/commands/execute.md
   - ai-sdlc-plugin/commands/execute.test.mjs
   - ai-sdlc-plugin/agents/agents.test.mjs
-  - backlog/completed/aisdlc-82*
-  - backlog/completed/aisdlc-90*
+  - backlog/completed/aisdlc-82 - Refactor-ai-sdlc-execute-to-a-self-contained-orchestrator-subagent-so-parallel-runs-are-first-class.md
+  - backlog/completed/aisdlc-90 - Fix-execute-orchestrator-agent-frontmatter-Task-Agent-rename-MCP-namespace.md
   - CLAUDE.md
 priority: high
 ---

--- a/backlog/completed/aisdlc-99 - mcp__plugin_ai-sdlc_ai-sdlc__task_edit-complete-hardcoded-to-wrong-backlog-root.md
+++ b/backlog/completed/aisdlc-99 - mcp__plugin_ai-sdlc_ai-sdlc__task_edit-complete-hardcoded-to-wrong-backlog-root.md
@@ -17,7 +17,7 @@ references:
   - ai-sdlc-plugin/mcp-server/src/
   - ai-sdlc-plugin/.claude-plugin/plugin.json
   - ai-sdlc-plugin/mcp-server/dist/bin.js
-  - backlog/completed/aisdlc-83*
+  - backlog/completed/aisdlc-83 - Wire-ai-sdlc-execute-and-other-commands-to-use-mcp__ai-sdlc-plugin__task_edit-task_complete-instead-of-upstream.md
 priority: high
 ---
 


### PR DESCRIPTION
## Summary
Resolves 21 wildcard `references:` entries (e.g. `backlog/completed/aisdlc-82*`) across 13 task files in `backlog/completed/` to their full filenames. Drops backlog-drift error count from **68 → 47** (-21, ~31% of AISDLC-125's outstanding sweep).

Pure markdown frontmatter; no code/schema/CI surfaces touched. Partial slice of the larger AISDLC-125 cleanup — **does NOT close the parent task**; the remaining ~47 errors continue separately.

## Why now
Today's CI/CD investigation found these wildcard refs were the largest fast-fixable slice of AISDLC-125's drift errors. The `backlog-drift fix` tool DELETES wildcard refs instead of resolving them (verified — would destroy historical provenance), so manual edits required.

## Files changed
13 task frontmatter files in `backlog/completed/` (aisdlc-{90,91,92,93,94,97,98,99,101,102,103,111,120}). No multi-match ambiguity — each wildcard prefix matched exactly one file in the directory.

## Verification
- pnpm build / test / lint / format:check — all pass (no-op for markdown)
- `npx backlog-drift check` — errors 68 → 47 confirmed
- AISDLC-136 fallback workflow will post `Post Review Results: success` for this docs-only PR

## Authoring note
Dev subagent reported it had no MCP tools to file a separate `partial-aisdlc-125-wildcards` backlog task — this PR is the canonical record per the dev's note. The parent AISDLC-125 task remains open for the larger sweep.

References AISDLC-125, today's CI/CD investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)