### PR TITLE
feat(deps): incremental review — only re-review the diff since last approval (AISDLC-142)

### DIFF
--- a/.github/workflows/ai-sdlc-review.yml
+++ b/.github/workflows/ai-sdlc-review.yml
@@ -39,7 +39,11 @@ jobs:
     name: Analyze PR
     runs-on: ubuntu-latest
     if: "!startsWith(github.head_ref, 'release-please--')"
-    permissions: {} # Fully sandboxed — no GitHub access
+    # AISDLC-142: analyze needs `pull-requests: read` to fetch existing PR
+    # comments for the incremental-review marker. Read-only — write happens
+    # in the `report` job (which already has `pull-requests: write`).
+    permissions:
+      pull-requests: read
     outputs:
       testing: ${{ steps.review.outputs.testing }}
       critic: ${{ steps.review.outputs.critic }}
@@ -50,6 +54,14 @@ jobs:
       classifier_selected: ${{ steps.classify.outputs.selected }}
       classifier_confidence: ${{ steps.classify.outputs.confidence }}
       classifier_fell_open: ${{ steps.classify.outputs.fell_open }}
+      # AISDLC-142: incremental-review decision so the report job can update
+      # the marker comment after posting the verdicts.
+      incremental_skip: ${{ steps.incremental.outputs.skip }}
+      incremental_delta_only: ${{ steps.incremental.outputs.delta_only }}
+      incremental_reason: ${{ steps.incremental.outputs.reason }}
+      incremental_content_hash: ${{ steps.incremental.outputs.content_hash }}
+      incremental_last_reviewed_sha: ${{ steps.incremental.outputs.last_reviewed_sha }}
+      incremental_delta_size: ${{ steps.incremental.outputs.delta_size }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -126,6 +138,83 @@ jobs:
       - name: Create empty issue file if not fetched
         run: test -f /tmp/linked-issue.json || echo '{}' > /tmp/linked-issue.json
 
+      # ── AISDLC-142: incremental review gate ─────────────────────────
+      # Read the prior `<!-- ai-sdlc:last-reviewed-contenthash:... -->` marker
+      # comment (if any) and decide whether to:
+      #   - SKIP the review (contentHash unchanged since prior approval)
+      #   - DELTA-ONLY review (`git diff <last-reviewed-sha>...HEAD`)
+      #   - FULL review (first push, no marker, or delta over the safety cap)
+      # The CLI is fail-open in the same shape as cli-classify-pr: any error
+      # routes to FULL review so we never silently skip a review we should
+      # have done.
+      - name: Decide incremental review mode
+        id: incremental
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Fetch existing PR comments. Empty file when we can't / no comments.
+          gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' \
+            > /tmp/pr-comments.txt 2>/dev/null || : > /tmp/pr-comments.txt
+
+          # Extract prior reviewedSha from the marker (if any) so we can
+          # compute the delta numstat against it. Failure is fine — empty
+          # PRIOR_SHA → no numstat → CLI takes the no-marker / full path.
+          PRIOR_SHA=$(grep -oE '<!-- ai-sdlc:last-reviewed-contenthash:[A-Za-z0-9_-]+ -->' /tmp/pr-comments.txt 2>/dev/null \
+            | tail -1 \
+            | sed -E 's/.*contenthash:([A-Za-z0-9_-]+) -->/\1/' \
+            | { read B64 && [ -n "$B64" ] && printf '%s' "$B64" \
+                | base64 -d 2>/dev/null \
+                | jq -r '.reviewedSha' 2>/dev/null; } || echo "")
+
+          : > /tmp/pr-delta-numstat.txt
+          if [ -n "$PRIOR_SHA" ]; then
+            # If PRIOR_SHA isn't reachable (rebase rewrote history), the diff
+            # silently fails and the CLI routes to delta-too-large → FULL.
+            git diff "$PRIOR_SHA"...HEAD --numstat > /tmp/pr-delta-numstat.txt 2>/dev/null \
+              || : > /tmp/pr-delta-numstat.txt
+          fi
+
+          INCREMENTAL_JSON=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-incremental-decide decide \
+            --comments-file /tmp/pr-comments.txt \
+            --base-ref "${{ github.event.pull_request.base.sha }}" \
+            --head-ref HEAD \
+            --repo-root . \
+            --numstat-file /tmp/pr-delta-numstat.txt \
+            --full-diff-paths-file /tmp/pr-files.txt 2>/tmp/incremental-stderr.txt \
+            || echo '{"skip":false,"deltaOnly":false,"reason":"no-marker","currentContentHash":"","priorContentHash":null,"lastReviewedSha":null,"deltaSize":0}')
+          if [ -s /tmp/incremental-stderr.txt ]; then
+            echo "::group::incremental-decide stderr"
+            cat /tmp/incremental-stderr.txt
+            echo "::endgroup::"
+          fi
+
+          SKIP=$(printf '%s' "$INCREMENTAL_JSON" | jq -r '.skip')
+          DELTA_ONLY=$(printf '%s' "$INCREMENTAL_JSON" | jq -r '.deltaOnly')
+          REASON=$(printf '%s' "$INCREMENTAL_JSON" | jq -r '.reason')
+          CONTENT_HASH=$(printf '%s' "$INCREMENTAL_JSON" | jq -r '.currentContentHash')
+          LAST_SHA=$(printf '%s' "$INCREMENTAL_JSON" | jq -r '.lastReviewedSha // ""')
+          DELTA_SIZE=$(printf '%s' "$INCREMENTAL_JSON" | jq -r '.deltaSize')
+          echo "skip=${SKIP}" >> "$GITHUB_OUTPUT"
+          echo "delta_only=${DELTA_ONLY}" >> "$GITHUB_OUTPUT"
+          echo "reason=${REASON}" >> "$GITHUB_OUTPUT"
+          echo "content_hash=${CONTENT_HASH}" >> "$GITHUB_OUTPUT"
+          echo "last_reviewed_sha=${LAST_SHA}" >> "$GITHUB_OUTPUT"
+          echo "delta_size=${DELTA_SIZE}" >> "$GITHUB_OUTPUT"
+          echo "Incremental decision: ${REASON} (skip=${SKIP}, deltaOnly=${DELTA_ONLY}, deltaSize=${DELTA_SIZE}, lastReviewedSha=${LAST_SHA:-none})"
+
+          # Build the actual review-input file the next step uses. Skip path:
+          # empty file (review step writes auto-approved verdicts directly).
+          # Delta path: `git diff <prior-sha>...HEAD`. Full path: copy /tmp/pr-diff.txt.
+          if [ "$SKIP" = "true" ]; then
+            : > /tmp/review-diff.txt
+          elif [ "$DELTA_ONLY" = "true" ] && [ -n "$LAST_SHA" ]; then
+            git diff "$LAST_SHA"...HEAD > /tmp/review-diff.txt 2>/dev/null \
+              || cp /tmp/pr-diff.txt /tmp/review-diff.txt
+          else
+            cp /tmp/pr-diff.txt /tmp/review-diff.txt
+          fi
+
       - name: Run conditional review agents (classifier-gated subset)
         id: review
         env:
@@ -137,13 +226,41 @@ jobs:
           # 0 files changed) — we treat un-selected reviewers as auto-approved
           # with empty findings so the report job's gate logic stays unchanged.
           SELECTED: ${{ steps.classify.outputs.selected }}
+          # AISDLC-142: incremental gate decision. When SKIP=true we spawn 0
+          # reviewers (auto-approved with the prior-approval-reused summary).
+          # When DELTA_ONLY=true the review reads /tmp/review-diff.txt
+          # (computed by the `incremental` step) instead of /tmp/pr-diff.txt.
+          INCR_SKIP: ${{ steps.incremental.outputs.skip }}
+          INCR_DELTA_ONLY: ${{ steps.incremental.outputs.delta_only }}
+          INCR_LAST_SHA: ${{ steps.incremental.outputs.last_reviewed_sha }}
+          INCR_DELTA_SIZE: ${{ steps.incremental.outputs.delta_size }}
         run: |
-          # Helper: spawn the dogfood reviewer for $TYPE in background.
+          # Helper: spawn the dogfood reviewer for $TYPE in background. Reads
+          # from /tmp/review-diff.txt — that file holds the FULL PR diff
+          # (default), the DELTA diff (incremental delta-only), or is empty
+          # (incremental skip). When delta-only, prepend a preamble so the
+          # reviewer knows the prior full review still binds.
           run_review() {
             local TYPE="$1"
+            local DIFF_FILE=/tmp/review-diff.txt
+            if [ "$INCR_DELTA_ONLY" = "true" ]; then
+              DIFF_FILE="/tmp/review-diff-${TYPE}.txt"
+              {
+                echo "## INCREMENTAL REVIEW (AISDLC-142)"
+                echo ""
+                echo "The FULL PR diff was reviewed earlier at SHA ${INCR_LAST_SHA}."
+                echo "This incremental review only covers the delta from ${INCR_LAST_SHA} to HEAD"
+                echo "(${INCR_DELTA_SIZE} lines). Your verdict still applies to the WHOLE PR — only"
+                echo "the diff you read is scoped down."
+                echo ""
+                echo "## DELTA DIFF"
+                echo ""
+                cat /tmp/review-diff.txt
+              } > "$DIFF_FILE"
+            fi
             pnpm --filter @ai-sdlc/dogfood review \
               --pr "$PR_NUMBER" \
-              --diff-file /tmp/pr-diff.txt \
+              --diff-file "$DIFF_FILE" \
               --issue-file /tmp/linked-issue.json \
               --type "$TYPE" > "/tmp/review-${TYPE}.txt" 2>"/tmp/review-${TYPE}-stderr.txt"
           }
@@ -152,6 +269,29 @@ jobs:
           # The schema must match what dogfood produces so the report job's
           # parser accepts it as a valid verdict.
           AUTO_APPROVED='{"approved":true,"findings":[],"summary":"Skipped by classifier (RFC-0010 §12) — change does not require this review type."}'
+
+          # AISDLC-142: when the incremental gate says SKIP, write the
+          # incremental auto-approved verdict for EVERY reviewer (whether or
+          # not the classifier selected them). The report job's gate
+          # semantics stay unchanged — three approved verdicts → APPROVE.
+          if [ "$INCR_SKIP" = "true" ]; then
+            INCR_AUTO_APPROVED=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-incremental-decide auto-approved-verdict \
+              --reviewed-sha "$INCR_LAST_SHA" 2>/dev/null \
+              || printf '%s' '{"approved":true,"findings":[],"summary":"Skipped by incremental review (AISDLC-142) — content unchanged."}')
+            for TYPE in testing critic security; do
+              printf '%s\n' "$INCR_AUTO_APPROVED" > "/tmp/review-${TYPE}.txt"
+              : > "/tmp/review-${TYPE}-stderr.txt"
+              echo "Incremental SKIP: writing auto-approved verdict for $TYPE (no reviewer agent invoked)"
+            done
+            # Skip the classifier-spawn loop entirely.
+            TESTING=$(tail -1 /tmp/review-testing.txt 2>/dev/null || echo '{}')
+            CRITIC=$(tail -1 /tmp/review-critic.txt 2>/dev/null || echo '{}')
+            SECURITY=$(tail -1 /tmp/review-security.txt 2>/dev/null || echo '{}')
+            echo "testing=$TESTING" >> "$GITHUB_OUTPUT"
+            echo "critic=$CRITIC" >> "$GITHUB_OUTPUT"
+            echo "security=$SECURITY" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           # Spawn each reviewer iff in $SELECTED; otherwise write the
           # auto-approved verdict directly. This preserves the existing
@@ -450,6 +590,97 @@ jobs:
               } else {
                 throw err;
               }
+            }
+
+      # ── AISDLC-142: update the incremental-review marker ─────────────
+      # Idempotent upsert of the `<!-- ai-sdlc:last-reviewed-contenthash:... -->`
+      # PR comment. Only fires when ALL reviewers approved (contentHash binds
+      # to APPROVED states only — never to CHANGES_REQUESTED). Best-effort:
+      # marker write failure at worst forces the next push back through a
+      # FULL review; never a SAFETY regression.
+      - name: Update incremental-review marker
+        if: always() && needs.analyze.result == 'success' && needs.analyze.outputs.incremental_content_hash != ''
+        uses: actions/github-script@v7
+        env:
+          TESTING_JSON: ${{ needs.analyze.outputs.testing }}
+          CRITIC_JSON: ${{ needs.analyze.outputs.critic }}
+          SECURITY_JSON: ${{ needs.analyze.outputs.security }}
+          INCR_CONTENT_HASH: ${{ needs.analyze.outputs.incremental_content_hash }}
+        with:
+          script: |
+            // Verify all three reviewers approved before binding the marker.
+            // A marker bound to a CHANGES_REQUESTED state would silently
+            // suppress the next push's review.
+            let allApproved = true;
+            for (const key of ['TESTING_JSON', 'CRITIC_JSON', 'SECURITY_JSON']) {
+              try {
+                const v = JSON.parse(process.env[key] || '{}');
+                if (!v.approved) allApproved = false;
+              } catch { allApproved = false; }
+            }
+            if (!allApproved) {
+              core.info('Skipping marker update — at least one reviewer did not approve.');
+              return;
+            }
+
+            const headSha = context.payload.pull_request.head.sha;
+            const contentHash = process.env.INCR_CONTENT_HASH;
+            if (!/^[0-9a-f]{64}$/.test(contentHash || '')) {
+              core.info(`Skipping marker update — invalid contentHash (${contentHash})`);
+              return;
+            }
+
+            const payload = {
+              contentHash,
+              reviewedSha: headSha.toLowerCase(),
+              reviewedAt: new Date().toISOString(),
+            };
+            const b64 = Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64url');
+            const marker = `<!-- ai-sdlc:last-reviewed-contenthash:${b64} -->`;
+            const body =
+              `## AI-SDLC: incremental review state\n\n` +
+              `_Auto-managed by \`ai-sdlc-review.yml\` (AISDLC-142). ` +
+              `Editing this comment will break incremental review for this PR ` +
+              `until the next full review re-creates it._\n\n` +
+              `${marker}\n`;
+
+            const issue_number = context.payload.pull_request.number;
+            // Idempotent: search existing comments for the marker prefix; update
+            // in place if found, else create new. Mirrors `dor-ingress.yml`.
+            const existing = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
+            const prior = existing.find(
+              (c) => c.body && c.body.includes('<!-- ai-sdlc:last-reviewed-contenthash:'),
+            );
+            try {
+              if (prior) {
+                if ((prior.body || '').includes(marker)) {
+                  core.info('Marker unchanged — no-op.');
+                  return;
+                }
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: prior.id,
+                  body,
+                });
+                core.notice(`Updated incremental-review marker comment ${prior.id} on PR #${issue_number}`);
+              } else {
+                const { data: created } = await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number,
+                  body,
+                });
+                core.notice(`Created incremental-review marker comment ${created.id} on PR #${issue_number}`);
+              }
+            } catch (err) {
+              // Best-effort: don't fail the workflow if the comment write fails.
+              core.warning(`Failed to upsert marker comment: ${err.message}`);
             }
 
       - name: Notify Slack that PR is ready for review

--- a/.github/workflows/ai-sdlc-review.yml
+++ b/.github/workflows/ai-sdlc-review.yml
@@ -153,9 +153,49 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Fetch existing PR comments. Empty file when we can't / no comments.
-          gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' \
-            > /tmp/pr-comments.txt 2>/dev/null || : > /tmp/pr-comments.txt
+          # ── AISDLC-142 round-2 CRITICAL fix ────────────────────────
+          # Fetch existing PR comments WITH author metadata, then filter to
+          # trusted authors at the jq boundary. The unfiltered version
+          # honored a forged `<!-- ai-sdlc:last-reviewed-contenthash:... -->`
+          # marker posted by ANY GitHub user (including external fork-PR
+          # contributors), letting them carry the publicly-computable
+          # current contentHash → CLI returns skip:true → CI skips all
+          # 3 reviewers → auto-approves → satisfies the required-merge-gate
+          # check. The author-filter below is the primary defense (Layer 1).
+          #
+          # Trust criteria (either gate is sufficient):
+          #   - login == "github-actions" (workflow-authored markers) OR
+          #     "ai-sdlc-ci-attestor" (CI-side attestor bot, AISDLC-87)
+          #   - authorAssociation in {OWNER, MEMBER, COLLABORATOR}
+          #     (push-access humans — they could write the marker via the
+          #     workflow itself; honoring their direct comment is no escalation)
+          #
+          # Note: GraphQL `gh pr view --json comments` returns author.login
+          # WITHOUT the [bot] suffix; the bot whitelist below matches that
+          # form. Layer 2 (defense-in-depth) is the in-CLI re-filter via
+          # --comments-json-file (`filterTrustedComments`).
+          gh pr view "$PR_NUMBER" --json comments --jq '
+            [
+              .comments[]
+              | select(
+                  .author.login == "github-actions"
+                  or .author.login == "ai-sdlc-ci-attestor"
+                  or .authorAssociation == "OWNER"
+                  or .authorAssociation == "MEMBER"
+                  or .authorAssociation == "COLLABORATOR"
+                )
+              | {
+                  authorLogin: .author.login,
+                  authorAssociation: .authorAssociation,
+                  body: .body
+                }
+            ]
+          ' > /tmp/pr-comments.json 2>/dev/null || echo '[]' > /tmp/pr-comments.json
+
+          # Bodies-only mirror for the PRIOR_SHA grep below (already
+          # author-filtered upstream — only trusted bodies make it here).
+          jq -r '.[].body' /tmp/pr-comments.json > /tmp/pr-comments.txt 2>/dev/null \
+            || : > /tmp/pr-comments.txt
 
           # Extract prior reviewedSha from the marker (if any) so we can
           # compute the delta numstat against it. Failure is fine — empty
@@ -175,8 +215,12 @@ jobs:
               || : > /tmp/pr-delta-numstat.txt
           fi
 
+          # Use the structured --comments-json-file path so the CLI applies
+          # the trusted-author filter (Layer 2 defense-in-depth) on top of
+          # the gh --jq filter above. Even if the jq filter is bypassed
+          # somehow, the CLI-side filter still rejects forged markers.
           INCREMENTAL_JSON=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-incremental-decide decide \
-            --comments-file /tmp/pr-comments.txt \
+            --comments-json-file /tmp/pr-comments.json \
             --base-ref "${{ github.event.pull_request.base.sha }}" \
             --head-ref HEAD \
             --repo-root . \
@@ -647,6 +691,36 @@ jobs:
             const issue_number = context.payload.pull_request.number;
             // Idempotent: search existing comments for the marker prefix; update
             // in place if found, else create new. Mirrors `dor-ingress.yml`.
+            //
+            // ── AISDLC-142 round-2 CRITICAL fix (Layer 1) ──────────────
+            // Filter to TRUSTED authors before selecting the prior marker.
+            // Without this filter an attacker-planted comment (containing the
+            // marker prefix substring) could be selected as `prior` and
+            // either (a) mutated by our updateComment call OR (b) left in
+            // place when the attacker's comment is "newer" than the bot's,
+            // which would let the next push's analyze-job read the
+            // attacker's marker first.
+            //
+            // REST API surface uses `user.login` (WITH `[bot]` suffix) +
+            // `author_association` — different from the GraphQL surface
+            // used in the analyze job's gh pr view step. Both flavors of
+            // the github-actions login (`github-actions` and
+            // `github-actions[bot]`) are listed for safety.
+            const TRUSTED_LOGINS = new Set([
+              'github-actions',
+              'github-actions[bot]',
+              'ai-sdlc-ci-attestor',
+              'ai-sdlc-ci-attestor[bot]',
+            ]);
+            const TRUSTED_ASSOCIATIONS = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+            const isTrustedComment = (c) => {
+              const login = c.user && c.user.login;
+              const assoc = c.author_association;
+              return (
+                (login && TRUSTED_LOGINS.has(login)) ||
+                (assoc && TRUSTED_ASSOCIATIONS.has(assoc))
+              );
+            };
             const existing = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -654,7 +728,10 @@ jobs:
               per_page: 100,
             });
             const prior = existing.find(
-              (c) => c.body && c.body.includes('<!-- ai-sdlc:last-reviewed-contenthash:'),
+              (c) =>
+                c.body &&
+                c.body.includes('<!-- ai-sdlc:last-reviewed-contenthash:') &&
+                isTrustedComment(c),
             );
             try {
               if (prior) {

--- a/ai-sdlc-plugin/commands/execute.md
+++ b/ai-sdlc-plugin/commands/execute.md
@@ -299,9 +299,50 @@ Marker storage: a single PR comment whose body contains `<!-- ai-sdlc:last-revie
 # `gh pr view --json comments` is cheap (one API call) and works against the
 # branch's open PR. Empty file when no PR exists yet (first push) — the gate
 # treats that as `no-marker` → FULL review.
+#
+# ── AISDLC-142 round-2 CRITICAL fix ────────────────────────────────────
+# Filter PR comments to TRUSTED AUTHORS at the jq boundary BEFORE the marker
+# is parsed. Without this filter ANY GitHub user could post a comment
+# carrying a forged `<!-- ai-sdlc:last-reviewed-contenthash:<base64url> -->`
+# marker (the contentHash is publicly computable from the PR diff), causing
+# the next push to skip all 3 reviewers + auto-approve + satisfy the
+# required-merge-gate check. This is an authorization-bypass with the same
+# blast radius as a forged review approval — keep the filter in lock-step
+# with the workflow analyzer's filter.
+#
+# Trust criteria (either gate is sufficient):
+#   - login == "github-actions" or "ai-sdlc-ci-attestor" (workflow-authored
+#     markers from the `ai-sdlc-review.yml` upsert step)
+#   - authorAssociation in {OWNER, MEMBER, COLLABORATOR} (push-access humans
+#     — they could write the marker via the workflow itself; honoring their
+#     direct comment is no escalation)
+#
+# We emit a STRUCTURED JSON file so the CLI's `--comments-json-file` flag
+# can re-apply the same filter as defense-in-depth (Layer 2).
+PR_COMMENTS_JSON="/tmp/pr-comments-${TASK_ID}.json"
 PR_COMMENTS_FILE="/tmp/pr-comments-${TASK_ID}.txt"
-gh pr view "$BRANCH" --json comments --jq '.comments[].body' \
-  > "$PR_COMMENTS_FILE" 2>/dev/null || : > "$PR_COMMENTS_FILE"
+gh pr view "$BRANCH" --json comments --jq '
+  [
+    .comments[]
+    | select(
+        .author.login == "github-actions"
+        or .author.login == "ai-sdlc-ci-attestor"
+        or .authorAssociation == "OWNER"
+        or .authorAssociation == "MEMBER"
+        or .authorAssociation == "COLLABORATOR"
+      )
+    | {
+        authorLogin: .author.login,
+        authorAssociation: .authorAssociation,
+        body: .body
+      }
+  ]
+' > "$PR_COMMENTS_JSON" 2>/dev/null || echo '[]' > "$PR_COMMENTS_JSON"
+
+# Bodies-only mirror for the PRIOR_SHA grep below (already author-filtered
+# upstream — only trusted bodies make it here).
+jq -r '.[].body' "$PR_COMMENTS_JSON" > "$PR_COMMENTS_FILE" 2>/dev/null \
+  || : > "$PR_COMMENTS_FILE"
 
 # Compute the delta numstat ONLY when a marker exists; the CLI no-ops it
 # otherwise. We extract the prior reviewedSha from the marker, then run
@@ -326,8 +367,10 @@ if [ -n "$PRIOR_SHA" ]; then
   cd - >/dev/null
 fi
 
+# Pass --comments-json-file (NOT --comments-file) so the CLI's trusted-author
+# filter runs as defense-in-depth on top of the gh --jq filter above.
 INCREMENTAL_JSON=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-incremental-decide decide \
-  --comments-file "$PR_COMMENTS_FILE" \
+  --comments-json-file "$PR_COMMENTS_JSON" \
   --base-ref origin/main \
   --head-ref HEAD \
   --repo-root "$WORKTREE_PATH" \
@@ -421,8 +464,30 @@ MARKER_BODY=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-incremental-
 # Idempotent upsert: search existing PR comments for the marker prefix; update
 # in-place if present, else create new. Mirrors the pattern at
 # .github/workflows/dor-ingress.yml around `<!-- ai-sdlc:dor-comment ... -->`.
+#
+# ── AISDLC-142 round-2 CRITICAL fix ────────────────────────────────────
+# Filter to TRUSTED authors before selecting the prior marker. Without
+# this filter an attacker-planted comment (containing the marker prefix
+# substring) could be selected as `EXISTING_COMMENT_ID` and either (a)
+# overwritten by the PATCH below — silently destroying the attacker's
+# evidence — OR more importantly (b) preserved in place when the
+# attacker's comment is "newer" than the bot's (`tail -1` keeps the
+# latest), which would let the next push's incremental gate read the
+# attacker's marker instead of the legitimate one. Same trust criteria
+# as the analyze-job's gh --jq filter — keep them in lock-step.
 EXISTING_COMMENT_ID=$(gh pr view "$BRANCH" --json comments \
-  --jq '.comments[] | select(.body | contains("<!-- ai-sdlc:last-reviewed-contenthash:")) | .id' \
+  --jq '
+    .comments[]
+    | select(
+        .author.login == "github-actions"
+        or .author.login == "ai-sdlc-ci-attestor"
+        or .authorAssociation == "OWNER"
+        or .authorAssociation == "MEMBER"
+        or .authorAssociation == "COLLABORATOR"
+      )
+    | select(.body | contains("<!-- ai-sdlc:last-reviewed-contenthash:"))
+    | .id
+  ' \
   2>/dev/null | tail -1)
 
 COMMENT_BODY=$(printf '%s\n\n%s\n\n%s\n' \

--- a/ai-sdlc-plugin/commands/execute.md
+++ b/ai-sdlc-plugin/commands/execute.md
@@ -234,7 +234,7 @@ The developer returns a JSON object. Parse it and check:
 - If any of `verifications.{build,test,lint}` is `failed`, treat as developer failure (same rollback as above).
 - Otherwise proceed to review.
 
-## Step 7 — Run conditional reviews (classifier-gated subset)
+## Step 7 — Run conditional reviews (classifier-gated subset, incremental delta)
 
 Build the review context once, share across all reviewers:
 
@@ -282,6 +282,88 @@ The classifier reviewer names map to the reviewer subagents like this (the agent
 | `critic`        | `code-reviewer`      |
 | `security`      | `security-reviewer`  |
 
+### Step 7a-bis — Incremental review gate (AISDLC-142)
+
+Pre-AISDLC-142 every push fed each spawned reviewer the FULL PR diff, even when only 5 lines changed since the prior approval. Now we layer a content-hash gate ON TOP of the classifier subset: the same `contentHashV3` algorithm CI uses for attestation tells us whether anything materially changed since the last review.
+
+The gate has three branches (decided by `cli-incremental-decide`, which is fail-open in the same shape as `cli-classify-pr`):
+
+- **`unchanged`** — content-hash matches the marker → SKIP all spawned reviewers, write auto-approved verdicts directly. Update marker with the same hash + new SHA. (AC #3)
+- **`delta-only`** — hash differs AND delta is within the safety threshold (default 200 lines, no new top-level dirs) → spawn the classifier-selected reviewers against `git diff <last-reviewed-sha>...HEAD` (delta only) PLUS a "the FULL PR diff was reviewed earlier; this incremental review only covers the delta from <sha>" preamble. Reviewer verdicts STILL apply to the whole PR. (AC #4)
+- **`no-marker` / `delta-too-large` / `new-top-level-dir`** — fall back to FULL review against `/tmp/pr-diff-${TASK_ID}.txt`. (AC #5, plus first-push)
+
+Marker storage: a single PR comment whose body contains `<!-- ai-sdlc:last-reviewed-contenthash:<base64url-json> -->`. Mirrors the idempotent-marker pattern from `<!-- ai-sdlc:dor-comment ... -->` and `<!-- ai-sdlc:attestation-fallback-comment -->`.
+
+```bash
+# Fetch existing PR comments (if any) so the gate can read the prior marker.
+# `gh pr view --json comments` is cheap (one API call) and works against the
+# branch's open PR. Empty file when no PR exists yet (first push) — the gate
+# treats that as `no-marker` → FULL review.
+PR_COMMENTS_FILE="/tmp/pr-comments-${TASK_ID}.txt"
+gh pr view "$BRANCH" --json comments --jq '.comments[].body' \
+  > "$PR_COMMENTS_FILE" 2>/dev/null || : > "$PR_COMMENTS_FILE"
+
+# Compute the delta numstat ONLY when a marker exists; the CLI no-ops it
+# otherwise. We extract the prior reviewedSha from the marker, then run
+# `git diff <sha>...HEAD --numstat`. If `gh` returned nothing, `jq` returns
+# empty and the numstat step is skipped — the gate falls through to no-marker.
+PRIOR_SHA=$(grep -oE '<!-- ai-sdlc:last-reviewed-contenthash:[A-Za-z0-9_-]+ -->' "$PR_COMMENTS_FILE" 2>/dev/null \
+  | tail -1 \
+  | sed -E 's/.*contenthash:([A-Za-z0-9_-]+) -->/\1/' \
+  | { read B64 && [ -n "$B64" ] && printf '%s' "$B64" \
+      | base64 -d 2>/dev/null \
+      | jq -r '.reviewedSha' 2>/dev/null; } || echo "")
+
+DELTA_NUMSTAT_FILE="/tmp/pr-delta-numstat-${TASK_ID}.txt"
+: > "$DELTA_NUMSTAT_FILE"
+if [ -n "$PRIOR_SHA" ]; then
+  cd "$WORKTREE_PATH"
+  # Cap the diff against PRIOR_SHA at the merge-base of HEAD if PRIOR_SHA isn't
+  # in the current history (rebase changed history). On failure we leave the
+  # numstat file empty — the CLI will treat unreadable input as the safer
+  # `delta-too-large` branch and route to FULL review.
+  git diff "$PRIOR_SHA"...HEAD --numstat > "$DELTA_NUMSTAT_FILE" 2>/dev/null || : > "$DELTA_NUMSTAT_FILE"
+  cd - >/dev/null
+fi
+
+INCREMENTAL_JSON=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-incremental-decide decide \
+  --comments-file "$PR_COMMENTS_FILE" \
+  --base-ref origin/main \
+  --head-ref HEAD \
+  --repo-root "$WORKTREE_PATH" \
+  --numstat-file "$DELTA_NUMSTAT_FILE" \
+  --full-diff-paths-file "/tmp/pr-files-${TASK_ID}.txt" 2>/dev/null \
+  || echo '{"skip":false,"deltaOnly":false,"reason":"no-marker","currentContentHash":"","priorContentHash":null,"lastReviewedSha":null,"deltaSize":0}')
+
+INCR_SKIP=$(printf '%s' "$INCREMENTAL_JSON" | jq -r '.skip')
+INCR_DELTA_ONLY=$(printf '%s' "$INCREMENTAL_JSON" | jq -r '.deltaOnly')
+INCR_REASON=$(printf '%s' "$INCREMENTAL_JSON" | jq -r '.reason')
+INCR_LAST_SHA=$(printf '%s' "$INCREMENTAL_JSON" | jq -r '.lastReviewedSha // empty')
+INCR_CONTENT_HASH=$(printf '%s' "$INCREMENTAL_JSON" | jq -r '.currentContentHash')
+INCR_DELTA_SIZE=$(printf '%s' "$INCREMENTAL_JSON" | jq -r '.deltaSize')
+
+echo "[ai-sdlc-progress] Step 7a-bis: incremental decision: $INCR_REASON (skip=$INCR_SKIP, deltaOnly=$INCR_DELTA_ONLY, deltaSize=$INCR_DELTA_SIZE, lastReviewedSha=${INCR_LAST_SHA:-none})"
+```
+
+When `INCR_SKIP=true` (AC #3): write the auto-approved verdict for EVERY reviewer in `$SELECTED` directly (no Agent calls), aggregate as APPROVED in Step 8, set the PR-body note to `> Incremental review (AISDLC-142): prior approval reused (no content change since SHA $INCR_LAST_SHA)`, then proceed to Step 8 / Step 10.
+
+When `INCR_DELTA_ONLY=true` (AC #4): the spawned reviewers in Step 7b receive the DELTA diff (`git diff $INCR_LAST_SHA...HEAD`) instead of the full PR diff, plus the preamble described above. Build the delta diff once into a separate file:
+
+```bash
+if [ "$INCR_DELTA_ONLY" = "true" ]; then
+  cd "$WORKTREE_PATH"
+  git diff "$INCR_LAST_SHA"...HEAD > "/tmp/pr-delta-diff-${TASK_ID}.txt" 2>/dev/null \
+    || cp "/tmp/pr-diff-${TASK_ID}.txt" "/tmp/pr-delta-diff-${TASK_ID}.txt"
+  cd - >/dev/null
+fi
+```
+
+Reviewers ALWAYS read from `/tmp/pr-delta-diff-${TASK_ID}.txt` when `INCR_DELTA_ONLY=true`, otherwise from `/tmp/pr-diff-${TASK_ID}.txt`.
+
+> **Composes with Step 7a (AISDLC-141, AC #7).** The classifier runs FIRST and decides WHICH reviewers to spawn (the `$SELECTED` subset). The incremental gate then decides WHAT each one reads (skip / delta / full). When the classifier scoped review to e.g. just `[security]` and the incremental gate says `unchanged`, we spawn 0 reviewers AND auto-approve only `security` — the other two are still skipped by the classifier with their AISDLC-141 auto-approved verdicts. Net: minimum work that still satisfies the safety contract.
+
+> **Marker update happens after Step 8 (post-aggregation).** See Step 8 below for the `gh pr comment` upsert. We do NOT update the marker before the reviewers report their verdicts — a marker update before the verdict gate would let a CHANGES_REQUESTED finding silently bind the marker to an un-approved SHA.
+
 ### Step 7b — Spawn the selected subset
 
 Detect Codex availability once (the reviewer agents declare `harness: codex`):
@@ -296,9 +378,14 @@ fi
 
 Spawn **only the reviewers in `$SELECTED`** in parallel (single message, N Agent tool calls where 0 ≤ N ≤ 3). For each name in `$SELECTED`, dispatch the matching subagent type per the table above. If `$SELECTED` is empty (e.g. the classifier saw an empty diff), skip Step 7b entirely and treat the gate as APPROVED with zero findings.
 
-Each prompt should contain:
+**AISDLC-142 — incremental short-circuit:** if `INCR_SKIP=true`, do NOT spawn any reviewers in `$SELECTED`. Write the auto-approved verdict (from `cli-incremental-decide auto-approved-verdict --reviewed-sha $INCR_LAST_SHA`) for each one and skip directly to Step 8 aggregation. The classifier-skipped reviewers' AISDLC-141 auto-approved verdicts still apply for the others.
 
-- The PR diff (from `/tmp/pr-diff-${TASK_ID}.txt`)
+Each spawned-reviewer prompt should contain:
+
+- The review diff:
+  - if `INCR_DELTA_ONLY=true` → the delta diff from `/tmp/pr-delta-diff-${TASK_ID}.txt` PLUS a preamble:
+    > **Incremental review (AISDLC-142):** the FULL PR diff was reviewed earlier at SHA `$INCR_LAST_SHA`. This incremental review only covers the delta from `$INCR_LAST_SHA` to HEAD ($INCR_DELTA_SIZE lines). Your verdict still applies to the WHOLE PR — only the diff you read is scoped down.
+  - otherwise → the full PR diff from `/tmp/pr-diff-${TASK_ID}.txt`
 - The task title, description, AC list
 - Contents of `.ai-sdlc/review-policy.md` if present (project-specific calibration)
 - The branch name + base (`main`)
@@ -316,10 +403,45 @@ Combine the three verdicts:
 - Count findings by severity across all reviewers (`critical`, `major`, `minor`, `suggestion`).
 - If `HARNESS_NOTE` is non-empty, prepend it to the aggregated summary so the operator sees the independence warning every time it applies.
 - Compute the gate decision:
-  - **APPROVED**: all three reviewers approved AND no `critical`/`major` findings → proceed to PR (Step 10).
-  - **CHANGES REQUESTED**: any `critical` or `major` findings → enter the iteration loop (Step 9).
+  - **APPROVED**: all three reviewers approved AND no `critical`/`major` findings → proceed to Step 8.5 marker update, then Step 10.
+  - **CHANGES REQUESTED**: any `critical` or `major` findings → enter the iteration loop (Step 9). Do NOT update the marker on this branch — the marker only ever binds to APPROVED states.
 
 Print the aggregation summary to the user before proceeding.
+
+## Step 8.5 — Update the incremental-review marker (AISDLC-142)
+
+ONLY if the gate decision is APPROVED (skip when `[needs-human-attention]` is being shipped from Step 9). Update the PR-comment marker with the freshly-computed contentHash + the SHA we just reviewed against. Subsequent pushes that don't change content can then short-circuit at Step 7a-bis.
+
+```bash
+HEAD_SHA=$(cd "$WORKTREE_PATH" && git rev-parse HEAD)
+MARKER_BODY=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-incremental-decide format-marker \
+  --content-hash "$INCR_CONTENT_HASH" \
+  --reviewed-sha "$HEAD_SHA")
+
+# Idempotent upsert: search existing PR comments for the marker prefix; update
+# in-place if present, else create new. Mirrors the pattern at
+# .github/workflows/dor-ingress.yml around `<!-- ai-sdlc:dor-comment ... -->`.
+EXISTING_COMMENT_ID=$(gh pr view "$BRANCH" --json comments \
+  --jq '.comments[] | select(.body | contains("<!-- ai-sdlc:last-reviewed-contenthash:")) | .id' \
+  2>/dev/null | tail -1)
+
+COMMENT_BODY=$(printf '%s\n\n%s\n\n%s\n' \
+  '## AI-SDLC: incremental review state' \
+  '_Auto-managed by `/ai-sdlc execute`. Editing this comment will break incremental review for this PR until the next full review re-creates it._' \
+  "$MARKER_BODY")
+
+if [ -n "$EXISTING_COMMENT_ID" ]; then
+  gh api "repos/{owner}/{repo}/issues/comments/${EXISTING_COMMENT_ID}" \
+    -X PATCH \
+    -f body="$COMMENT_BODY" >/dev/null \
+    || echo "[ai-sdlc-progress] Step 8.5: marker update failed (non-fatal — next push will re-create)"
+else
+  gh pr comment "$BRANCH" --body "$COMMENT_BODY" >/dev/null \
+    || echo "[ai-sdlc-progress] Step 8.5: marker create failed (non-fatal — next push will re-try)"
+fi
+```
+
+The marker write is best-effort. A failure here at worst forces the next push back through a FULL review — never a SAFETY regression. The actual review verdicts already landed in the PR via Step 11.
 
 ## Step 9 — Iteration loop (max 2 dev iterations on review failure)
 

--- a/ai-sdlc-plugin/mcp-server/dist/bin.js
+++ b/ai-sdlc-plugin/mcp-server/dist/bin.js
@@ -22942,6 +22942,9 @@ async function cleanupTask(opts) {
 import { existsSync as existsSync14, readdirSync as readdirSync4, readFileSync as readFileSync12 } from "node:fs";
 import { join as join15 } from "node:path";
 
+// ../../pipeline-cli/dist/incremental-review/incremental.js
+import { createHash } from "node:crypto";
+
 // ../../pipeline-cli/dist/classifier/classifier.js
 import { appendFile, mkdir } from "node:fs/promises";
 import { dirname as dirname4, join as join16 } from "node:path";

--- a/backlog/completed/aisdlc-142 - Incremental-review-—-only-re-review-the-diff-since-last-approval.md
+++ b/backlog/completed/aisdlc-142 - Incremental-review-—-only-re-review-the-diff-since-last-approval.md
@@ -1,0 +1,52 @@
+---
+id: AISDLC-142
+title: Incremental review — only re-review the diff since last approval
+status: Done
+assignee: []
+created_date: '2026-05-02 22:13'
+updated_date: '2026-05-02 23:58'
+labels:
+  - ci
+  - cost-optimization
+  - follow-up
+  - review
+dependencies:
+  - AISDLC-141
+references:
+  - ai-sdlc-plugin/commands/execute.md
+  - .github/workflows/ai-sdlc-review.yml
+  - orchestrator/src/runtime/attestations.ts (contentHashV3)
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+**Cost-optimization follow-up to AISDLC-140.** Today every push triggers full reviewer fan-out against `git diff origin/main...HEAD` (the entire PR diff). When a 200-line PR rebases or pushes a 5-line fix, reviewers re-read the same 200 lines.
+
+## Proposed shape
+- Store "last-reviewed contentHash" per PR. Use the existing `contentHashV3` (per-file blob delta hash) — already implemented at `orchestrator/src/runtime/attestations.ts`
+- Storage: GitHub PR comment with marker `<!-- ai-sdlc:last-reviewed-contenthash:VALUE -->` (simplest; idempotent; visible in PR)
+- On each push:
+  - Compute current `contentHashV3`. Compare to last-reviewed.
+  - If equal: skip review entirely (reuse prior approval signal — post `Post Review Results: success` directly per stale approval)
+  - If changed: run reviewers against `git diff <last-reviewed-sha>...HEAD` (delta-only)
+  - If diff is large (>200 lines OR touches new file types): fall back to full diff
+  - After review: update the PR-comment marker with the new contentHash
+- Composes with AISDLC-141 classifier — first decide which reviewers, then review only the delta
+
+## Acceptance criteria
+1. PR comment marker `<!-- ai-sdlc:last-reviewed-contenthash:... -->` written + updated per cycle
+2. Reviewers receive only the delta diff (`git diff <last-reviewed-sha>...HEAD`) when delta is reasonable size
+3. Skip-when-unchanged path: contentHash equal → no reviewer agents spawned, prior approval reused
+4. Fall-back-to-full path: delta > N lines triggers full review
+5. Composes correctly with AISDLC-141 classifier (classifier runs first, then incremental on the chosen subset)
+6. Hermetic tests: rebase no-content-change → skip; small fix → delta-only review; large refactor → full review
+7. ≥80% patch coverage
+
+## Expected savings
+60-80% on multi-push PRs (most PRs after rebase/fix iterations).
+**Combined with AISDLC-141:** 70-95% total reduction in reviewer-agent invocations vs current baseline. Achieves AISDLC-74's original "halve CI cost" goal WITHOUT the attestation-as-gate complexity.</description>
+<acceptanceCriteria>["PR comment marker for last-reviewed-contenthash", "Reviewers receive delta diff when delta is small", "Skip-when-unchanged: contentHash equal → no reviewers spawned", "Fall-back-to-full when delta > 200 lines or touches new file types", "Composes with AISDLC-141 classifier (subset + delta)", "Hermetic tests cover all paths", ">=80% patch coverage"]</acceptanceCriteria>
+</invoke>
+<!-- SECTION:DESCRIPTION:END -->

--- a/pipeline-cli/bin/cli-incremental-decide.mjs
+++ b/pipeline-cli/bin/cli-incremental-decide.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+/**
+ * Bin shim for `cli-incremental-decide` (AISDLC-142). Forwards to the
+ * compiled router. Compiled entry lives in `dist/cli/incremental-decide.js`
+ * after `pnpm build`.
+ *
+ * Wraps the incremental-review primitives so Step 7 of the slash command
+ * body and the `analyze` job in `.github/workflows/ai-sdlc-review.yml` can
+ * decide on each push whether to skip / delta-only / full review. Composes
+ * ON TOP of the AISDLC-141 classifier (cli-classify-pr).
+ */
+import { runIncrementalDecideCli } from '../dist/cli/incremental-decide.js';
+
+runIncrementalDecideCli().catch((err) => {
+  process.stderr.write(`[cli-incremental-decide] error: ${err?.message ?? String(err)}\n`);
+  process.exit(1);
+});

--- a/pipeline-cli/package.json
+++ b/pipeline-cli/package.json
@@ -22,7 +22,8 @@
     "cli-deps": "bin/cli-deps.mjs",
     "cli-dor-stats": "bin/cli-dor-stats.mjs",
     "cli-dor-digest": "bin/cli-dor-digest.mjs",
-    "cli-classify-pr": "bin/cli-classify-pr.mjs"
+    "cli-classify-pr": "bin/cli-classify-pr.mjs",
+    "cli-incremental-decide": "bin/cli-incremental-decide.mjs"
   },
   "exports": {
     ".": {
@@ -44,6 +45,10 @@
     "./classifier": {
       "types": "./dist/classifier/index.d.ts",
       "import": "./dist/classifier/index.js"
+    },
+    "./incremental-review": {
+      "types": "./dist/incremental-review/index.d.ts",
+      "import": "./dist/incremental-review/index.js"
     }
   },
   "publishConfig": {

--- a/pipeline-cli/src/cli/incremental-decide.test.ts
+++ b/pipeline-cli/src/cli/incremental-decide.test.ts
@@ -1,0 +1,318 @@
+/**
+ * cli-incremental-decide router tests — drive the yargs program in-process
+ * with an injected runGit stub and assert on stdout/stderr.
+ *
+ * Covers the CLI surface for AC #8 scenarios (rebase-no-content-change,
+ * small-fix, large-refactor, first-push) plus the format-marker subcommand
+ * + the auto-approved-verdict subcommand. Pure unit tests; no real git
+ * worktree required.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildIncrementalDecideCli, decide, type DecideArgs } from './incremental-decide.js';
+import {
+  formatMarker,
+  type IncrementalDecision,
+  type RunGit,
+} from '../incremental-review/incremental.js';
+
+let tmp: string;
+let stdoutChunks: string[];
+let stderrChunks: string[];
+let savedWrite: typeof process.stdout.write;
+let savedErrWrite: typeof process.stderr.write;
+let savedExit: typeof process.exit;
+
+const HASH_A = 'a'.repeat(64);
+const SHA_A = '1'.repeat(40);
+const BASE_SHA = '9'.repeat(40);
+const HEAD_SHA_A = 'a'.repeat(40);
+const HEAD_SHA_B = 'b'.repeat(40);
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'cli-incremental-decide-'));
+  stdoutChunks = [];
+  stderrChunks = [];
+  savedWrite = process.stdout.write.bind(process.stdout);
+  savedErrWrite = process.stderr.write.bind(process.stderr);
+  savedExit = process.exit;
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    stdoutChunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderrChunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+    return true;
+  }) as typeof process.stderr.write;
+  process.exit = ((code?: number) => {
+    throw new Error(`process.exit(${code})`);
+  }) as typeof process.exit;
+});
+
+afterEach(() => {
+  process.stdout.write = savedWrite;
+  process.stderr.write = savedErrWrite;
+  process.exit = savedExit;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function stdoutJson<T>(): T {
+  for (let i = stdoutChunks.length - 1; i >= 0; i--) {
+    const c = stdoutChunks[i].trim();
+    if (c.startsWith('{') || c.startsWith('[')) return JSON.parse(c) as T;
+  }
+  throw new Error(`no JSON found in stdout: ${stdoutChunks.join('')}`);
+}
+
+/**
+ * Build a runGit stub matching the substring-on-key pattern used by the
+ * incremental.test.ts version. Keeps the test cases readable.
+ */
+function makeRunGit(responses: Record<string, string>): RunGit {
+  return (args: string[], _cwd: string) => {
+    const key = args.join(' ');
+    for (const k of Object.keys(responses)) {
+      if (key.includes(k)) return responses[k];
+    }
+    throw new Error(`unexpected git invocation: ${key}`);
+  };
+}
+
+// ── decide() composite — exercises all I/O paths ──────────────────
+
+describe('decide() — integration over file inputs + injected runGit', () => {
+  function baseArgs(over: Partial<DecideArgs>): DecideArgs {
+    return {
+      baseRef: 'origin/main',
+      headRef: 'HEAD',
+      repoRoot: '/tmp/repo',
+      maxDeltaLines: 200,
+      runGit: makeRunGit({
+        'merge-base origin/main HEAD': BASE_SHA + '\n',
+        'diff --name-only --no-renames origin/main...HEAD': 'src/foo.ts\n',
+        [`ls-tree -r ${BASE_SHA} -- src/foo.ts`]: `100644 blob ${HEAD_SHA_A}\tsrc/foo.ts\n`,
+        'ls-tree -r HEAD -- src/foo.ts': `100644 blob ${HEAD_SHA_B}\tsrc/foo.ts\n`,
+      }),
+      ...over,
+    };
+  }
+
+  it('AC #8.4 first-push (no comments file, no marker) → no-marker / FULL', () => {
+    const d = decide(baseArgs({}));
+    expect(d.skip).toBe(false);
+    expect(d.deltaOnly).toBe(false);
+    expect(d.reason).toBe('no-marker');
+    // currentContentHash is computed from the stubbed git output
+    expect(d.currentContentHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('AC #8.1 rebase-no-content-change (marker hash equals current) → SKIP', () => {
+    const d1 = decide(baseArgs({}));
+    // Round-trip: write a marker carrying the current hash, then re-decide.
+    const commentsFile = join(tmp, 'comments.txt');
+    writeFileSync(
+      commentsFile,
+      `## prior comment\n\n${formatMarker({
+        contentHash: d1.currentContentHash,
+        reviewedSha: SHA_A,
+        reviewedAt: '2026-05-01T00:00:00.000Z',
+      })}\n`,
+    );
+    const d2 = decide(baseArgs({ commentsFile }));
+    expect(d2.skip).toBe(true);
+    expect(d2.reason).toBe('unchanged');
+    expect(d2.lastReviewedSha).toBe(SHA_A);
+  });
+
+  it('AC #8.2 small-fix → DELTA-ONLY', () => {
+    const commentsFile = join(tmp, 'comments.txt');
+    writeFileSync(
+      commentsFile,
+      formatMarker({
+        contentHash: HASH_A, // mismatches current → forces change branch
+        reviewedSha: SHA_A,
+        reviewedAt: '2026-05-01T00:00:00.000Z',
+      }),
+    );
+    const numstatFile = join(tmp, 'numstat.txt');
+    writeFileSync(numstatFile, '4\t1\tsrc/foo.ts\n');
+    const d = decide(baseArgs({ commentsFile, numstatFile }));
+    expect(d.skip).toBe(false);
+    expect(d.deltaOnly).toBe(true);
+    expect(d.reason).toBe('delta-only');
+    expect(d.deltaSize).toBe(5);
+  });
+
+  it('AC #8.3 large-refactor → FULL (delta-too-large)', () => {
+    const commentsFile = join(tmp, 'comments.txt');
+    writeFileSync(
+      commentsFile,
+      formatMarker({
+        contentHash: HASH_A,
+        reviewedSha: SHA_A,
+        reviewedAt: '2026-05-01T00:00:00.000Z',
+      }),
+    );
+    const numstatFile = join(tmp, 'numstat.txt');
+    writeFileSync(numstatFile, '300\t150\tsrc/foo.ts\n');
+    const d = decide(baseArgs({ commentsFile, numstatFile, maxDeltaLines: 200 }));
+    expect(d.deltaOnly).toBe(false);
+    expect(d.reason).toBe('delta-too-large');
+  });
+
+  it('honors --max-delta-lines (configurable threshold)', () => {
+    const commentsFile = join(tmp, 'comments.txt');
+    writeFileSync(
+      commentsFile,
+      formatMarker({
+        contentHash: HASH_A,
+        reviewedSha: SHA_A,
+        reviewedAt: '2026-05-01T00:00:00.000Z',
+      }),
+    );
+    const numstatFile = join(tmp, 'numstat.txt');
+    writeFileSync(numstatFile, '60\t0\tsrc/foo.ts\n');
+    const d = decide(baseArgs({ commentsFile, numstatFile, maxDeltaLines: 50 }));
+    expect(d.reason).toBe('delta-too-large');
+  });
+
+  it('safety: delta touches a top-level dir not in full PR diff → new-top-level-dir', () => {
+    const commentsFile = join(tmp, 'comments.txt');
+    writeFileSync(
+      commentsFile,
+      formatMarker({
+        contentHash: HASH_A,
+        reviewedSha: SHA_A,
+        reviewedAt: '2026-05-01T00:00:00.000Z',
+      }),
+    );
+    const numstatFile = join(tmp, 'numstat.txt');
+    writeFileSync(numstatFile, '10\t0\tscripts/new.sh\n');
+    const fullDiffPathsFile = join(tmp, 'paths.txt');
+    writeFileSync(fullDiffPathsFile, 'src/foo.ts\n');
+    const d = decide(baseArgs({ commentsFile, numstatFile, fullDiffPathsFile }));
+    expect(d.deltaOnly).toBe(false);
+    expect(d.reason).toBe('new-top-level-dir');
+  });
+
+  it('falls back to FULL review when --comments-file path is unreadable', () => {
+    const d = decide(baseArgs({ commentsFile: join(tmp, 'does-not-exist.txt') }));
+    expect(d.reason).toBe('no-marker');
+    expect(stderrChunks.join('')).toMatch(/failed to read --comments-file/);
+  });
+
+  it('falls back when --numstat-file is unreadable: routes to delta-too-large (safer side)', () => {
+    const commentsFile = join(tmp, 'comments.txt');
+    writeFileSync(
+      commentsFile,
+      formatMarker({
+        contentHash: HASH_A,
+        reviewedSha: SHA_A,
+        reviewedAt: '2026-05-01T00:00:00.000Z',
+      }),
+    );
+    const d = decide(baseArgs({ commentsFile, numstatFile: join(tmp, 'missing.txt') }));
+    expect(d.deltaOnly).toBe(false);
+    expect(d.reason).toBe('delta-too-large');
+    expect(stderrChunks.join('')).toMatch(/failed to read --numstat-file/);
+  });
+
+  it('falls back to no-marker when collectChangedFileDeltaEntries throws', () => {
+    const runGit: RunGit = (_args) => {
+      throw new Error('git missing');
+    };
+    const d = decide(baseArgs({ runGit }));
+    expect(d.reason).toBe('no-marker');
+    expect(stderrChunks.join('')).toMatch(/failed to compute contentHashV3/);
+  });
+
+  it('--full-diff-paths-file unreadable → guard becomes no-op (delta-only path still works)', () => {
+    const commentsFile = join(tmp, 'comments.txt');
+    writeFileSync(
+      commentsFile,
+      formatMarker({
+        contentHash: HASH_A,
+        reviewedSha: SHA_A,
+        reviewedAt: '2026-05-01T00:00:00.000Z',
+      }),
+    );
+    const numstatFile = join(tmp, 'numstat.txt');
+    writeFileSync(numstatFile, '5\t0\tsrc/foo.ts\n');
+    const d = decide(
+      baseArgs({
+        commentsFile,
+        numstatFile,
+        fullDiffPathsFile: join(tmp, 'missing.txt'),
+      }),
+    );
+    expect(d.deltaOnly).toBe(true); // guard disabled → deltaOnly still wins
+    expect(stderrChunks.join('')).toMatch(/failed to read --full-diff-paths-file/);
+  });
+});
+
+// ── yargs CLI surface ──────────────────────────────────────────────
+
+describe('cli-incremental-decide — yargs router', () => {
+  it('decide subcommand emits the IncrementalDecision JSON on stdout', async () => {
+    const commentsFile = join(tmp, 'comments.txt');
+    writeFileSync(commentsFile, '## empty comment\n');
+    const cli = buildIncrementalDecideCli({
+      argv: ['decide', '--comments-file', commentsFile, '--repo-root', '/tmp/repo'],
+      runGit: makeRunGit({
+        'merge-base origin/main HEAD': BASE_SHA + '\n',
+        'diff --name-only --no-renames origin/main...HEAD': 'src/foo.ts\n',
+        [`ls-tree -r ${BASE_SHA} -- src/foo.ts`]: `100644 blob ${HEAD_SHA_A}\tsrc/foo.ts\n`,
+        'ls-tree -r HEAD -- src/foo.ts': `100644 blob ${HEAD_SHA_B}\tsrc/foo.ts\n`,
+      }),
+    });
+    await cli.parseAsync();
+    const d = stdoutJson<IncrementalDecision>();
+    expect(d.reason).toBe('no-marker');
+  });
+
+  it('format-marker subcommand emits the marker comment body on stdout', async () => {
+    const cli = buildIncrementalDecideCli({
+      argv: [
+        'format-marker',
+        '--content-hash',
+        HASH_A,
+        '--reviewed-sha',
+        SHA_A,
+        '--reviewed-at',
+        '2026-05-01T00:00:00.000Z',
+      ],
+    });
+    await cli.parseAsync();
+    const printed = stdoutChunks.join('');
+    expect(printed).toMatch(/^<!-- ai-sdlc:last-reviewed-contenthash:.+ -->\n$/);
+  });
+
+  it('auto-approved-verdict subcommand emits the matching schema for the report job', async () => {
+    const cli = buildIncrementalDecideCli({
+      argv: ['auto-approved-verdict', '--reviewed-sha', SHA_A],
+    });
+    await cli.parseAsync();
+    const v = stdoutJson<{ approved: boolean; findings: unknown[]; summary: string }>();
+    expect(v.approved).toBe(true);
+    expect(v.findings).toEqual([]);
+    expect(v.summary).toContain(SHA_A);
+  });
+
+  it('decide defaults work even when only --comments-file is passed (no marker → no-marker)', async () => {
+    const commentsFile = join(tmp, 'comments.txt');
+    writeFileSync(commentsFile, '');
+    const cli = buildIncrementalDecideCli({
+      argv: ['decide', '--comments-file', commentsFile, '--repo-root', '/tmp/repo'],
+      runGit: makeRunGit({
+        'merge-base origin/main HEAD': BASE_SHA + '\n',
+        'diff --name-only --no-renames origin/main...HEAD': '',
+      }),
+    });
+    await cli.parseAsync();
+    const d = stdoutJson<IncrementalDecision>();
+    expect(d.reason).toBe('no-marker');
+  });
+});

--- a/pipeline-cli/src/cli/incremental-decide.test.ts
+++ b/pipeline-cli/src/cli/incremental-decide.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { buildIncrementalDecideCli, decide, type DecideArgs } from './incremental-decide.js';
@@ -299,6 +299,94 @@ describe('cli-incremental-decide — yargs router', () => {
     expect(v.approved).toBe(true);
     expect(v.findings).toEqual([]);
     expect(v.summary).toContain(SHA_A);
+  });
+
+  // ── AISDLC-142 round-3 CRITICAL: SKIP-path JSON serialization ─────
+  //
+  // The `analyze` job in `.github/workflows/ai-sdlc-review.yml` consumes
+  // the auto-approved-verdict output via `tail -1 /tmp/review-${TYPE}.txt`.
+  // If the CLI emits pretty-printed multi-line JSON, `tail -1` extracts
+  // only `}` and the report job's `JSON.parse('}')` throws → all reviewers
+  // FAILED → CHANGES_REQUESTED → PR BLOCKED → marker never refreshed →
+  // PR permanently stuck.
+  //
+  // These tests assert the workflow contract: every JSON line is exactly
+  // one line, and the `tail -1 → JSON.parse` shell pipeline yields a valid
+  // verdict with `approved: true`.
+
+  it('auto-approved-verdict emits SINGLE-LINE JSON (no embedded newlines) — tail -1 must yield the full verdict', async () => {
+    const cli = buildIncrementalDecideCli({
+      argv: ['auto-approved-verdict', '--reviewed-sha', SHA_A],
+    });
+    await cli.parseAsync();
+    const printed = stdoutChunks.join('');
+    // Strict: the entire emitted payload must be exactly ONE line of JSON
+    // followed by exactly ONE trailing newline. No embedded newlines, no
+    // pretty-print whitespace.
+    expect(printed.endsWith('\n')).toBe(true);
+    const trimmed = printed.replace(/\n$/, '');
+    expect(trimmed).not.toContain('\n');
+    // Sanity: it parses, and the shape is what the report job expects.
+    const parsed = JSON.parse(trimmed);
+    expect(parsed.approved).toBe(true);
+  });
+
+  it('decide subcommand also emits SINGLE-LINE JSON (workflow contract: every JSON line is one line)', async () => {
+    const commentsFile = join(tmp, 'comments.txt');
+    writeFileSync(commentsFile, '');
+    const cli = buildIncrementalDecideCli({
+      argv: ['decide', '--comments-file', commentsFile, '--repo-root', '/tmp/repo'],
+      runGit: makeRunGit({
+        'merge-base origin/main HEAD': BASE_SHA + '\n',
+        'diff --name-only --no-renames origin/main...HEAD': '',
+      }),
+    });
+    await cli.parseAsync();
+    const printed = stdoutChunks.join('');
+    expect(printed.endsWith('\n')).toBe(true);
+    const trimmed = printed.replace(/\n$/, '');
+    expect(trimmed).not.toContain('\n');
+    const parsed = JSON.parse(trimmed);
+    expect(parsed.reason).toBe('no-marker');
+  });
+
+  // Workflow-pipeline regression: simulate the EXACT shell flow the
+  // `analyze` job runs — CLI stdout → tmpfile → `tail -1` → JSON.parse.
+  // This is the path the round 1+2 tests didn't exercise, which let the
+  // pretty-print regression slip through.
+  it('workflow-pipeline regression: CLI → tmpfile → tail -1 → JSON.parse yields valid verdict for every reviewer type', async () => {
+    for (const type of ['testing', 'critic', 'security']) {
+      // Reset stdout capture between iterations (mimicking three separate
+      // CLI invocations the workflow runs in a loop).
+      stdoutChunks = [];
+      const cli = buildIncrementalDecideCli({
+        argv: ['auto-approved-verdict', '--reviewed-sha', SHA_A],
+      });
+      await cli.parseAsync();
+
+      // Step 1: write the CLI output to a tmpfile (mirrors `> "/tmp/review-${TYPE}.txt"`).
+      const reviewFile = join(tmp, `review-${type}.txt`);
+      writeFileSync(reviewFile, stdoutChunks.join(''));
+
+      // Step 2: apply `tail -1` semantics — last non-empty line.
+      // (POSIX `tail -1` returns the final line; on a file ending with `\n`
+      // there's a trailing empty token after split, which `tail -1` skips.)
+      const lines = readFileSync(reviewFile, 'utf-8').split('\n');
+      // Drop the trailing empty token from the final newline, if present.
+      while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+      const lastLine = lines[lines.length - 1] ?? '';
+
+      // Step 3: JSON.parse — must yield a valid verdict (the bug was that
+      // pretty-print made this `}` and threw).
+      const verdict = JSON.parse(lastLine) as {
+        approved: boolean;
+        findings: unknown[];
+        summary: string;
+      };
+      expect(verdict.approved, `reviewer=${type}`).toBe(true);
+      expect(verdict.findings, `reviewer=${type}`).toEqual([]);
+      expect(verdict.summary, `reviewer=${type}`).toContain(SHA_A);
+    }
   });
 
   it('decide defaults work even when only --comments-file is passed (no marker → no-marker)', async () => {

--- a/pipeline-cli/src/cli/incremental-decide.test.ts
+++ b/pipeline-cli/src/cli/incremental-decide.test.ts
@@ -316,3 +316,237 @@ describe('cli-incremental-decide — yargs router', () => {
     expect(d.reason).toBe('no-marker');
   });
 });
+
+// ── --comments-json-file (AISDLC-142 round-2 CRITICAL fix) ─────────
+//
+// The structured-JSON path is the safe-by-default input — the CLI applies
+// the trusted-author filter (`filterTrustedComments`) BEFORE searching for
+// the marker. These tests assert the bypass scenarios from the round-2
+// security finding.
+
+describe('decide() — --comments-json-file applies trusted-author filter', () => {
+  function baseArgsJson(over: Partial<DecideArgs>): DecideArgs {
+    return {
+      baseRef: 'origin/main',
+      headRef: 'HEAD',
+      repoRoot: '/tmp/repo',
+      maxDeltaLines: 200,
+      runGit: makeRunGit({
+        'merge-base origin/main HEAD': BASE_SHA + '\n',
+        'diff --name-only --no-renames origin/main...HEAD': 'src/foo.ts\n',
+        [`ls-tree -r ${BASE_SHA} -- src/foo.ts`]: `100644 blob ${HEAD_SHA_A}\tsrc/foo.ts\n`,
+        'ls-tree -r HEAD -- src/foo.ts': `100644 blob ${HEAD_SHA_B}\tsrc/foo.ts\n`,
+      }),
+      ...over,
+    };
+  }
+
+  it('AC #2 — IGNORES a forged marker authored by external-attacker (returns no-marker)', () => {
+    // Compute the actual current contentHash so the forged marker carries
+    // the value an attacker would derive from the public PR diff.
+    const probe = decide(baseArgsJson({}));
+    const forgedMarker = formatMarker({
+      contentHash: probe.currentContentHash, // attacker computes this from the PR
+      reviewedSha: SHA_A,
+      reviewedAt: '2026-05-01T00:00:00.000Z',
+    });
+    const commentsJsonFile = join(tmp, 'comments.json');
+    writeFileSync(
+      commentsJsonFile,
+      JSON.stringify([
+        {
+          authorLogin: 'external-attacker',
+          authorAssociation: 'NONE',
+          body: `## Looks legit\n\n${forgedMarker}\n`,
+        },
+      ]),
+    );
+    const d = decide(baseArgsJson({ commentsJsonFile }));
+    // Without the filter, this would return skip:true / unchanged — that's
+    // the CRITICAL bypass. With the filter, the attacker comment is dropped
+    // and the gate routes through `no-marker` → FULL review.
+    expect(d.skip).toBe(false);
+    expect(d.reason).toBe('no-marker');
+  });
+
+  it('AC #3 — HONORS a marker authored by github-actions normally (skip path works)', () => {
+    const probe = decide(baseArgsJson({}));
+    const trustedMarker = formatMarker({
+      contentHash: probe.currentContentHash,
+      reviewedSha: SHA_A,
+      reviewedAt: '2026-05-01T00:00:00.000Z',
+    });
+    const commentsJsonFile = join(tmp, 'comments.json');
+    writeFileSync(
+      commentsJsonFile,
+      JSON.stringify([
+        // GraphQL shape (gh pr view): author.login WITHOUT [bot] suffix.
+        {
+          authorLogin: 'github-actions',
+          authorAssociation: 'CONTRIBUTOR',
+          body: `## AI-SDLC: incremental review state\n\n${trustedMarker}\n`,
+        },
+      ]),
+    );
+    const d = decide(baseArgsJson({ commentsJsonFile }));
+    expect(d.skip).toBe(true);
+    expect(d.reason).toBe('unchanged');
+    expect(d.lastReviewedSha).toBe(SHA_A);
+  });
+
+  it('AC #2+#3 mixed — bot marker present + attacker marker present → bot wins', () => {
+    const probe = decide(baseArgsJson({}));
+    const trustedMarker = formatMarker({
+      contentHash: probe.currentContentHash,
+      reviewedSha: SHA_A,
+      reviewedAt: '2026-05-01T00:00:00.000Z',
+    });
+    const forgedMarker = formatMarker({
+      contentHash: 'f'.repeat(64), // mismatching hash that would NOT trigger skip anyway
+      reviewedSha: '2'.repeat(40),
+      reviewedAt: '2026-05-02T00:00:00.000Z',
+    });
+    const commentsJsonFile = join(tmp, 'comments.json');
+    // Attacker post is AFTER the bot post — without the filter, the
+    // freshest-wins findMarker scan would return the attacker's forged
+    // marker (which has a mismatching hash, so it wouldn't trigger skip
+    // here, but in the AC #2 test above an attacker who copies the bot's
+    // CURRENT hash succeeds). With the filter, the attacker is dropped
+    // and the bot's marker survives → skip:true.
+    writeFileSync(
+      commentsJsonFile,
+      JSON.stringify([
+        { authorLogin: 'github-actions', authorAssociation: 'CONTRIBUTOR', body: trustedMarker },
+        { authorLogin: 'external-attacker', authorAssociation: 'NONE', body: forgedMarker },
+      ]),
+    );
+    const d = decide(baseArgsJson({ commentsJsonFile }));
+    expect(d.skip).toBe(true);
+    expect(d.priorContentHash).toBe(probe.currentContentHash); // trusted hash, not 'f'*64
+  });
+
+  it('accepts the REST API shape (user.login + author_association) too', () => {
+    const probe = decide(baseArgsJson({}));
+    const trustedMarker = formatMarker({
+      contentHash: probe.currentContentHash,
+      reviewedSha: SHA_A,
+      reviewedAt: '2026-05-01T00:00:00.000Z',
+    });
+    const commentsJsonFile = join(tmp, 'comments.json');
+    // REST API shape: `user.login` WITH [bot] suffix + `author_association`.
+    writeFileSync(
+      commentsJsonFile,
+      JSON.stringify([
+        {
+          user: { login: 'github-actions[bot]' },
+          author_association: 'CONTRIBUTOR',
+          body: trustedMarker,
+        },
+      ]),
+    );
+    const d = decide(baseArgsJson({ commentsJsonFile }));
+    expect(d.skip).toBe(true);
+    expect(d.reason).toBe('unchanged');
+  });
+
+  it('treats unparseable JSON as empty list (safe-side: no-marker → FULL)', () => {
+    const commentsJsonFile = join(tmp, 'comments.json');
+    writeFileSync(commentsJsonFile, '{not valid json');
+    const d = decide(baseArgsJson({ commentsJsonFile }));
+    expect(d.reason).toBe('no-marker');
+    expect(stderrChunks.join('')).toMatch(/failed to parse --comments-json-file/);
+  });
+
+  it('treats non-array JSON as empty list (defensive)', () => {
+    const commentsJsonFile = join(tmp, 'comments.json');
+    writeFileSync(commentsJsonFile, '{"comments": []}'); // wrong shape — should be the array directly
+    const d = decide(baseArgsJson({ commentsJsonFile }));
+    expect(d.reason).toBe('no-marker');
+    expect(stderrChunks.join('')).toMatch(/--comments-json-file is not a JSON array/);
+  });
+
+  it('falls back to no-marker when --comments-json-file is unreadable', () => {
+    const d = decide(baseArgsJson({ commentsJsonFile: join(tmp, 'missing.json') }));
+    expect(d.reason).toBe('no-marker');
+    expect(stderrChunks.join('')).toMatch(/failed to read --comments-json-file/);
+  });
+
+  it('drops malformed records (no author info) without crashing', () => {
+    const probe = decide(baseArgsJson({}));
+    const trustedMarker = formatMarker({
+      contentHash: probe.currentContentHash,
+      reviewedSha: SHA_A,
+      reviewedAt: '2026-05-01T00:00:00.000Z',
+    });
+    const commentsJsonFile = join(tmp, 'comments.json');
+    writeFileSync(
+      commentsJsonFile,
+      JSON.stringify([
+        null,
+        'not an object',
+        { body: 'no author info at all' },
+        { authorLogin: 'github-actions', authorAssociation: 'CONTRIBUTOR', body: trustedMarker },
+      ]),
+    );
+    const d = decide(baseArgsJson({ commentsJsonFile }));
+    // The valid trusted comment still wins.
+    expect(d.skip).toBe(true);
+  });
+
+  it('--comments-json-file takes precedence over --comments-file when both are passed', () => {
+    // Set up: --comments-file carries an UNFILTERED bot-marker (legacy
+    // path). --comments-json-file carries an attacker comment. The newer
+    // safer path should win — and since the attacker comment is filtered
+    // out, the result is no-marker (NOT the legacy file's marker).
+    const probe = decide(baseArgsJson({}));
+    const validMarker = formatMarker({
+      contentHash: probe.currentContentHash,
+      reviewedSha: SHA_A,
+      reviewedAt: '2026-05-01T00:00:00.000Z',
+    });
+    const commentsFile = join(tmp, 'comments.txt');
+    writeFileSync(commentsFile, validMarker);
+    const commentsJsonFile = join(tmp, 'comments.json');
+    writeFileSync(
+      commentsJsonFile,
+      JSON.stringify([
+        { authorLogin: 'external-attacker', authorAssociation: 'NONE', body: validMarker },
+      ]),
+    );
+    const d = decide(baseArgsJson({ commentsFile, commentsJsonFile }));
+    expect(d.reason).toBe('no-marker');
+  });
+});
+
+describe('cli-incremental-decide — --comments-json-file CLI plumbing', () => {
+  it('CLI accepts --comments-json-file and routes through the filter', async () => {
+    const commentsJsonFile = join(tmp, 'comments.json');
+    // No prior trusted marker → no-marker on the JSON path.
+    writeFileSync(
+      commentsJsonFile,
+      JSON.stringify([
+        {
+          authorLogin: 'external-attacker',
+          authorAssociation: 'NONE',
+          body: formatMarker({
+            contentHash: HASH_A,
+            reviewedSha: SHA_A,
+            reviewedAt: '2026-05-01T00:00:00.000Z',
+          }),
+        },
+      ]),
+    );
+    const cli = buildIncrementalDecideCli({
+      argv: ['decide', '--comments-json-file', commentsJsonFile, '--repo-root', '/tmp/repo'],
+      runGit: makeRunGit({
+        'merge-base origin/main HEAD': BASE_SHA + '\n',
+        'diff --name-only --no-renames origin/main...HEAD': 'src/foo.ts\n',
+        [`ls-tree -r ${BASE_SHA} -- src/foo.ts`]: `100644 blob ${HEAD_SHA_A}\tsrc/foo.ts\n`,
+        'ls-tree -r HEAD -- src/foo.ts': `100644 blob ${HEAD_SHA_B}\tsrc/foo.ts\n`,
+      }),
+    });
+    await cli.parseAsync();
+    const d = stdoutJson<IncrementalDecision>();
+    expect(d.reason).toBe('no-marker'); // attacker filtered out → no marker
+  });
+});

--- a/pipeline-cli/src/cli/incremental-decide.ts
+++ b/pipeline-cli/src/cli/incremental-decide.ts
@@ -59,10 +59,13 @@ import {
   decideIncrementalReview,
   DEFAULT_MAX_DELTA_LINES,
   findMarkerInComments,
+  findTrustedMarkerInComments,
   formatMarker,
   parseNumstatForDelta,
+  type CommentWithAuthor,
   type DeltaStats,
   type IncrementalDecision,
+  type MarkerPayload,
   type RunGit,
 } from '../incremental-review/incremental.js';
 
@@ -115,7 +118,18 @@ export function buildIncrementalDecideCli(opts: BuildOptions = {}): Argv {
         y
           .option('comments-file', {
             type: 'string',
-            describe: 'File of prior PR comment bodies (search target for the marker).',
+            describe:
+              'File of prior PR comment bodies (search target for the marker). ' +
+              'IMPORTANT: callers MUST pre-filter to trusted authors at the fetch ' +
+              'site (gh pr view --jq) — this flag does NOT verify authorship. ' +
+              'Prefer --comments-json-file for defense-in-depth.',
+          })
+          .option('comments-json-file', {
+            type: 'string',
+            describe:
+              'Structured comments JSON: array of {authorLogin, authorAssociation, body}. ' +
+              'When passed, the CLI applies the trusted-author filter (Layer 1 + ' +
+              'Layer 2 of the AISDLC-142 round-2 fix) before searching for the marker.',
           })
           .option('base-ref', {
             type: 'string',
@@ -149,6 +163,7 @@ export function buildIncrementalDecideCli(opts: BuildOptions = {}): Argv {
       (parsed) => {
         const decision = decide({
           commentsFile: parsed['comments-file'] as string | undefined,
+          commentsJsonFile: parsed['comments-json-file'] as string | undefined,
           baseRef: parsed['base-ref'] as string,
           headRef: parsed['head-ref'] as string,
           repoRoot: parsed['repo-root'] as string,
@@ -215,6 +230,18 @@ export function buildIncrementalDecideCli(opts: BuildOptions = {}): Argv {
  */
 export interface DecideArgs {
   commentsFile?: string;
+  /**
+   * Path to a JSON file containing an array of `CommentWithAuthor` objects.
+   * When provided, the CLI applies the trusted-author filter
+   * (`filterTrustedComments`) BEFORE searching for the marker — defending
+   * against the AISDLC-142 round-2 forged-marker authorization bypass.
+   *
+   * Takes precedence over `commentsFile` when both are passed (the JSON
+   * variant is strictly more secure). The string-body variant is retained
+   * for backward compatibility but emits a warning to nudge callers
+   * toward the safer path.
+   */
+  commentsJsonFile?: string;
   baseRef: string;
   headRef: string;
   repoRoot: string;
@@ -224,18 +251,106 @@ export interface DecideArgs {
   runGit: RunGit;
 }
 
+/**
+ * Coerce a raw JSON-parsed comments record into a `CommentWithAuthor`. Tolerates
+ * both GraphQL (`author.login` + `authorAssociation`) and REST
+ * (`user.login` + `author_association`) shapes so callers can pass `gh pr
+ * view --json comments | jq '.comments'` output OR `github.rest.issues.listComments`
+ * output without a normalisation step. Drops malformed records.
+ */
+function coerceComment(raw: unknown): CommentWithAuthor | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const body = typeof r.body === 'string' ? r.body : '';
+  // Author login: prefer GraphQL `author.login`, fall back to REST `user.login`,
+  // fall back to top-level `authorLogin` (when callers already pre-normalise).
+  let authorLogin = '';
+  if (typeof r.authorLogin === 'string') {
+    authorLogin = r.authorLogin;
+  } else if (r.author && typeof r.author === 'object') {
+    const a = r.author as Record<string, unknown>;
+    if (typeof a.login === 'string') authorLogin = a.login;
+  } else if (r.user && typeof r.user === 'object') {
+    const u = r.user as Record<string, unknown>;
+    if (typeof u.login === 'string') authorLogin = u.login;
+  }
+  // Author association: GraphQL `authorAssociation` OR REST `author_association`
+  // OR pre-normalised top-level field.
+  let authorAssociation = '';
+  if (typeof r.authorAssociation === 'string') {
+    authorAssociation = r.authorAssociation;
+  } else if (typeof r.author_association === 'string') {
+    authorAssociation = r.author_association;
+  }
+  // Reject records with no author info — never safe to trust.
+  if (!authorLogin && !authorAssociation) return null;
+  return { authorLogin, authorAssociation, body };
+}
+
+/**
+ * Parse a comments-JSON file into a list of `CommentWithAuthor`. The file
+ * MUST be a JSON array (not the wrapping `{comments: [...]}` shape from `gh
+ * pr view`); callers pre-extract the array via `--jq '.comments'` to keep
+ * the CLI input simple.
+ *
+ * Errors fall through with an empty list — the calling decision then
+ * sees `prior: null` and routes to FULL review, preserving the safe-side
+ * default.
+ */
+function readCommentsJsonFile(path: string): CommentWithAuthor[] {
+  let text: string;
+  try {
+    text = readFileSync(path, 'utf-8');
+  } catch (err) {
+    warn(`failed to read --comments-json-file: ${(err as Error).message}`);
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    warn(`failed to parse --comments-json-file as JSON: ${(err as Error).message}`);
+    return [];
+  }
+  if (!Array.isArray(parsed)) {
+    warn(`--comments-json-file is not a JSON array (got ${typeof parsed})`);
+    return [];
+  }
+  const out: CommentWithAuthor[] = [];
+  for (const raw of parsed) {
+    const c = coerceComment(raw);
+    if (c !== null) out.push(c);
+  }
+  return out;
+}
+
 export function decide(args: DecideArgs): IncrementalDecision {
   // ── Locate prior marker (if any) ─────────────────────────────────
-  let priorMarkerBody = '';
-  if (args.commentsFile) {
+  let prior: MarkerPayload | null = null;
+  if (args.commentsJsonFile) {
+    // Preferred path (Layer 1 defense-in-depth): structured comments with
+    // author info → trust-filter → marker search.
+    const comments = readCommentsJsonFile(args.commentsJsonFile);
+    prior = findTrustedMarkerInComments(comments);
+  } else if (args.commentsFile) {
+    // Legacy path: bodies-only file. The CALLER (workflow `gh pr view --jq`
+    // filter, or slash-command body) is responsible for ensuring only
+    // trusted-author comments end up in this file. We warn so misuse is
+    // visible in CI logs.
+    warn(
+      '--comments-file is the legacy bodies-only input; ensure the FETCH ' +
+        'site filters by trusted author (CRITICAL — AISDLC-142 round 2). ' +
+        'Prefer --comments-json-file for in-CLI verification.',
+    );
+    let priorMarkerBody = '';
     try {
       priorMarkerBody = readFileSync(args.commentsFile, 'utf-8');
     } catch (err) {
       warn(`failed to read --comments-file: ${(err as Error).message}`);
       // Fall through with empty body → no marker → FULL review.
     }
+    prior = findMarkerInComments([priorMarkerBody]);
   }
-  const prior = findMarkerInComments([priorMarkerBody]);
 
   // ── Compute current contentHashV3 ───────────────────────────────
   let currentContentHash = '';

--- a/pipeline-cli/src/cli/incremental-decide.ts
+++ b/pipeline-cli/src/cli/incremental-decide.ts
@@ -1,0 +1,319 @@
+/**
+ * `cli-incremental-decide` subcommand router (AISDLC-142).
+ *
+ * Wraps the incremental-review primitives so the `/ai-sdlc execute` Step 7
+ * body + the `analyze` job in `.github/workflows/ai-sdlc-review.yml` can
+ * decide on each push whether to:
+ *   - SKIP the review entirely (contentHash unchanged since prior approval)
+ *   - DELTA-ONLY review (`git diff <last-reviewed-sha>...HEAD`)
+ *   - FULL review (first push, or delta over the safety threshold)
+ *
+ * Composes ON TOP of the AISDLC-141 classifier — classifier decides WHICH
+ * reviewers to run; this CLI decides WHAT each one reads. The two CLIs are
+ * kept separate so callers can run only one (e.g. local dev that wants the
+ * incremental decision but not the classifier subset).
+ *
+ * Subcommands:
+ *   - `decide`              — emit an IncrementalDecision JSON for a PR push
+ *   - `format-marker`       — emit the marker comment body for a hash + sha
+ *
+ * Inputs (all required for `decide` unless noted):
+ *   --comments-file <path>   — file containing prior PR comment bodies, one
+ *                              per line OR concatenated. We just search for
+ *                              the marker substring so any reasonable encoding
+ *                              works. Pass /dev/null for "no prior comments."
+ *   --base-ref <ref>         — base ref (typically `origin/main`)
+ *   --head-ref <ref>         — head ref (typically `HEAD`)
+ *   --repo-root <path>       — path to the git worktree root (defaults cwd)
+ *   --numstat-file <path>    — `git diff <last-reviewed-sha>...HEAD --numstat`
+ *                              output. Required when a prior marker exists;
+ *                              omit on first push (we'll synthesise empty
+ *                              stats and the no-marker branch wins).
+ *   --full-diff-paths-file <path>
+ *                            — `git diff <base-ref>...HEAD --name-only` output.
+ *                              Used to compute the set of top-level dirs in
+ *                              the FULL PR diff so the new-top-level-dir
+ *                              guard can fire correctly. Optional.
+ *   --max-delta-lines <n>    — threshold for the `delta-too-large` branch.
+ *                              Defaults to DEFAULT_MAX_DELTA_LINES (200).
+ *
+ * Output: IncrementalDecision JSON on stdout. Exit 0 on success.
+ *
+ * Failure modes (mirrors AISDLC-141 fall-open semantics):
+ *   - If git fails or the inputs are unreadable, we emit a `no-marker`-equivalent
+ *     decision (`deltaOnly: false`, `skip: false`, current contentHash empty)
+ *     so the caller falls back to FULL review. We never silently skip a
+ *     review we should have done.
+ *
+ * @module cli/incremental-decide
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import yargs, { type Argv } from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import {
+  buildAutoApprovedVerdict,
+  collectChangedFileDeltaEntries,
+  computeContentHashV3,
+  decideIncrementalReview,
+  DEFAULT_MAX_DELTA_LINES,
+  findMarkerInComments,
+  formatMarker,
+  parseNumstatForDelta,
+  type DeltaStats,
+  type IncrementalDecision,
+  type RunGit,
+} from '../incremental-review/incremental.js';
+
+function emit(result: unknown): void {
+  process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+}
+
+function warn(message: string): void {
+  process.stderr.write(`[cli-incremental-decide] ${message}\n`);
+}
+
+/**
+ * Default git runner — `execFileSync` with the operator's PATH. Tests inject
+ * a stub via `buildIncrementalDecideCli({ runGit })`.
+ */
+function defaultRunGit(): RunGit {
+  return (args: string[], cwd: string): string =>
+    execFileSync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+}
+
+/** Override hooks (tests pass a stub `runGit` to avoid spawning git). */
+export interface BuildOptions {
+  runGit?: RunGit;
+  /**
+   * Override `process.argv` slice handed to yargs. Used by tests so they
+   * don't have to mutate `process.argv` directly. Defaults `hideBin(process.argv)`.
+   */
+  argv?: string[];
+}
+
+/**
+ * Build the cli-incremental-decide yargs program. Exported so tests can
+ * drive the parser without going through process.argv.
+ */
+export function buildIncrementalDecideCli(opts: BuildOptions = {}): Argv {
+  const runGit = opts.runGit ?? defaultRunGit();
+  const argv = opts.argv ?? hideBin(process.argv);
+
+  return yargs(argv)
+    .scriptName('cli-incremental-decide')
+    .usage('Usage: $0 <command> [options]')
+    .command(
+      ['decide', '$0'],
+      'Decide skip / delta-only / full for the current push.',
+      (y) =>
+        y
+          .option('comments-file', {
+            type: 'string',
+            describe: 'File of prior PR comment bodies (search target for the marker).',
+          })
+          .option('base-ref', {
+            type: 'string',
+            default: 'origin/main',
+            describe: 'Base ref for the contentHashV3 computation.',
+          })
+          .option('head-ref', {
+            type: 'string',
+            default: 'HEAD',
+            describe: 'Head ref for the contentHashV3 computation.',
+          })
+          .option('repo-root', {
+            type: 'string',
+            default: process.cwd(),
+            describe: 'Path to the git worktree root.',
+          })
+          .option('numstat-file', {
+            type: 'string',
+            describe: 'git diff <last-reviewed-sha>...HEAD --numstat output (delta sizing).',
+          })
+          .option('full-diff-paths-file', {
+            type: 'string',
+            describe:
+              'git diff <base-ref>...HEAD --name-only output (computes full-PR top-level dir set).',
+          })
+          .option('max-delta-lines', {
+            type: 'number',
+            default: DEFAULT_MAX_DELTA_LINES,
+            describe: 'Lines threshold for the delta-too-large branch.',
+          }),
+      (parsed) => {
+        const decision = decide({
+          commentsFile: parsed['comments-file'] as string | undefined,
+          baseRef: parsed['base-ref'] as string,
+          headRef: parsed['head-ref'] as string,
+          repoRoot: parsed['repo-root'] as string,
+          numstatFile: parsed['numstat-file'] as string | undefined,
+          fullDiffPathsFile: parsed['full-diff-paths-file'] as string | undefined,
+          maxDeltaLines: parsed['max-delta-lines'] as number,
+          runGit,
+        });
+        emit(decision);
+      },
+    )
+    .command(
+      'format-marker',
+      'Emit the marker comment body for a contentHash + reviewedSha.',
+      (y) =>
+        y
+          .option('content-hash', {
+            type: 'string',
+            demandOption: true,
+            describe: '64-char hex sha256 (the contentHashV3 just computed).',
+          })
+          .option('reviewed-sha', {
+            type: 'string',
+            demandOption: true,
+            describe: '40-char hex sha1 (the commit reviewed against this hash).',
+          })
+          .option('reviewed-at', {
+            type: 'string',
+            describe: 'ISO 8601 timestamp; defaults to now.',
+          }),
+      (parsed) => {
+        const marker = formatMarker({
+          contentHash: String(parsed['content-hash']).toLowerCase(),
+          reviewedSha: String(parsed['reviewed-sha']).toLowerCase(),
+          reviewedAt: (parsed['reviewed-at'] as string | undefined) ?? new Date().toISOString(),
+        });
+        process.stdout.write(`${marker}\n`);
+      },
+    )
+    .command(
+      'auto-approved-verdict',
+      'Emit the auto-approved verdict JSON for the skip path.',
+      (y) =>
+        y.option('reviewed-sha', {
+          type: 'string',
+          demandOption: true,
+          describe: 'SHA the prior approval bound to (for the summary line).',
+        }),
+      (parsed) => {
+        emit(buildAutoApprovedVerdict(String(parsed['reviewed-sha']).toLowerCase()));
+      },
+    )
+    .strict()
+    .help()
+    .alias('h', 'help')
+    .version(false);
+}
+
+/**
+ * Pure decision wrapper — read the inputs, build the decision, return the
+ * envelope. Exported so the slash-command body can be unit-tested without
+ * shelling out, and so callers can compose the decision into other flows
+ * (e.g. dogfood watch, RFC-0012 Tier-2 spawner).
+ */
+export interface DecideArgs {
+  commentsFile?: string;
+  baseRef: string;
+  headRef: string;
+  repoRoot: string;
+  numstatFile?: string;
+  fullDiffPathsFile?: string;
+  maxDeltaLines: number;
+  runGit: RunGit;
+}
+
+export function decide(args: DecideArgs): IncrementalDecision {
+  // ── Locate prior marker (if any) ─────────────────────────────────
+  let priorMarkerBody = '';
+  if (args.commentsFile) {
+    try {
+      priorMarkerBody = readFileSync(args.commentsFile, 'utf-8');
+    } catch (err) {
+      warn(`failed to read --comments-file: ${(err as Error).message}`);
+      // Fall through with empty body → no marker → FULL review.
+    }
+  }
+  const prior = findMarkerInComments([priorMarkerBody]);
+
+  // ── Compute current contentHashV3 ───────────────────────────────
+  let currentContentHash = '';
+  try {
+    const entries = collectChangedFileDeltaEntries(
+      args.baseRef,
+      args.headRef,
+      args.repoRoot,
+      args.runGit,
+    );
+    currentContentHash = computeContentHashV3(entries);
+  } catch (err) {
+    warn(`failed to compute contentHashV3: ${(err as Error).message}`);
+    // Fall through. The decision below will see empty currentContentHash;
+    // since prior?.contentHash will never equal '' (parseMarker rejects
+    // non-hex), the unchanged branch can't fire spuriously, and we'll
+    // route to FULL review on the no-marker / delta-too-large branch.
+  }
+
+  // ── Compute delta stats (when a marker exists) ──────────────────
+  let deltaStats: DeltaStats = {
+    linesAdded: 0,
+    linesRemoved: 0,
+    totalLines: 0,
+    topLevelDirs: new Set<string>(),
+    filesChanged: 0,
+  };
+  if (prior !== null && args.numstatFile) {
+    try {
+      const numstat = readFileSync(args.numstatFile, 'utf-8');
+      deltaStats = parseNumstatForDelta(numstat);
+    } catch (err) {
+      warn(`failed to read --numstat-file: ${(err as Error).message}`);
+      // Fall through with empty stats. The contentHash mismatch will still
+      // route us through the change branch; an empty delta-stats set means
+      // totalLines is 0, which falls under the threshold → delta-only path.
+      // That's the WRONG answer when the file is missing because of an
+      // I/O error rather than a genuinely empty delta — so we deliberately
+      // bias toward the safer FULL review by zeroing out the marker.
+      // (Implementation detail: we set deltaSize past the cap below.)
+      deltaStats.totalLines = args.maxDeltaLines + 1;
+    }
+  }
+
+  // ── Compute full-diff top-level dir set for the new-dir guard ───
+  const fullDiffTopLevelDirs = new Set<string>();
+  if (args.fullDiffPathsFile) {
+    try {
+      const text = readFileSync(args.fullDiffPathsFile, 'utf-8');
+      for (const raw of text.split('\n')) {
+        const path = raw.trim();
+        if (!path) continue;
+        const slash = path.indexOf('/');
+        fullDiffTopLevelDirs.add(slash === -1 ? '' : path.slice(0, slash));
+      }
+    } catch (err) {
+      warn(`failed to read --full-diff-paths-file: ${(err as Error).message}`);
+      // Without the full-diff set, the new-top-level-dir guard cannot fire
+      // (every dir in the delta is "new"). Bias toward safer FULL review by
+      // adding every delta-side dir to the full-diff set so the guard is a
+      // no-op. The decision then hinges on hash + delta size only.
+      for (const dir of deltaStats.topLevelDirs) fullDiffTopLevelDirs.add(dir);
+    }
+  } else {
+    // No --full-diff-paths-file → disable the new-dir guard cleanly.
+    for (const dir of deltaStats.topLevelDirs) fullDiffTopLevelDirs.add(dir);
+  }
+
+  return decideIncrementalReview({
+    prior,
+    currentContentHash,
+    deltaStats,
+    fullDiffTopLevelDirs,
+    maxDeltaLines: args.maxDeltaLines,
+  });
+}
+
+/** Run the cli-incremental-decide CLI. Used by the bin shim. */
+export async function runIncrementalDecideCli(): Promise<void> {
+  await buildIncrementalDecideCli().parseAsync();
+}

--- a/pipeline-cli/src/cli/incremental-decide.ts
+++ b/pipeline-cli/src/cli/incremental-decide.ts
@@ -69,8 +69,27 @@ import {
   type RunGit,
 } from '../incremental-review/incremental.js';
 
+/**
+ * Emit a CLI result as a single line of JSON followed by `\n`.
+ *
+ * CRITICAL — DO NOT pretty-print (AISDLC-142 round 3): the `analyze` job in
+ * `.github/workflows/ai-sdlc-review.yml` consumes the `auto-approved-verdict`
+ * subcommand output via `tail -1 /tmp/review-${TYPE}.txt`. If the output is
+ * multi-line pretty-printed JSON, `tail -1` extracts only the trailing `}`
+ * and the report job's `JSON.parse('}')` throws → every reviewer is reported
+ * as FAILED → gate computes CHANGES_REQUESTED → PR is BLOCKED. That defeats
+ * the entire SKIP path the incremental-review feature exists to provide,
+ * AND because the marker step then sees `allApproved=false` the marker is
+ * never refreshed, so the next push hits the same problem (PR permanently
+ * stuck).
+ *
+ * The `decide` subcommand consumer (`printf '%s' | jq -r`) works fine with
+ * either single-line or multi-line — single-line is strictly more compatible.
+ *
+ * Workflow contract: every JSON line emitted by this CLI is exactly one line.
+ */
 function emit(result: unknown): void {
-  process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  process.stdout.write(JSON.stringify(result) + '\n');
 }
 
 function warn(message: string): void {

--- a/pipeline-cli/src/incremental-review/incremental.test.ts
+++ b/pipeline-cli/src/incremental-review/incremental.test.ts
@@ -1,0 +1,489 @@
+/**
+ * Hermetic tests for the AISDLC-142 incremental-review primitives.
+ *
+ * Covers AC #8 scenarios (rebase-no-content-change → skip; small-fix →
+ * delta-only; large-refactor → full; first-push → full) plus the marker
+ * parse/format round-trip + the delta-size predicate + contentHashV3
+ * algorithm parity with the orchestrator copy.
+ */
+
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  buildAutoApprovedVerdict,
+  collectChangedFileDeltaEntries,
+  computeContentHashV3,
+  DEFAULT_MAX_DELTA_LINES,
+  decideIncrementalReview,
+  findMarkerInComments,
+  formatMarker,
+  MARKER_PREFIX,
+  parseMarker,
+  parseNumstatForDelta,
+  type DeltaStats,
+  type MarkerPayload,
+  type RunGit,
+} from './incremental.js';
+
+// ── Marker parse / format round-trip ────────────────────────────────
+
+describe('formatMarker / parseMarker', () => {
+  it('round-trips a payload exactly', () => {
+    const payload: MarkerPayload = {
+      contentHash: 'a'.repeat(64),
+      reviewedSha: 'b'.repeat(40),
+      reviewedAt: '2026-05-01T12:34:56.000Z',
+    };
+    const body = formatMarker(payload);
+    expect(body.startsWith(MARKER_PREFIX)).toBe(true);
+    expect(body.endsWith(' -->')).toBe(true);
+    const parsed = parseMarker(body);
+    expect(parsed).toEqual(payload);
+  });
+
+  it('locates the marker even when surrounded by other markdown', () => {
+    const payload: MarkerPayload = {
+      contentHash: 'c'.repeat(64),
+      reviewedSha: 'd'.repeat(40),
+      reviewedAt: '2026-05-02T01:02:03.000Z',
+    };
+    const body = `## AI-SDLC: incremental review state\n\nLast reviewed: foo\n\n${formatMarker(payload)}\n\n_Edit at your own peril._`;
+    expect(parseMarker(body)).toEqual(payload);
+  });
+
+  it('returns null when no marker is present', () => {
+    expect(parseMarker('## Some other comment\n\nHello world.\n')).toBeNull();
+    expect(parseMarker('')).toBeNull();
+  });
+
+  it('returns null on a malformed marker (corrupt b64)', () => {
+    const body = `${MARKER_PREFIX}!!! not base64 !!! -->`;
+    expect(parseMarker(body)).toBeNull();
+  });
+
+  it('returns null when the parsed JSON has the wrong shape', () => {
+    const body = `${MARKER_PREFIX}${Buffer.from('{"contentHash":"too-short","reviewedSha":"x","reviewedAt":"now"}').toString('base64url')} -->`;
+    expect(parseMarker(body)).toBeNull();
+  });
+
+  it('returns null when the marker is unterminated', () => {
+    expect(parseMarker(`${MARKER_PREFIX}some-payload-but-no-suffix`)).toBeNull();
+  });
+
+  it('returns null when the encoded payload is empty', () => {
+    expect(parseMarker(`${MARKER_PREFIX} -->`)).toBeNull();
+  });
+
+  it('lowercases case-insensitive hex fields on parse', () => {
+    const body = formatMarker({
+      contentHash: 'A'.repeat(64),
+      reviewedSha: 'B'.repeat(40),
+      reviewedAt: '2026-05-01T00:00:00.000Z',
+    });
+    const parsed = parseMarker(body);
+    expect(parsed?.contentHash).toBe('a'.repeat(64));
+    expect(parsed?.reviewedSha).toBe('b'.repeat(40));
+  });
+});
+
+describe('findMarkerInComments', () => {
+  it('returns the LAST marker when multiple comments carry one (freshest wins)', () => {
+    const older = formatMarker({
+      contentHash: '1'.repeat(64),
+      reviewedSha: '1'.repeat(40),
+      reviewedAt: '2026-05-01T00:00:00.000Z',
+    });
+    const newer = formatMarker({
+      contentHash: '2'.repeat(64),
+      reviewedSha: '2'.repeat(40),
+      reviewedAt: '2026-05-02T00:00:00.000Z',
+    });
+    expect(findMarkerInComments([older, 'no marker here', newer])?.contentHash).toBe(
+      '2'.repeat(64),
+    );
+  });
+
+  it('returns null when no comment has a marker', () => {
+    expect(findMarkerInComments(['hello', 'world'])).toBeNull();
+  });
+
+  it('returns null on an empty list', () => {
+    expect(findMarkerInComments([])).toBeNull();
+  });
+});
+
+// ── ContentHashV3 parity with orchestrator ─────────────────────────
+
+/**
+ * Reference implementation of the canonical `contentHashV3` encoding pulled
+ * verbatim from `orchestrator/src/runtime/attestations.ts#computeContentHashV3`.
+ * Re-implementing it here keeps the parity check hermetic (no cross-package
+ * src import) while still asserting the algorithms are byte-identical. If
+ * the orchestrator copy ever changes, this test must be updated too.
+ */
+function referenceContentHashV3(
+  entries: { path: string; baseBlobSha: string; headBlobSha: string }[],
+): string {
+  const sha256Hex = (s: string): string => createHash('sha256').update(s, 'utf-8').digest('hex');
+  const byPath = new Map<string, { baseBlobSha: string; headBlobSha: string }>();
+  for (const e of entries) {
+    const normalizedPath = e.path.replace(/\\/g, '/');
+    byPath.set(normalizedPath, {
+      baseBlobSha: e.baseBlobSha.toLowerCase(),
+      headBlobSha: e.headBlobSha.toLowerCase(),
+    });
+  }
+  const sorted = [...byPath.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  const canonical = sorted
+    .map(([path, { baseBlobSha, headBlobSha }]) => {
+      const fileDeltaHash = sha256Hex(`${baseBlobSha} -> ${headBlobSha}`);
+      return `${path}\t${fileDeltaHash}\n`;
+    })
+    .join('');
+  return sha256Hex(canonical);
+}
+
+describe('computeContentHashV3 — algorithm parity with orchestrator', () => {
+  it('produces byte-identical hashes to the orchestrator reference implementation', () => {
+    const entries = [
+      { path: 'src/foo.ts', baseBlobSha: 'aa'.repeat(20), headBlobSha: 'bb'.repeat(20) },
+      { path: 'docs/intro.md', baseBlobSha: '', headBlobSha: 'cc'.repeat(20) },
+    ];
+    expect(computeContentHashV3(entries)).toBe(referenceContentHashV3(entries));
+  });
+
+  it('ignores path order via dedup-by-path + sort', () => {
+    const a = [
+      { path: 'a.ts', baseBlobSha: '11'.repeat(20), headBlobSha: '22'.repeat(20) },
+      { path: 'b.ts', baseBlobSha: '33'.repeat(20), headBlobSha: '44'.repeat(20) },
+    ];
+    const b = [a[1], a[0]];
+    expect(computeContentHashV3(a)).toBe(computeContentHashV3(b));
+  });
+
+  it('returns sha256("") for an empty entry list (well-defined no-op)', () => {
+    // sha256 of the empty string — verifiable independently.
+    expect(computeContentHashV3([])).toBe(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    );
+  });
+
+  it('rejects path entries containing tabs or newlines (canonical injectivity)', () => {
+    expect(() =>
+      computeContentHashV3([{ path: 'a\tb.ts', baseBlobSha: '', headBlobSha: '' }]),
+    ).toThrow(/tab or newline/);
+    expect(() =>
+      computeContentHashV3([{ path: 'a\nb.ts', baseBlobSha: '', headBlobSha: '' }]),
+    ).toThrow(/tab or newline/);
+  });
+
+  it('rejects malformed inputs with a precise reason', () => {
+    expect(() => computeContentHashV3([{ path: '', baseBlobSha: '', headBlobSha: '' }])).toThrow(
+      /non-empty/,
+    );
+    // Force the bad-type branches via `any`-style casts — pure-function
+    // contract validation, not type-system sugar.
+    expect(() =>
+      computeContentHashV3([
+        { path: 'a.ts', baseBlobSha: 1 as unknown as string, headBlobSha: '' },
+      ]),
+    ).toThrow(/baseBlobSha/);
+    expect(() =>
+      computeContentHashV3([
+        { path: 'a.ts', baseBlobSha: '', headBlobSha: 1 as unknown as string },
+      ]),
+    ).toThrow(/headBlobSha/);
+  });
+});
+
+// ── collectChangedFileDeltaEntries — exercises the runGit injection ─
+
+describe('collectChangedFileDeltaEntries', () => {
+  function makeRunGit(responses: Record<string, string>): RunGit {
+    return (args: string[], _cwd: string) => {
+      const key = args.join(' ');
+      for (const k of Object.keys(responses)) {
+        if (key.includes(k)) return responses[k];
+      }
+      throw new Error(`unexpected git invocation: ${key}`);
+    };
+  }
+
+  it('walks merge-base + diff --name-only + ls-tree and assembles entries', () => {
+    const runGit = makeRunGit({
+      'merge-base origin/main HEAD': 'a'.repeat(40) + '\n',
+      'diff --name-only --no-renames origin/main...HEAD': 'src/foo.ts\nsrc/bar.ts\n',
+      [`ls-tree -r ${'a'.repeat(40)} -- src/foo.ts`]: `100644 blob ${'1'.repeat(40)}\tsrc/foo.ts\n`,
+      'ls-tree -r HEAD -- src/foo.ts': `100644 blob ${'2'.repeat(40)}\tsrc/foo.ts\n`,
+      [`ls-tree -r ${'a'.repeat(40)} -- src/bar.ts`]: '', // newly added file
+      'ls-tree -r HEAD -- src/bar.ts': `100644 blob ${'3'.repeat(40)}\tsrc/bar.ts\n`,
+    });
+    const entries = collectChangedFileDeltaEntries('origin/main', 'HEAD', '/tmp/repo', runGit);
+    expect(entries).toEqual([
+      { path: 'src/foo.ts', baseBlobSha: '1'.repeat(40), headBlobSha: '2'.repeat(40) },
+      { path: 'src/bar.ts', baseBlobSha: '', headBlobSha: '3'.repeat(40) },
+    ]);
+  });
+
+  it('throws a tagged error when git merge-base fails', () => {
+    const runGit: RunGit = (args) => {
+      if (args[0] === 'merge-base') throw new Error('boom');
+      return '';
+    };
+    expect(() => collectChangedFileDeltaEntries('a', 'b', '/r', runGit)).toThrow(
+      /git merge-base failed/,
+    );
+  });
+
+  it('throws when merge-base returns non-SHA output (defends against weird CI envs)', () => {
+    const runGit: RunGit = (args) => (args[0] === 'merge-base' ? 'not-a-sha\n' : '');
+    expect(() => collectChangedFileDeltaEntries('a', 'b', '/r', runGit)).toThrow(/non-SHA output/);
+  });
+
+  it('throws when git diff --name-only fails', () => {
+    const runGit: RunGit = (args) => {
+      if (args[0] === 'merge-base') return 'a'.repeat(40) + '\n';
+      throw new Error('diff blew up');
+    };
+    expect(() => collectChangedFileDeltaEntries('a', 'b', '/r', runGit)).toThrow(
+      /git diff --name-only failed/,
+    );
+  });
+
+  it('rejects paths containing tab/newline (mirrors injectivity guard)', () => {
+    const runGit: RunGit = (args) => {
+      if (args[0] === 'merge-base') return 'a'.repeat(40) + '\n';
+      if (args.includes('--name-only')) return 'bad\tpath.ts\n';
+      return '';
+    };
+    expect(() => collectChangedFileDeltaEntries('origin/main', 'HEAD', '/r', runGit)).toThrow(
+      /tab or newline/,
+    );
+  });
+
+  it('treats empty ls-tree output as a deleted file (empty blob marker)', () => {
+    const runGit = makeRunGit({
+      'merge-base origin/main HEAD': 'a'.repeat(40) + '\n',
+      'diff --name-only --no-renames origin/main...HEAD': 'src/old.ts\n',
+      [`ls-tree -r ${'a'.repeat(40)} -- src/old.ts`]: `100644 blob ${'4'.repeat(40)}\tsrc/old.ts\n`,
+      'ls-tree -r HEAD -- src/old.ts': '', // file deleted at HEAD
+    });
+    const entries = collectChangedFileDeltaEntries('origin/main', 'HEAD', '/r', runGit);
+    expect(entries[0].headBlobSha).toBe('');
+    expect(entries[0].baseBlobSha).toBe('4'.repeat(40));
+  });
+
+  it('treats ls-tree throwing as an empty blob (path missing at ref)', () => {
+    const runGit: RunGit = (args) => {
+      if (args[0] === 'merge-base') return 'a'.repeat(40) + '\n';
+      if (args.includes('--name-only')) return 'src/x.ts\n';
+      throw new Error('ls-tree exploded');
+    };
+    const entries = collectChangedFileDeltaEntries('origin/main', 'HEAD', '/r', runGit);
+    expect(entries).toEqual([{ path: 'src/x.ts', baseBlobSha: '', headBlobSha: '' }]);
+  });
+});
+
+// ── parseNumstatForDelta ────────────────────────────────────────────
+
+describe('parseNumstatForDelta', () => {
+  it('sums lines + collects top-level dirs', () => {
+    const out = parseNumstatForDelta(
+      ['10\t2\tsrc/foo.ts', '0\t5\tdocs/intro.md', '3\t0\tREADME.md'].join('\n'),
+    );
+    expect(out.linesAdded).toBe(13);
+    expect(out.linesRemoved).toBe(7);
+    expect(out.totalLines).toBe(20);
+    expect(out.filesChanged).toBe(3);
+    expect([...out.topLevelDirs].sort()).toEqual(['', 'docs', 'src']);
+  });
+
+  it("treats `-` (binary) as 0 lines so binary churn doesn't fall through to the cap", () => {
+    const out = parseNumstatForDelta('-\t-\tsrc/image.png\n10\t0\tsrc/wire.ts\n');
+    expect(out.linesAdded).toBe(10);
+    expect(out.linesRemoved).toBe(0);
+    expect(out.filesChanged).toBe(2);
+  });
+
+  it('skips blank lines + malformed lines', () => {
+    const out = parseNumstatForDelta('\nnot-a-numstat-line\n5\t1\tsrc/foo.ts\n');
+    expect(out.totalLines).toBe(6);
+    expect(out.filesChanged).toBe(1);
+  });
+});
+
+// ── decideIncrementalReview — AC #8 scenarios ──────────────────────
+
+const HASH_A = 'a'.repeat(64);
+const HASH_B = 'b'.repeat(64);
+const SHA_A = '1'.repeat(40);
+
+const emptyStats: DeltaStats = {
+  linesAdded: 0,
+  linesRemoved: 0,
+  totalLines: 0,
+  topLevelDirs: new Set<string>(),
+  filesChanged: 0,
+};
+
+describe('decideIncrementalReview — AC #8 scenarios', () => {
+  it('AC #8.4 first-push (no marker) → full review (`no-marker`)', () => {
+    const d = decideIncrementalReview({
+      prior: null,
+      currentContentHash: HASH_A,
+      deltaStats: emptyStats,
+      fullDiffTopLevelDirs: new Set(['src']),
+    });
+    expect(d.skip).toBe(false);
+    expect(d.deltaOnly).toBe(false);
+    expect(d.reason).toBe('no-marker');
+    expect(d.lastReviewedSha).toBeNull();
+    expect(d.priorContentHash).toBeNull();
+    expect(d.currentContentHash).toBe(HASH_A);
+  });
+
+  it('AC #8.1 rebase-no-content-change (hash equal) → SKIP (`unchanged`)', () => {
+    const d = decideIncrementalReview({
+      prior: { contentHash: HASH_A, reviewedSha: SHA_A, reviewedAt: '2026-05-01T00:00:00.000Z' },
+      currentContentHash: HASH_A,
+      deltaStats: { ...emptyStats, totalLines: 999 }, // even huge delta
+      fullDiffTopLevelDirs: new Set(['src']),
+    });
+    expect(d.skip).toBe(true);
+    expect(d.deltaOnly).toBe(false);
+    expect(d.reason).toBe('unchanged');
+    expect(d.lastReviewedSha).toBe(SHA_A);
+    expect(d.priorContentHash).toBe(HASH_A);
+  });
+
+  it('AC #8.2 small-fix scenario → DELTA-ONLY (`delta-only`)', () => {
+    const d = decideIncrementalReview({
+      prior: { contentHash: HASH_A, reviewedSha: SHA_A, reviewedAt: '2026-05-01T00:00:00.000Z' },
+      currentContentHash: HASH_B,
+      deltaStats: {
+        linesAdded: 4,
+        linesRemoved: 1,
+        totalLines: 5,
+        topLevelDirs: new Set(['src']),
+        filesChanged: 1,
+      },
+      fullDiffTopLevelDirs: new Set(['src', 'docs']),
+    });
+    expect(d.skip).toBe(false);
+    expect(d.deltaOnly).toBe(true);
+    expect(d.reason).toBe('delta-only');
+    expect(d.deltaSize).toBe(5);
+  });
+
+  it('AC #8.3 large-refactor scenario → FULL review (`delta-too-large`)', () => {
+    const d = decideIncrementalReview({
+      prior: { contentHash: HASH_A, reviewedSha: SHA_A, reviewedAt: '2026-05-01T00:00:00.000Z' },
+      currentContentHash: HASH_B,
+      deltaStats: {
+        linesAdded: 350,
+        linesRemoved: 100,
+        totalLines: 450,
+        topLevelDirs: new Set(['src']),
+        filesChanged: 12,
+      },
+      fullDiffTopLevelDirs: new Set(['src']),
+    });
+    expect(d.skip).toBe(false);
+    expect(d.deltaOnly).toBe(false);
+    expect(d.reason).toBe('delta-too-large');
+  });
+
+  it('boundary: delta exactly at the cap stays delta-only (cap is `>`, not `>=`)', () => {
+    const d = decideIncrementalReview({
+      prior: { contentHash: HASH_A, reviewedSha: SHA_A, reviewedAt: '2026-05-01T00:00:00.000Z' },
+      currentContentHash: HASH_B,
+      deltaStats: {
+        linesAdded: DEFAULT_MAX_DELTA_LINES,
+        linesRemoved: 0,
+        totalLines: DEFAULT_MAX_DELTA_LINES,
+        topLevelDirs: new Set(['src']),
+        filesChanged: 1,
+      },
+      fullDiffTopLevelDirs: new Set(['src']),
+    });
+    expect(d.deltaOnly).toBe(true);
+  });
+
+  it('configurable cap: `--max-delta-lines 50` shrinks the threshold', () => {
+    const d = decideIncrementalReview({
+      prior: { contentHash: HASH_A, reviewedSha: SHA_A, reviewedAt: '2026-05-01T00:00:00.000Z' },
+      currentContentHash: HASH_B,
+      deltaStats: {
+        linesAdded: 60,
+        linesRemoved: 0,
+        totalLines: 60,
+        topLevelDirs: new Set(['src']),
+        filesChanged: 1,
+      },
+      fullDiffTopLevelDirs: new Set(['src']),
+      maxDeltaLines: 50,
+    });
+    expect(d.reason).toBe('delta-too-large');
+  });
+
+  it('safety: delta touches a top-level dir not in full PR → FULL (`new-top-level-dir`)', () => {
+    // Arises when the delta itself adds a brand-new top-level dir vs. the
+    // full PR diff at the time of the prior review. We approximate via the
+    // current full-diff set; if the delta dir isn't in that set, the delta
+    // is the FIRST push touching it.
+    const d = decideIncrementalReview({
+      prior: { contentHash: HASH_A, reviewedSha: SHA_A, reviewedAt: '2026-05-01T00:00:00.000Z' },
+      currentContentHash: HASH_B,
+      deltaStats: {
+        linesAdded: 10,
+        linesRemoved: 0,
+        totalLines: 10,
+        topLevelDirs: new Set(['scripts']), // scripts NOT in full-diff set
+        filesChanged: 1,
+      },
+      fullDiffTopLevelDirs: new Set(['src']),
+    });
+    expect(d.deltaOnly).toBe(false);
+    expect(d.reason).toBe('new-top-level-dir');
+  });
+
+  it('safety: delta-only never returned with skip=true (mutual exclusion)', () => {
+    // Defensive — verify the function NEVER returns both flags true.
+    const cases: Parameters<typeof decideIncrementalReview>[0][] = [
+      {
+        prior: null,
+        currentContentHash: HASH_A,
+        deltaStats: emptyStats,
+        fullDiffTopLevelDirs: new Set(),
+      },
+      {
+        prior: { contentHash: HASH_A, reviewedSha: SHA_A, reviewedAt: '' },
+        currentContentHash: HASH_A,
+        deltaStats: emptyStats,
+        fullDiffTopLevelDirs: new Set(),
+      },
+      {
+        prior: { contentHash: HASH_A, reviewedSha: SHA_A, reviewedAt: '' },
+        currentContentHash: HASH_B,
+        deltaStats: { ...emptyStats, totalLines: 5, topLevelDirs: new Set(['src']) },
+        fullDiffTopLevelDirs: new Set(['src']),
+      },
+    ];
+    for (const inp of cases) {
+      const d = decideIncrementalReview(inp);
+      expect(d.skip && d.deltaOnly).toBe(false);
+    }
+  });
+});
+
+// ── buildAutoApprovedVerdict ────────────────────────────────────────
+
+describe('buildAutoApprovedVerdict', () => {
+  it('produces the auto-approved shape that matches AISDLC-141 schema', () => {
+    const v = buildAutoApprovedVerdict('1'.repeat(40));
+    expect(v.approved).toBe(true);
+    expect(v.findings).toEqual([]);
+    expect(v.summary).toMatch(/Skipped by incremental review/);
+    expect(v.summary).toContain('1'.repeat(40));
+  });
+});

--- a/pipeline-cli/src/incremental-review/incremental.test.ts
+++ b/pipeline-cli/src/incremental-review/incremental.test.ts
@@ -15,11 +15,16 @@ import {
   computeContentHashV3,
   DEFAULT_MAX_DELTA_LINES,
   decideIncrementalReview,
+  filterTrustedComments,
   findMarkerInComments,
+  findTrustedMarkerInComments,
   formatMarker,
   MARKER_PREFIX,
   parseMarker,
   parseNumstatForDelta,
+  TRUSTED_MARKER_AUTHOR_ASSOCIATIONS,
+  TRUSTED_MARKER_AUTHOR_LOGINS,
+  type CommentWithAuthor,
   type DeltaStats,
   type MarkerPayload,
   type RunGit,
@@ -473,6 +478,178 @@ describe('decideIncrementalReview — AC #8 scenarios', () => {
       const d = decideIncrementalReview(inp);
       expect(d.skip && d.deltaOnly).toBe(false);
     }
+  });
+});
+
+// ── Trusted-author filter (AISDLC-142 round-2 CRITICAL fix) ────────
+//
+// Threat model: an external GitHub user (or a fork-PR contributor) posts a
+// PR comment whose body contains a forged
+// `<!-- ai-sdlc:last-reviewed-contenthash:<base64url> -->` marker carrying
+// the publicly-computable current contentHashV3. Without an author filter,
+// the next push reads the marker, sees `prior.contentHash === current` →
+// SKIP review → auto-approves all 3 reviewers → satisfies the
+// required-merge-gate check. Authorization bypass with the same blast
+// radius as a forged review approval.
+//
+// Defense (Layer 1 in this module): `filterTrustedComments` drops every
+// comment whose `authorLogin` is not in `TRUSTED_MARKER_AUTHOR_LOGINS` AND
+// whose `authorAssociation` is not in `TRUSTED_MARKER_AUTHOR_ASSOCIATIONS`.
+// `findTrustedMarkerInComments` chains the filter with the marker search
+// so callers can't accidentally skip the filter.
+
+describe('TRUSTED_MARKER_AUTHOR_LOGINS / TRUSTED_MARKER_AUTHOR_ASSOCIATIONS', () => {
+  it('includes both flavors of the github-actions login (GraphQL + REST)', () => {
+    expect(TRUSTED_MARKER_AUTHOR_LOGINS.has('github-actions')).toBe(true);
+    expect(TRUSTED_MARKER_AUTHOR_LOGINS.has('github-actions[bot]')).toBe(true);
+  });
+
+  it('includes both flavors of the ai-sdlc-ci-attestor login', () => {
+    expect(TRUSTED_MARKER_AUTHOR_LOGINS.has('ai-sdlc-ci-attestor')).toBe(true);
+    expect(TRUSTED_MARKER_AUTHOR_LOGINS.has('ai-sdlc-ci-attestor[bot]')).toBe(true);
+  });
+
+  it('does NOT trust unrelated bots (codecov, dependabot, etc.)', () => {
+    expect(TRUSTED_MARKER_AUTHOR_LOGINS.has('codecov')).toBe(false);
+    expect(TRUSTED_MARKER_AUTHOR_LOGINS.has('codecov[bot]')).toBe(false);
+    expect(TRUSTED_MARKER_AUTHOR_LOGINS.has('dependabot[bot]')).toBe(false);
+  });
+
+  it('trusts only push-access associations (OWNER / MEMBER / COLLABORATOR)', () => {
+    for (const a of ['OWNER', 'MEMBER', 'COLLABORATOR']) {
+      expect(TRUSTED_MARKER_AUTHOR_ASSOCIATIONS.has(a)).toBe(true);
+    }
+    for (const a of ['CONTRIBUTOR', 'NONE', 'FIRST_TIME_CONTRIBUTOR', 'FIRST_TIMER']) {
+      expect(TRUSTED_MARKER_AUTHOR_ASSOCIATIONS.has(a)).toBe(false);
+    }
+  });
+});
+
+describe('filterTrustedComments', () => {
+  const validMarker = formatMarker({
+    contentHash: 'a'.repeat(64),
+    reviewedSha: '1'.repeat(40),
+    reviewedAt: '2026-05-01T00:00:00.000Z',
+  });
+
+  it('keeps comments authored by github-actions (workflow-authored markers)', () => {
+    const comments: CommentWithAuthor[] = [
+      { authorLogin: 'github-actions', authorAssociation: 'CONTRIBUTOR', body: validMarker },
+    ];
+    expect(filterTrustedComments(comments)).toEqual([validMarker]);
+  });
+
+  it('keeps comments authored by ai-sdlc-ci-attestor (CI-side attestor bot)', () => {
+    const comments: CommentWithAuthor[] = [
+      { authorLogin: 'ai-sdlc-ci-attestor[bot]', authorAssociation: 'NONE', body: validMarker },
+    ];
+    expect(filterTrustedComments(comments)).toEqual([validMarker]);
+  });
+
+  it('keeps comments from OWNER / MEMBER / COLLABORATOR even with unknown logins', () => {
+    const comments: CommentWithAuthor[] = [
+      { authorLogin: 'maintainer-1', authorAssociation: 'OWNER', body: 'a' },
+      { authorLogin: 'maintainer-2', authorAssociation: 'MEMBER', body: 'b' },
+      { authorLogin: 'maintainer-3', authorAssociation: 'COLLABORATOR', body: 'c' },
+    ];
+    expect(filterTrustedComments(comments)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('AC #2 — DROPS comments authored by external-attacker carrying a forged marker', () => {
+    const comments: CommentWithAuthor[] = [
+      { authorLogin: 'external-attacker', authorAssociation: 'NONE', body: validMarker },
+      { authorLogin: 'fork-pr-contributor', authorAssociation: 'CONTRIBUTOR', body: validMarker },
+      {
+        authorLogin: 'first-timer',
+        authorAssociation: 'FIRST_TIME_CONTRIBUTOR',
+        body: validMarker,
+      },
+    ];
+    expect(filterTrustedComments(comments)).toEqual([]);
+  });
+
+  it('drops unrelated bots (codecov, dependabot) even when they post lookalike bodies', () => {
+    const comments: CommentWithAuthor[] = [
+      { authorLogin: 'codecov', authorAssociation: 'NONE', body: validMarker },
+      { authorLogin: 'codecov[bot]', authorAssociation: 'NONE', body: validMarker },
+      { authorLogin: 'dependabot[bot]', authorAssociation: 'CONTRIBUTOR', body: validMarker },
+    ];
+    expect(filterTrustedComments(comments)).toEqual([]);
+  });
+
+  it('preserves input order (idempotent against the freshest-wins findMarker scan)', () => {
+    const comments: CommentWithAuthor[] = [
+      { authorLogin: 'github-actions', authorAssociation: 'CONTRIBUTOR', body: 'first' },
+      { authorLogin: 'external', authorAssociation: 'NONE', body: 'attacker' },
+      { authorLogin: 'github-actions', authorAssociation: 'CONTRIBUTOR', body: 'second' },
+    ];
+    expect(filterTrustedComments(comments)).toEqual(['first', 'second']);
+  });
+
+  it('returns an empty list for an empty input (no crash)', () => {
+    expect(filterTrustedComments([])).toEqual([]);
+  });
+
+  it('treats missing authorLogin / authorAssociation as untrusted (defense-in-depth)', () => {
+    const comments: CommentWithAuthor[] = [
+      { authorLogin: '', authorAssociation: '', body: validMarker },
+    ];
+    expect(filterTrustedComments(comments)).toEqual([]);
+  });
+});
+
+describe('findTrustedMarkerInComments — end-to-end safety check', () => {
+  const trustedMarker = formatMarker({
+    contentHash: 'a'.repeat(64),
+    reviewedSha: '1'.repeat(40),
+    reviewedAt: '2026-05-01T00:00:00.000Z',
+  });
+  const forgedMarker = formatMarker({
+    contentHash: 'f'.repeat(64),
+    reviewedSha: '2'.repeat(40),
+    reviewedAt: '2026-05-02T00:00:00.000Z',
+  });
+
+  it('AC #2 — IGNORES a forged marker authored by external-attacker (returns null)', () => {
+    const comments: CommentWithAuthor[] = [
+      { authorLogin: 'external-attacker', authorAssociation: 'NONE', body: forgedMarker },
+    ];
+    expect(findTrustedMarkerInComments(comments)).toBeNull();
+  });
+
+  it('AC #3 — HONORS a marker authored by github-actions[bot] normally', () => {
+    const comments: CommentWithAuthor[] = [
+      { authorLogin: 'github-actions', authorAssociation: 'CONTRIBUTOR', body: trustedMarker },
+    ];
+    const m = findTrustedMarkerInComments(comments);
+    expect(m).not.toBeNull();
+    expect(m?.contentHash).toBe('a'.repeat(64));
+    expect(m?.reviewedSha).toBe('1'.repeat(40));
+  });
+
+  it('AC #2+#3 mixed — picks the LATEST trusted marker, ignores attacker comments interleaved', () => {
+    // Threat scenario: attacker posts AFTER the bot, trying to override.
+    // Without the filter, findMarkerInComments would return the attacker's
+    // forged marker (LAST-occurrence wins). With the filter, the attacker
+    // is dropped and the bot's earlier marker survives.
+    const comments: CommentWithAuthor[] = [
+      { authorLogin: 'github-actions', authorAssociation: 'CONTRIBUTOR', body: trustedMarker },
+      { authorLogin: 'external-attacker', authorAssociation: 'NONE', body: forgedMarker },
+    ];
+    const m = findTrustedMarkerInComments(comments);
+    expect(m?.contentHash).toBe('a'.repeat(64)); // trusted, not 'f'.repeat(64)
+  });
+
+  it('returns null when ALL trusted comments are non-marker (no false positive)', () => {
+    const comments: CommentWithAuthor[] = [
+      { authorLogin: 'github-actions', authorAssociation: 'CONTRIBUTOR', body: 'CI build status' },
+      { authorLogin: 'maintainer', authorAssociation: 'OWNER', body: 'LGTM' },
+    ];
+    expect(findTrustedMarkerInComments(comments)).toBeNull();
+  });
+
+  it('returns null when comment list is empty', () => {
+    expect(findTrustedMarkerInComments([])).toBeNull();
   });
 });
 

--- a/pipeline-cli/src/incremental-review/incremental.ts
+++ b/pipeline-cli/src/incremental-review/incremental.ts
@@ -1,0 +1,489 @@
+/**
+ * Incremental review — only re-review the diff since last approval (AISDLC-142).
+ *
+ * AISDLC-141 cut WHICH reviewers run via the deterministic classifier. This
+ * module cuts WHAT each reviewer reads:
+ *
+ *   - Pre-AISDLC-142: every push spawns the classifier-selected reviewer subset
+ *     against `git diff origin/main...HEAD` (entire PR diff). A 200-line PR
+ *     that pushes a 5-line fix re-reads the same 200 lines wastefully.
+ *   - Post-AISDLC-142: store the last-reviewed `contentHashV3` (AISDLC-101) +
+ *     SHA in a PR-comment marker. On each push:
+ *       * marker absent / first push       → full review
+ *       * marker present, hash equal       → SKIP review entirely (auto-approve)
+ *       * marker present, delta within cap → delta-only review
+ *       * marker present, delta over cap   → full review (safety fallback)
+ *
+ * Composes ON TOP of the AISDLC-141 classifier — the classifier still decides
+ * the reviewer subset; this module decides what each one reads.
+ *
+ * ## Why a PR-comment marker (not a status check / branch ref)
+ *
+ *   - PR comments are visible in the PR UI — operators can see what state the
+ *     incremental gate is in without spelunking workflow logs.
+ *   - Idempotent-marker pattern is already proven in this repo
+ *     (`<!-- ai-sdlc:dor-comment ... -->`, `<!-- ai-sdlc:attestation-fallback-comment -->`).
+ *   - `gh api` reads/writes are cheap and deterministic — no need for a
+ *     side-channel database.
+ *
+ * ## Self-contained (mirrors classifier rationale)
+ *
+ * Re-implements `computeContentHashV3` + `collectChangedFileDeltaEntries`
+ * locally so pipeline-cli stays free of an `@ai-sdlc/orchestrator` dep. The
+ * algorithm is byte-identical to `orchestrator/src/runtime/attestations.ts`
+ * (verified by tests in `incremental.test.ts`). If you change one, change
+ * the other — divergence would silently drift the producer-side oracle from
+ * the verifier-side check.
+ *
+ * @module incremental-review/incremental
+ */
+
+import { createHash } from 'node:crypto';
+
+/** Marker substring used to locate the last-reviewed-contenthash PR comment. */
+export const MARKER_PREFIX = '<!-- ai-sdlc:last-reviewed-contenthash:';
+/** Closing token for the marker so the parser can isolate the encoded payload. */
+export const MARKER_SUFFIX = ' -->';
+
+/**
+ * Default delta-size threshold (lines). When the delta diff exceeds this, fall
+ * back to full review — the savings vs. the safety regression of skipping
+ * larger changes isn't worth it. Configurable via `--max-delta-lines` on the
+ * CLI; the default is the value AISDLC-142 ships with based on the original
+ * task description ("if delta is too large (>200 lines)").
+ */
+export const DEFAULT_MAX_DELTA_LINES = 200;
+
+/** Marker payload encoded into the comment body. */
+export interface MarkerPayload {
+  /** sha256 hex of the per-file (base, head) blob-pair transition. */
+  contentHash: string;
+  /** Commit SHA-1 (40 hex chars) reviewed against this contentHash. */
+  reviewedSha: string;
+  /** ISO 8601 timestamp the marker was written. */
+  reviewedAt: string;
+}
+
+/** One entry in the changed-file set used to compute `contentHashV3`. */
+export interface ChangedFileDeltaEntry {
+  path: string;
+  baseBlobSha: string;
+  headBlobSha: string;
+}
+
+/** Decision returned by `decideIncrementalReview`. */
+export interface IncrementalDecision {
+  /**
+   * `true` when the marker's contentHash equals the current one — caller
+   * should spawn 0 reviewers, post auto-approved verdicts, update marker.
+   */
+  skip: boolean;
+  /**
+   * `true` when delta is within `maxDeltaLines` AND no new top-level dirs
+   * — caller should spawn reviewers against the delta diff
+   * (`git diff <lastReviewedSha>...HEAD`).
+   *
+   * When BOTH `skip` and `deltaOnly` are `false`, the caller should run
+   * a full review (`git diff origin/main...HEAD`). This happens on the
+   * first push (no marker) and on the safety-fallback path (delta too
+   * large or new top-level dirs touched).
+   */
+  deltaOnly: boolean;
+  /** SHA the prior review covered, when known. */
+  lastReviewedSha: string | null;
+  /** Current `contentHashV3` (callers update the marker with this). */
+  currentContentHash: string;
+  /** Marker's contentHash, when known. */
+  priorContentHash: string | null;
+  /** Lines added + lines removed in the delta diff. */
+  deltaSize: number;
+  /**
+   * Why `deltaOnly` is `false` when it could have been `true` — exposed for
+   * operator-facing logs. One of:
+   *   - 'no-marker'         (first push for this PR, or marker missing)
+   *   - 'unchanged'         (skip path; deltaOnly N/A)
+   *   - 'delta-too-large'   (lines exceed `maxDeltaLines`)
+   *   - 'new-top-level-dir' (delta touches a top-level dir not in prior review)
+   *   - 'delta-only'        (the affirmative case — `deltaOnly: true`)
+   */
+  reason: IncrementalReason;
+}
+
+export type IncrementalReason =
+  | 'no-marker'
+  | 'unchanged'
+  | 'delta-too-large'
+  | 'new-top-level-dir'
+  | 'delta-only';
+
+// ── Marker parse / format ────────────────────────────────────────────
+
+/**
+ * Encode the marker payload as a single-line HTML comment. Format (load-bearing
+ * — the workflows search for the prefix substring to locate the comment):
+ *
+ *   <!-- ai-sdlc:last-reviewed-contenthash:<base64url(json)> -->
+ *
+ * base64url avoids `+/=` chars that markdown sometimes mangles in comments,
+ * and JSON-inside-base64 keeps the marker forward-compatible (we can add
+ * fields without breaking parsers that only key off the comment prefix).
+ */
+export function formatMarker(payload: MarkerPayload): string {
+  const json = JSON.stringify(payload);
+  const b64 = Buffer.from(json, 'utf-8').toString('base64url');
+  return `${MARKER_PREFIX}${b64}${MARKER_SUFFIX}`;
+}
+
+/**
+ * Locate + parse the marker inside `commentBody`. Returns `null` when no
+ * marker is present OR when the encoded payload is malformed (defensive —
+ * a corrupted marker should fall back to full review, NOT crash the
+ * workflow).
+ */
+export function parseMarker(commentBody: string): MarkerPayload | null {
+  const start = commentBody.indexOf(MARKER_PREFIX);
+  if (start === -1) return null;
+  const payloadStart = start + MARKER_PREFIX.length;
+  const end = commentBody.indexOf(MARKER_SUFFIX, payloadStart);
+  if (end === -1) return null;
+  const b64 = commentBody.slice(payloadStart, end).trim();
+  if (b64.length === 0) return null;
+  try {
+    const json = Buffer.from(b64, 'base64url').toString('utf-8');
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    if (
+      typeof parsed.contentHash !== 'string' ||
+      !/^[0-9a-f]{64}$/i.test(parsed.contentHash) ||
+      typeof parsed.reviewedSha !== 'string' ||
+      !/^[0-9a-f]{40}$/i.test(parsed.reviewedSha) ||
+      typeof parsed.reviewedAt !== 'string'
+    ) {
+      return null;
+    }
+    return {
+      contentHash: parsed.contentHash.toLowerCase(),
+      reviewedSha: parsed.reviewedSha.toLowerCase(),
+      reviewedAt: parsed.reviewedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Search a list of PR-comment bodies for the most recent marker. Returns
+ * `null` when none of them carry the marker. When more than one comment
+ * carries a marker (shouldn't happen with the idempotent update path, but
+ * defensively), the LAST occurrence wins — that's the freshest marker.
+ */
+export function findMarkerInComments(commentBodies: string[]): MarkerPayload | null {
+  for (let i = commentBodies.length - 1; i >= 0; i--) {
+    const m = parseMarker(commentBodies[i]);
+    if (m !== null) return m;
+  }
+  return null;
+}
+
+// ── ContentHashV3 (mirror of orchestrator/src/runtime/attestations.ts) ─
+
+/** Compute a sha256 hex digest. */
+function sha256Hex(input: string): string {
+  return createHash('sha256').update(input, 'utf-8').digest('hex');
+}
+
+/**
+ * Compute the per-file-delta `contentHashV3` over a set of
+ * `{path, baseBlobSha, headBlobSha}` triples. Byte-identical algorithm to
+ * `orchestrator/src/runtime/attestations.ts#computeContentHashV3` — see
+ * that file for the rationale + threat-model documentation.
+ *
+ * Pure function. Idempotent against double-enumeration via dedup-by-path.
+ */
+export function computeContentHashV3(entries: ChangedFileDeltaEntry[]): string {
+  const byPath = new Map<string, { baseBlobSha: string; headBlobSha: string }>();
+  for (const e of entries) {
+    if (typeof e?.path !== 'string' || e.path.length === 0) {
+      throw new Error('computeContentHashV3: entry path must be a non-empty string');
+    }
+    if (typeof e.baseBlobSha !== 'string') {
+      throw new Error(`computeContentHashV3: entry baseBlobSha must be a string for ${e.path}`);
+    }
+    if (typeof e.headBlobSha !== 'string') {
+      throw new Error(`computeContentHashV3: entry headBlobSha must be a string for ${e.path}`);
+    }
+    if (e.path.includes('\t') || e.path.includes('\n')) {
+      throw new Error(
+        `computeContentHashV3: entry path must not contain tab or newline characters (got ${JSON.stringify(e.path)})`,
+      );
+    }
+    const normalizedPath = e.path.replace(/\\/g, '/');
+    byPath.set(normalizedPath, {
+      baseBlobSha: e.baseBlobSha.toLowerCase(),
+      headBlobSha: e.headBlobSha.toLowerCase(),
+    });
+  }
+  const sorted = [...byPath.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  const canonical = sorted
+    .map(([path, { baseBlobSha, headBlobSha }]) => {
+      const fileDeltaHash = sha256Hex(`${baseBlobSha} -> ${headBlobSha}`);
+      return `${path}\t${fileDeltaHash}\n`;
+    })
+    .join('');
+  return sha256Hex(canonical);
+}
+
+/**
+ * Run-git callback (kept injectable so tests don't depend on a real worktree).
+ * Returns stdout (utf-8) on success; throw on failure.
+ */
+export type RunGit = (args: string[], cwd: string) => string;
+
+/**
+ * Collect the per-file-delta set from a git worktree. Mirror of
+ * `collectChangedFileDeltaEntries` in
+ * `orchestrator/src/runtime/attestations.ts` — see that file for rationale.
+ */
+export function collectChangedFileDeltaEntries(
+  baseRef: string,
+  headRef: string,
+  repoRoot: string,
+  runGit: RunGit,
+): ChangedFileDeltaEntry[] {
+  let mergeBase: string;
+  try {
+    mergeBase = runGit(['merge-base', baseRef, headRef], repoRoot).trim();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`collectChangedFileDeltaEntries: git merge-base failed: ${msg}`);
+  }
+  if (!/^[0-9a-f]{40}$/.test(mergeBase)) {
+    throw new Error(
+      `collectChangedFileDeltaEntries: git merge-base returned non-SHA output: ${JSON.stringify(mergeBase)}`,
+    );
+  }
+
+  let nameOnly: string;
+  try {
+    nameOnly = runGit(
+      [
+        '-c',
+        'core.quotepath=false',
+        'diff',
+        '--name-only',
+        '--no-renames',
+        `${baseRef}...${headRef}`,
+      ],
+      repoRoot,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`collectChangedFileDeltaEntries: git diff --name-only failed: ${msg}`);
+  }
+
+  const paths = nameOnly.split('\n').filter((p) => p.length > 0);
+  const entries: ChangedFileDeltaEntry[] = [];
+
+  const resolveBlobSha = (ref: string, path: string): string => {
+    try {
+      const lsOut = runGit(
+        ['-c', 'core.quotepath=false', 'ls-tree', '-r', ref, '--', path],
+        repoRoot,
+      );
+      const line = lsOut.split('\n').find((l) => l.length > 0);
+      if (line) {
+        const m = line.match(/^[0-9]+\s+blob\s+([0-9a-f]{40})\t/);
+        if (m) return m[1];
+      }
+    } catch {
+      // Path missing at ref → empty blob marker.
+    }
+    return '';
+  };
+
+  for (const path of paths) {
+    if (path.includes('\t') || path.includes('\n')) {
+      throw new Error(
+        `collectChangedFileDeltaEntries: path must not contain tab or newline characters (got ${JSON.stringify(path)})`,
+      );
+    }
+    const baseBlobSha = resolveBlobSha(mergeBase, path);
+    const headBlobSha = resolveBlobSha(headRef, path);
+    entries.push({ path, baseBlobSha, headBlobSha });
+  }
+  return entries;
+}
+
+// ── Delta sizing + decision ─────────────────────────────────────────
+
+/**
+ * Parse a `git diff --numstat` output (added\tremoved\tpath, one line each)
+ * into total lines + the set of top-level dirs touched. Used by the delta-size
+ * predicate. Robust against the `-` placeholder git uses for binary files
+ * (treated as 0).
+ */
+export interface DeltaStats {
+  /** Sum of lines added across all files. */
+  linesAdded: number;
+  /** Sum of lines removed across all files. */
+  linesRemoved: number;
+  /** Lines added + lines removed (the predicate input). */
+  totalLines: number;
+  /** Top-level directory of each changed path (e.g. `src`, `docs`). */
+  topLevelDirs: Set<string>;
+  /** Number of files changed. */
+  filesChanged: number;
+}
+
+export function parseNumstatForDelta(numstat: string): DeltaStats {
+  let linesAdded = 0;
+  let linesRemoved = 0;
+  const topLevelDirs = new Set<string>();
+  let filesChanged = 0;
+  for (const raw of numstat.split('\n')) {
+    const line = raw.trimEnd();
+    if (!line) continue;
+    const m = line.match(/^(-|\d+)\t(-|\d+)\t(.+)$/);
+    if (!m) continue;
+    const a = m[1] === '-' ? 0 : Number(m[1]);
+    const r = m[2] === '-' ? 0 : Number(m[2]);
+    linesAdded += a;
+    linesRemoved += r;
+    const path = m[3];
+    filesChanged += 1;
+    // First path segment is the top-level dir; root files map to ''.
+    const slash = path.indexOf('/');
+    topLevelDirs.add(slash === -1 ? '' : path.slice(0, slash));
+  }
+  return {
+    linesAdded,
+    linesRemoved,
+    totalLines: linesAdded + linesRemoved,
+    topLevelDirs,
+    filesChanged,
+  };
+}
+
+/** Inputs for `decideIncrementalReview`. Pure-function shape; no I/O. */
+export interface DecideInputs {
+  /** Marker payload from the prior review, or `null` on first push. */
+  prior: MarkerPayload | null;
+  /** Current `contentHashV3` for HEAD. */
+  currentContentHash: string;
+  /**
+   * Stats for the delta diff between `prior.reviewedSha` and HEAD. When
+   * `prior` is `null`, callers may pass a synthetic zero-stat object — the
+   * `no-marker` branch returns `deltaOnly: false` regardless.
+   */
+  deltaStats: DeltaStats;
+  /**
+   * Top-level dirs touched in the FULL PR diff (`git diff base...head`).
+   * Compared against `deltaStats.topLevelDirs` to detect "delta touches a
+   * new top-level dir not in the prior review" — that's the AC-5
+   * "touches new top-level dirs" safety condition.
+   *
+   * Pass an empty set to disable the new-top-level-dir guard. The full PR
+   * diff at the time of the prior review is what we'd ideally compare
+   * against, but we don't store it; the conservative approximation here
+   * is "any top-level dir in the delta that ISN'T in this set triggers
+   * fallback." Since this set is the union of all top-level dirs in the
+   * current full diff, the only triggering case is when the delta itself
+   * adds a brand-new top-level dir to the PR — exactly what the safety
+   * condition is meant to catch.
+   */
+  fullDiffTopLevelDirs: Set<string>;
+  /** Threshold for the `delta-too-large` branch. Defaults `DEFAULT_MAX_DELTA_LINES`. */
+  maxDeltaLines?: number;
+}
+
+/**
+ * The deterministic decision function. Pure — no I/O, no clock, no random.
+ *
+ * Branches (in order):
+ *   1. no marker          → deltaOnly: false, reason: 'no-marker' (full review)
+ *   2. hash unchanged     → skip: true, reason: 'unchanged' (auto-approve)
+ *   3. delta over cap     → deltaOnly: false, reason: 'delta-too-large'
+ *   4. new top-level dir  → deltaOnly: false, reason: 'new-top-level-dir'
+ *   5. otherwise          → deltaOnly: true, reason: 'delta-only'
+ *
+ * Safety property: the function NEVER returns `skip: true` AND `deltaOnly: true`
+ * — they are mutually exclusive states surfaced in distinct branches.
+ */
+export function decideIncrementalReview(inputs: DecideInputs): IncrementalDecision {
+  const maxDeltaLines = inputs.maxDeltaLines ?? DEFAULT_MAX_DELTA_LINES;
+  const baseDecision = {
+    currentContentHash: inputs.currentContentHash,
+    deltaSize: inputs.deltaStats.totalLines,
+  };
+  if (inputs.prior === null) {
+    return {
+      ...baseDecision,
+      skip: false,
+      deltaOnly: false,
+      lastReviewedSha: null,
+      priorContentHash: null,
+      reason: 'no-marker',
+    };
+  }
+  if (inputs.prior.contentHash === inputs.currentContentHash) {
+    return {
+      ...baseDecision,
+      skip: true,
+      deltaOnly: false,
+      lastReviewedSha: inputs.prior.reviewedSha,
+      priorContentHash: inputs.prior.contentHash,
+      reason: 'unchanged',
+    };
+  }
+  if (inputs.deltaStats.totalLines > maxDeltaLines) {
+    return {
+      ...baseDecision,
+      skip: false,
+      deltaOnly: false,
+      lastReviewedSha: inputs.prior.reviewedSha,
+      priorContentHash: inputs.prior.contentHash,
+      reason: 'delta-too-large',
+    };
+  }
+  for (const dir of inputs.deltaStats.topLevelDirs) {
+    if (!inputs.fullDiffTopLevelDirs.has(dir)) {
+      return {
+        ...baseDecision,
+        skip: false,
+        deltaOnly: false,
+        lastReviewedSha: inputs.prior.reviewedSha,
+        priorContentHash: inputs.prior.contentHash,
+        reason: 'new-top-level-dir',
+      };
+    }
+  }
+  return {
+    ...baseDecision,
+    skip: false,
+    deltaOnly: true,
+    lastReviewedSha: inputs.prior.reviewedSha,
+    priorContentHash: inputs.prior.contentHash,
+    reason: 'delta-only',
+  };
+}
+
+/**
+ * Build the auto-approved verdict JSON the caller posts when `skip: true`.
+ * Mirrors the AISDLC-141 auto-approved shape so the report-job parser
+ * accepts it as a valid verdict without changes.
+ *
+ * The summary mentions the prior reviewed SHA so the operator can audit
+ * which review the skip is reusing.
+ */
+export function buildAutoApprovedVerdict(lastReviewedSha: string): {
+  approved: true;
+  findings: never[];
+  summary: string;
+} {
+  return {
+    approved: true,
+    findings: [],
+    summary:
+      `Skipped by incremental review (AISDLC-142) — content unchanged ` +
+      `since prior approval at ${lastReviewedSha}.`,
+  };
+}

--- a/pipeline-cli/src/incremental-review/incremental.ts
+++ b/pipeline-cli/src/incremental-review/incremental.ts
@@ -175,6 +175,15 @@ export function parseMarker(commentBody: string): MarkerPayload | null {
  * `null` when none of them carry the marker. When more than one comment
  * carries a marker (shouldn't happen with the idempotent update path, but
  * defensively), the LAST occurrence wins — that's the freshest marker.
+ *
+ * **Author-filter at the call site is REQUIRED.** This function does NOT
+ * verify who authored the comment — pass only bodies you've already
+ * filtered to trusted identities (see `filterTrustedComments`). Calling
+ * with raw, unfiltered comment bodies is a CRITICAL authorization bypass:
+ * any GitHub user (including external fork-PR contributors) can post a
+ * comment carrying a forged marker that this function would happily honor.
+ * The fix lives at the FETCH boundary — see the `gh pr view --jq` filter
+ * in `.github/workflows/ai-sdlc-review.yml` and `ai-sdlc-plugin/commands/execute.md`.
  */
 export function findMarkerInComments(commentBodies: string[]): MarkerPayload | null {
   for (let i = commentBodies.length - 1; i >= 0; i--) {
@@ -182,6 +191,99 @@ export function findMarkerInComments(commentBodies: string[]): MarkerPayload | n
     if (m !== null) return m;
   }
   return null;
+}
+
+/**
+ * Trusted-author identities that are allowed to author the incremental-review
+ * marker comment. Compiled into a Set so callers can do O(1) membership
+ * checks. Two flavors of GitHub-Actions login are listed because the GraphQL
+ * surface (`gh pr view --json comments`) returns `author.login` WITHOUT the
+ * `[bot]` suffix while the REST API (`github.rest.issues.listComments`)
+ * returns `user.login` WITH the suffix — both forms map to the same actor.
+ *
+ * Any login NOT in this set is treated as untrusted; comments authored by
+ * untrusted identities are filtered out before `findMarkerInComments` is
+ * called. This is the defense-in-depth Layer 1 fix for the AISDLC-142
+ * round-2 CRITICAL finding (forged-marker authorization bypass).
+ *
+ * To rotate or extend this list, update BOTH this constant AND the
+ * `gh pr view --jq 'select(.author.login == ...)'` filters in:
+ *   - `.github/workflows/ai-sdlc-review.yml` (analyze + report jobs)
+ *   - `ai-sdlc-plugin/commands/execute.md` (Step 7a-bis)
+ */
+export const TRUSTED_MARKER_AUTHOR_LOGINS: ReadonlySet<string> = new Set([
+  'github-actions',
+  'github-actions[bot]',
+  'ai-sdlc-ci-attestor',
+  'ai-sdlc-ci-attestor[bot]',
+]);
+
+/**
+ * Trusted `authorAssociation` values (GitHub's relationship-to-repo enum).
+ * Repo OWNER, members of the org, and explicit collaborators are allowed
+ * to author the marker — they have push access, so they could already
+ * write the marker via the workflow itself; honoring their direct comments
+ * is no escalation. CONTRIBUTOR / NONE / FIRST_TIME_* are external and
+ * MUST NOT be trusted to author markers.
+ */
+export const TRUSTED_MARKER_AUTHOR_ASSOCIATIONS: ReadonlySet<string> = new Set([
+  'OWNER',
+  'MEMBER',
+  'COLLABORATOR',
+]);
+
+/**
+ * One PR comment with the metadata needed to verify it was authored by a
+ * trusted identity. Both APIs surface roughly this shape; callers normalise
+ * to this struct before calling `filterTrustedComments`:
+ *
+ *   - GraphQL `gh pr view --json comments`: `{author: {login}, authorAssociation, body}`
+ *   - REST `github.rest.issues.listComments`: `{user: {login}, author_association, body}`
+ */
+export interface CommentWithAuthor {
+  /** Author login (may be `<name>` from GraphQL or `<name>[bot]` from REST). */
+  authorLogin: string;
+  /** `authorAssociation` (GraphQL) / `author_association` (REST), uppercase enum. */
+  authorAssociation: string;
+  body: string;
+}
+
+/**
+ * Filter PR comments down to those authored by trusted identities. Returns
+ * the bodies of the surviving comments in the SAME order as the input, ready
+ * to hand to `findMarkerInComments`.
+ *
+ * Trust criteria (either gate is sufficient):
+ *   1. `authorLogin` is in `TRUSTED_MARKER_AUTHOR_LOGINS` (the bot allowlist), OR
+ *   2. `authorAssociation` is in `TRUSTED_MARKER_AUTHOR_ASSOCIATIONS`
+ *      (push-access humans).
+ *
+ * Defense-in-depth Layer 1 — the primary defense is the `gh pr view --jq`
+ * filter at the fetch boundary; calling this helper after fetch is a
+ * belt-and-braces guard for callers that go through the GitHub REST API
+ * (where filtering at fetch time is awkward).
+ */
+export function filterTrustedComments(comments: readonly CommentWithAuthor[]): string[] {
+  const out: string[] = [];
+  for (const c of comments) {
+    const loginTrusted = TRUSTED_MARKER_AUTHOR_LOGINS.has(c.authorLogin);
+    const assocTrusted = TRUSTED_MARKER_AUTHOR_ASSOCIATIONS.has(c.authorAssociation);
+    if (loginTrusted || assocTrusted) {
+      out.push(c.body);
+    }
+  }
+  return out;
+}
+
+/**
+ * One-call helper that filters by author and then locates the freshest
+ * marker. Equivalent to `findMarkerInComments(filterTrustedComments(...))`
+ * but documents the safe-by-default contract in a single name.
+ */
+export function findTrustedMarkerInComments(
+  comments: readonly CommentWithAuthor[],
+): MarkerPayload | null {
+  return findMarkerInComments(filterTrustedComments(comments));
 }
 
 // ── ContentHashV3 (mirror of orchestrator/src/runtime/attestations.ts) ─

--- a/pipeline-cli/src/incremental-review/index.ts
+++ b/pipeline-cli/src/incremental-review/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Barrel re-export for the incremental-review module (AISDLC-142). The
+ * implementation lives in `./incremental.ts` so the coverage tracker
+ * (which excludes `src/star-star/index.ts` per `vitest.config.ts`) still
+ * reports on the actual logic.
+ */
+export * from './incremental.js';

--- a/pipeline-cli/src/index.ts
+++ b/pipeline-cli/src/index.ts
@@ -18,6 +18,28 @@ export * from './steps/index.js';
 export * from './deps/index.js';
 export { executePipeline } from './execute-pipeline.js';
 
+// AISDLC-142 — incremental review primitives (skip / delta-only / full).
+export {
+  buildAutoApprovedVerdict,
+  collectChangedFileDeltaEntries,
+  computeContentHashV3,
+  decideIncrementalReview,
+  DEFAULT_MAX_DELTA_LINES,
+  findMarkerInComments,
+  formatMarker,
+  MARKER_PREFIX,
+  MARKER_SUFFIX,
+  parseMarker,
+  parseNumstatForDelta,
+  type ChangedFileDeltaEntry,
+  type DecideInputs,
+  type DeltaStats,
+  type IncrementalDecision,
+  type IncrementalReason,
+  type MarkerPayload,
+  type RunGit,
+} from './incremental-review/incremental.js';
+
 // AISDLC-141 — conditional review classifier (RFC-0010 §12).
 export {
   ALL_REVIEWERS,


### PR DESCRIPTION
## Summary

Cost optimization for the reviewer-agent fan-out in `ai-sdlc-review.yml`. When a PR's contentHashV3 hasn't changed since the last review, SKIP all 3 reviewer agents (60-80% reduction in reviewer invocations on multi-push PRs). When only a partial delta has changed, restrict the diff scope to the delta paths.

Combined with AISDLC-141 classifier (30-50% reduction): ~70-95% combined reduction in reviewer-agent invocations.

## Changes

- `pipeline-cli/src/incremental-review/incremental.ts` (new): marker parse/format, contentHashV3 mirror, 5-branch decision (no-marker / unchanged / delta-too-large / new-top-level-dir / delta-only), trusted-author filter for marker comments
- `pipeline-cli/src/cli/incremental-decide.ts` (new): CLI used by workflow; emits single-line JSON; `--comments-json-file` defense-in-depth re-applies trusted-author filter
- `.github/workflows/ai-sdlc-review.yml`: incremental-decide gate before reviewer fan-out; marker upsert post-review (trusted authors only); SKIP path emits auto-approved verdicts
- `ai-sdlc-plugin/commands/execute.md`: Step 7a-bis (read marker, decide), Step 8.5 (write/update marker)
- 84+ new tests; 96% line coverage on incremental-decide.ts; 100% on incremental.ts

## Round 2 (CRITICAL — security)

Forged-marker authorization bypass: external contributors could post a marker comment with a fabricated contentHash and trick the workflow into skipping reviewer fan-out. Fixed by trusted-author filter at all 4 fetch sites (workflow analyze read, workflow report-job marker upsert, slash-command Step 7a-bis read, slash-command Step 8.5 marker upsert) + defense-in-depth in-CLI filter via `--comments-json-file`. Tests assert: external attacker → IGNORED; github-actions[bot] → HONORED.

## Round 3 (CRITICAL — SKIP-path)

`emit()` was using `JSON.stringify(result, null, 2)` (multi-line). The workflow's `tail -1` extracted only `}`, breaking the SKIP path silently (verdicts never wrote). Fixed by single-line emit. Workflow-pipeline regression test simulates the exact CLI → tmpfile → tail -1 → JSON.parse shell flow for all 3 reviewer types.

## Reviewer verdicts

- **Code (round 3):** APPROVED — 1 minor + 2 suggestions. Both criticals demonstrably closed.
- **Test (round 3):** APPROVED — 2 minors. All 5 decision branches covered, hermeticity preserved.
- **Security (round 3):** APPROVED — 1 low (`PRIOR_SHA` shell-side validation as defense-in-depth) + 1 info (COLLABORATOR-override is documented trust model).

## Note on push

Pre-push coverage gate skipped via documented `AI_SDLC_SKIP_COVERAGE_GATE=1` escape hatch. The blocking failure was in `orchestrator/src/cli/commands/init-workspace.test.ts` (10 init-workspace tests fail under parallel `pnpm -r test:coverage` due to `GIT_DIR` inheritance from the husky pre-push environment + `git init` silent-failure under CPU contention) — unrelated to AISDLC-142 changes (which only touch pipeline-cli + workflows). The flake fix lands in PR #189.

## Test plan

- [x] `pnpm --filter @ai-sdlc/pipeline-cli build && test` — 809/809
- [x] `pnpm --filter @ai-sdlc/pipeline-cli test src/incremental-review` — full coverage, all branches
- [x] `pnpm lint && pnpm format:check` — clean
- [ ] CI verifies the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)