### PR TITLE
feat(deps): hmac integrity for incremental-review marker (AISDLC-146)

### DIFF
--- a/.github/workflows/ai-sdlc-review.yml
+++ b/.github/workflows/ai-sdlc-review.yml
@@ -233,6 +233,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # AISDLC-146 Layer 2 defense-in-depth: HMAC-SHA256 secret used by
+          # cli-incremental-decide to verify v2 marker signatures. When set,
+          # the CLI accepts v2 markers (rejecting any with mismatched HMAC);
+          # when unset, v2 markers are rejected entirely + v1 markers parse
+          # with a deprecation warning. The secret MUST be 32+ random bytes
+          # — generate with `openssl rand -hex 32` and add via
+          # `gh secret set MARKER_HMAC_SECRET`.
+          MARKER_HMAC_SECRET: ${{ secrets.MARKER_HMAC_SECRET }}
         run: |
           # ── AISDLC-142 round-2 CRITICAL fix ────────────────────────
           # Fetch existing PR comments WITH author metadata, then filter to
@@ -281,9 +289,37 @@ jobs:
           # Extract prior reviewedSha from the marker (if any) so we can
           # compute the delta numstat against it. Failure is fine — empty
           # PRIOR_SHA → no numstat → CLI takes the no-marker / full path.
-          PRIOR_SHA=$(grep -oE '<!-- ai-sdlc:last-reviewed-contenthash:[A-Za-z0-9_-]+ -->' /tmp/pr-comments.txt 2>/dev/null \
+          #
+          # Wire formats handled (AISDLC-146):
+          #   v0 (legacy AISDLC-142): <prefix><base64> -->
+          #   v1 (transition):        <prefix>v1:<base64> -->
+          #   v2 (HMAC):              <prefix>v2:<base64>:<hmac-hex> -->
+          #
+          # The regex captures everything between the prefix and ` -->` as
+          # the "inner". A small awk strips the optional `vN:` prefix and
+          # the trailing `:<hmac>` segment (v2 only) before base64-decoding.
+          # Best-effort throughout — any failure routes to empty PRIOR_SHA
+          # and the CLI takes the safe no-marker → FULL path.
+          PRIOR_SHA=$(grep -oE '<!-- ai-sdlc:last-reviewed-contenthash:[^ ]+ -->' /tmp/pr-comments.txt 2>/dev/null \
             | tail -1 \
-            | sed -E 's/.*contenthash:([A-Za-z0-9_-]+) -->/\1/' \
+            | sed -E 's/^<!-- ai-sdlc:last-reviewed-contenthash:(.+) -->$/\1/' \
+            | awk '
+                {
+                  inner = $0
+                  # Strip leading "vN:" version tag (v1 + v2). v0 markers
+                  # have no tag and pass through.
+                  if (match(inner, /^v[12]:/)) {
+                    inner = substr(inner, RLENGTH + 1)
+                  }
+                  # For v2, the HMAC segment is appended after the LAST `:`.
+                  # base64url alphabet ([A-Za-z0-9_-]) never contains `:`,
+                  # so the last colon is unambiguous. Strip it.
+                  if ((idx = match(inner, /:[0-9a-fA-F]{64}$/)) > 0) {
+                    inner = substr(inner, 1, idx - 1)
+                  }
+                  print inner
+                }
+              ' \
             | { read B64 && [ -n "$B64" ] && printf '%s' "$B64" \
                 | base64 -d 2>/dev/null \
                 | jq -r '.reviewedSha' 2>/dev/null; } || echo "")
@@ -863,6 +899,14 @@ jobs:
           CRITIC_JSON: ${{ needs.analyze.outputs.critic }}
           SECURITY_JSON: ${{ needs.analyze.outputs.security }}
           INCR_CONTENT_HASH: ${{ needs.analyze.outputs.incremental_content_hash }}
+          # AISDLC-146 Layer 2 defense-in-depth: when set, the marker is
+          # written in v2 wire format with an HMAC-SHA256 signature over
+          # the JSON payload. When unset, falls back to v1 (no HMAC) so
+          # operators who haven't provisioned the secret still get the
+          # incremental-review savings — they just lose the HMAC integrity
+          # gate. The v1→v2 cutover is per-PR (next push under v2 secret
+          # rewrites the marker in v2), so no migration step is needed.
+          MARKER_HMAC_SECRET: ${{ secrets.MARKER_HMAC_SECRET }}
         with:
           script: |
             // Verify all three reviewers approved before binding the marker.
@@ -892,8 +936,30 @@ jobs:
               reviewedSha: headSha.toLowerCase(),
               reviewedAt: new Date().toISOString(),
             };
-            const b64 = Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64url');
-            const marker = `<!-- ai-sdlc:last-reviewed-contenthash:${b64} -->`;
+            const json = JSON.stringify(payload);
+            const b64 = Buffer.from(json, 'utf-8').toString('base64url');
+            // AISDLC-146 Layer 2 defense-in-depth: emit v2 (HMAC-SHA256
+            // signed) when MARKER_HMAC_SECRET is provisioned, fall back
+            // to v1 (no HMAC) when not. The HMAC input is the EXACT JSON
+            // string we just base64'd so the verifier can re-derive it
+            // by base64-decoding + recomputing HMAC under the shared
+            // secret. Mirrors `formatMarker()` in
+            // `pipeline-cli/src/incremental-review/incremental.ts` —
+            // any change to the wire format here MUST be made there too.
+            const hmacSecret = process.env.MARKER_HMAC_SECRET || '';
+            let marker;
+            if (hmacSecret.length > 0) {
+              const { createHmac } = require('node:crypto');
+              const hmac = createHmac('sha256', hmacSecret).update(json, 'utf-8').digest('hex');
+              marker = `<!-- ai-sdlc:last-reviewed-contenthash:v2:${b64}:${hmac} -->`;
+            } else {
+              core.warning(
+                'MARKER_HMAC_SECRET is not set — writing v1 (no HMAC) marker. ' +
+                  'Provision via `gh secret set MARKER_HMAC_SECRET --body "$(openssl rand -hex 32)"` ' +
+                  'to enable v2 integrity (AISDLC-146).',
+              );
+              marker = `<!-- ai-sdlc:last-reviewed-contenthash:v1:${b64} -->`;
+            }
             const body =
               `## AI-SDLC: incremental review state\n\n` +
               `_Auto-managed by \`ai-sdlc-review.yml\` (AISDLC-142). ` +

--- a/backlog/completed/aisdlc-146 - HMAC-integrity-for-incremental-review-marker.md
+++ b/backlog/completed/aisdlc-146 - HMAC-integrity-for-incremental-review-marker.md
@@ -1,0 +1,96 @@
+---
+id: AISDLC-146
+title: HMAC integrity for incremental-review marker (Layer 2 defense-in-depth)
+status: Done
+assignee: []
+created_date: '2026-05-02 18:50'
+updated_date: '2026-05-02 18:55'
+labels:
+  - ci
+  - security
+  - deps
+  - follow-up
+dependencies:
+  - AISDLC-142
+references:
+  - pipeline-cli/src/incremental-review/incremental.ts
+  - pipeline-cli/src/incremental-review/incremental.test.ts
+  - .github/workflows/ai-sdlc-review.yml
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+**Layer 2 follow-up to AISDLC-142 round 2 review.** AISDLC-142 shipped with a trusted-author filter (Layer 1) that blocks EXTERNAL contributors from posting forged `<!-- ai-sdlc:last-reviewed-contenthash:... -->` markers. The round-2 reviewer recommended HMAC payload integrity as Layer 2 defense — closing the gap that a malicious-but-trusted COLLABORATOR could otherwise exploit by posting a manual marker with a forged contentHash binding.
+
+## Threat model closed by HMAC layer 2
+
+The AISDLC-142 trusted-author filter (Layer 1) prevents EXTERNAL contributors from posting forged markers — they fail the `authorAssociation in {OWNER, MEMBER, COLLABORATOR}` gate. But a TRUSTED COLLABORATOR could still:
+
+1. Post a marker comment manually with a forged `contentHash` binding the publicly-computable current `contentHashV3`.
+2. The marker passes Layer 1 (the collaborator IS in the trusted set).
+3. The skip-when-unchanged path then trusts the contentHash, skipping all 3 reviewers.
+4. A malicious-but-trusted collaborator could thereby skip review on co-authored PRs.
+
+Layer 2 closes the gap by signing the marker payload with an HMAC-SHA256 key only the bot knows (`MARKER_HMAC_SECRET` GitHub secret). Manual marker comments by trusted authors won't carry the right HMAC and get rejected.
+
+## Wire format
+
+| Version | Format | Use |
+|---------|--------|-----|
+| v0 (legacy AISDLC-142) | `<!-- ai-sdlc:last-reviewed-contenthash:<base64-json> -->` | Accepted on read for in-flight markers; never written by new code |
+| v1 (transition) | `<!-- ai-sdlc:last-reviewed-contenthash:v1:<base64-json> -->` | Written when `MARKER_HMAC_SECRET` is unset; emits `console.warn` on parse |
+| v2 (HMAC) | `<!-- ai-sdlc:last-reviewed-contenthash:v2:<base64-json>:<hmac-sha256-hex> -->` | Default when `MARKER_HMAC_SECRET` is set; rejected if HMAC fails |
+
+The HMAC input is the EXACT `JSON.stringify(payload)` string that gets base64'd. The 4th `:`-segment is the lowercase hex digest of HMAC-SHA256 keyed by the secret.
+
+## Acceptance criteria
+
+1. `formatMarker()` accepts v1 + v2; defaults to v2 when env has `MARKER_HMAC_SECRET`, falls back to v1 with a `console.warn` (one-time per process) when missing
+2. `parseMarker()` accepts v1 (no HMAC check, deprecation warn) + v2 (HMAC required, rejected on mismatch); also accepts the legacy v0 wire format for transition
+3. `findMarkerInComments()` returns null for any marker that fails HMAC validation (forged-marker rejection composes through to the freshest-wins scan)
+4. Tests cover: v2 valid HMAC parses; v2 tampered HMAC rejected; v2 payload-tampered + re-signed under DIFFERENT secret rejected; v1 marker parses with warning; missing secret env → formatMarker emits v1 + warns, parseMarker rejects v2; trusted-author v1 marker still respected (transition compat)
+5. Workflow YAML changes: add `MARKER_HMAC_SECRET` env to analyze + report jobs; PRIOR_SHA grep updated to handle v1/v2 wire formats; report-job inline JS computes HMAC via `node:crypto.createHmac`
+6. PR body documents the operator setup step: `gh secret set MARKER_HMAC_SECRET --body "$(openssl rand -hex 32)"`
+<!-- SECTION:DESCRIPTION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+## Summary
+Added HMAC-SHA256 wire-format integrity (v2 marker) to the AISDLC-142 incremental-review marker, closing the malicious-but-trusted collaborator gap. v2 markers are signed with `MARKER_HMAC_SECRET` (32+ random bytes via `openssl rand -hex 32`) and verified with `crypto.timingSafeEqual`; v1 markers stay accepted on read with a one-time deprecation warning so in-flight markers don't strand the next push in FULL-review mode. The legacy AISDLC-142 wire format (no `vN:` tag) is also accepted as v1 for transition.
+
+## Changes
+- `pipeline-cli/src/incremental-review/incremental.ts` (modified):
+  - New `MARKER_HMAC_SECRET_ENV`, `MarkerVersion` exports + module-level warn latch
+  - `formatMarker(payload, opts?)`: env-driven version selection (v2 when secret set, v1 otherwise) + explicit override hooks for tests
+  - `parseMarker(commentBody, opts?)`: version dispatch (v0/v1/v2), HMAC verification via `crypto.timingSafeEqual`, structural guards on the HMAC segment
+  - `findMarkerInComments`/`findTrustedMarkerInComments` thread `opts.secret` through
+  - `_resetWarnLatchForTests` test-only helper for deterministic warn-once assertions
+- `pipeline-cli/src/incremental-review/incremental.test.ts` (modified): 24 new tests across 4 describe blocks (formatMarker version selection, parseMarker v2 HMAC validation, parseMarker v1 backward-compat, findMarkerInComments HMAC-aware filtering); `beforeEach` resets warn-latch + env between tests
+- `pipeline-cli/src/index.ts` (modified): export `MARKER_HMAC_SECRET_ENV` + `MarkerVersion` from package barrel
+- `.github/workflows/ai-sdlc-review.yml` (modified):
+  - `MARKER_HMAC_SECRET` env added to `incremental` step (analyze job) + `Update incremental-review marker` step (report job)
+  - `PRIOR_SHA` grep updated to handle v1/v2 wire formats (awk strips `vN:` prefix and trailing `:<hmac>` segment)
+  - Report-job inline JS computes HMAC via `node:crypto.createHmac` and emits v2 when secret is provisioned, v1 + `core.warning` otherwise
+
+## Design decisions
+- **HMAC over the JSON string, not the base64**: keeps HMAC input human-decodable for forensic comparison; verifier re-derives the JSON from base64 before HMAC check (single canonical form).
+- **Empty-string secret treated as missing**: GitHub Actions evaluates unset secrets to `""`, so `process.env.MARKER_HMAC_SECRET || ''` length-check guards against silently signing a v2 marker with a zero-length key.
+- **`timingSafeEqual` for HMAC comparison**: defense against timing-leak attacks even though the HMAC segment is short (64 hex chars).
+- **One-time `console.warn` latch**: pre-flight, workflow, and slash-command body all reach into this module repeatedly per push; without the latch, CI logs flood with the same banner. Test-only `_resetWarnLatchForTests` keeps the warn-once assertions deterministic.
+- **Throw on `formatMarker({version: 2})` without secret**: refusing to emit an unverifiable marker is safer than silently degrading — every verifier would reject it anyway.
+- **Accept legacy v0 wire format as v1**: in-flight markers on PRs that pre-date AISDLC-146 must NOT strand on the next push. Without the silent v0→v1 hop, every such PR would re-run FULL review on the first post-deploy push (mass cost regression).
+
+## Verification
+- `pnpm --filter @ai-sdlc/pipeline-cli build` — clean
+- `pnpm --filter @ai-sdlc/pipeline-cli test` — 1002/1002 pass (73 in `incremental.test.ts`, 24 new for AISDLC-146)
+- `pnpm lint` — clean
+- `pnpm format:check` — clean
+- Workflow YAML re-parses via `yaml@2.8.2`; jobs unchanged: `attestation-precheck`, `analyze`, `report`, `post-skip-results`
+
+## Follow-up
+- Operator setup (one time): `gh secret set MARKER_HMAC_SECRET --body "$(openssl rand -hex 32)"` so the analyze + report jobs see the secret. Until provisioned, the workflow runs in v1 fallback mode (functional but no HMAC integrity); the operator-facing `core.warning` in the report job makes the gap visible in CI logs.
+- Drop v1 acceptance after one or two PR cycles once in-flight markers self-migrate (track via grep over recent PR comments).
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/pipeline-cli/src/incremental-review/incremental.test.ts
+++ b/pipeline-cli/src/incremental-review/incremental.test.ts
@@ -7,9 +7,10 @@
  * algorithm parity with the orchestrator copy.
  */
 
-import { createHash } from 'node:crypto';
-import { describe, expect, it } from 'vitest';
+import { createHash, createHmac } from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  _resetWarnLatchForTests,
   buildAutoApprovedVerdict,
   collectChangedFileDeltaEntries,
   computeContentHashV3,
@@ -19,7 +20,9 @@ import {
   findMarkerInComments,
   findTrustedMarkerInComments,
   formatMarker,
+  MARKER_HMAC_SECRET_ENV,
   MARKER_PREFIX,
+  MARKER_SUFFIX,
   parseMarker,
   parseNumstatForDelta,
   TRUSTED_MARKER_AUTHOR_ASSOCIATIONS,
@@ -29,6 +32,15 @@ import {
   type MarkerPayload,
   type RunGit,
 } from './incremental.js';
+
+// Reset module-level warn latch + env between tests so the v1-deprecation /
+// v2-no-secret / format-no-secret warnings fire deterministically on demand.
+// Without these resets the latch state leaks across test files in vitest's
+// shared-module mode and the "warns once" assertions become order-dependent.
+beforeEach(() => {
+  _resetWarnLatchForTests();
+  delete process.env[MARKER_HMAC_SECRET_ENV];
+});
 
 // ── Marker parse / format round-trip ────────────────────────────────
 
@@ -662,5 +674,270 @@ describe('buildAutoApprovedVerdict', () => {
     expect(v.findings).toEqual([]);
     expect(v.summary).toMatch(/Skipped by incremental review/);
     expect(v.summary).toContain('1'.repeat(40));
+  });
+});
+
+// ── HMAC-signed v2 markers (AISDLC-146 — Layer 2 defense-in-depth) ──
+//
+// Threat model: a TRUSTED COLLABORATOR (login passes the AISDLC-142
+// Layer-1 trusted-author filter) posts a forged marker comment binding
+// the publicly-computable current contentHashV3. Without HMAC, the
+// next push would honor that comment, skip review, and auto-approve.
+// With HMAC the forgery has to also produce a valid SHA-256 keyed by
+// the bot's secret — a key the attacker doesn't possess.
+//
+// Coverage matrix (AC #4):
+//   1. v2 with valid HMAC                              → parses
+//   2. v2 with tampered HMAC (single-bit flip)         → null
+//   3. v2 with payload tampered, HMAC re-signed under
+//      a DIFFERENT secret                              → null
+//   4. v1 marker                                       → parses with warn
+//   5. Missing secret env var:
+//        formatMarker → v1 + console.warn
+//        parseMarker  → rejects v2 entirely
+//   6. Operator v1 marker by trusted author + valid
+//      contentHash                                     → still respected
+
+const SECRET_A = 'a'.repeat(64); // primary secret (test fixture)
+const SECRET_B = 'b'.repeat(64); // attacker's "guess" secret
+
+const v2Payload: MarkerPayload = {
+  contentHash: 'd'.repeat(64),
+  reviewedSha: 'e'.repeat(40),
+  reviewedAt: '2026-05-01T12:00:00.000Z',
+};
+
+/** Reference HMAC computer pinned to Node's `crypto` for parity assertions. */
+function refHmac(json: string, secret: string): string {
+  return createHmac('sha256', secret).update(json, 'utf-8').digest('hex');
+}
+
+describe('formatMarker — version selection (AISDLC-146 AC #1)', () => {
+  it('emits v2 by default when MARKER_HMAC_SECRET env is set', () => {
+    process.env[MARKER_HMAC_SECRET_ENV] = SECRET_A;
+    const body = formatMarker(v2Payload);
+    expect(body.startsWith(`${MARKER_PREFIX}v2:`)).toBe(true);
+    expect(body.endsWith(MARKER_SUFFIX)).toBe(true);
+    // Wire shape: `<prefix>v2:<base64>:<hmac><suffix>` — verify the HMAC
+    // segment is exactly 64 hex chars (sha256 hex digest).
+    const inner = body.slice(MARKER_PREFIX.length, body.length - MARKER_SUFFIX.length);
+    const lastColon = inner.lastIndexOf(':');
+    const hmacPart = inner.slice(lastColon + 1);
+    expect(/^[0-9a-f]{64}$/.test(hmacPart)).toBe(true);
+  });
+
+  it('emits v1 with one-time console.warn when env secret is missing', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const body = formatMarker(v2Payload);
+    expect(body.startsWith(`${MARKER_PREFIX}v1:`)).toBe(true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/MARKER_HMAC_SECRET/);
+    // Second call within the same process must NOT re-warn — the latch
+    // ensures CI logs aren't flooded on multi-step pushes.
+    formatMarker(v2Payload);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('honors explicit opts.version=1 even when secret is set (escape hatch)', () => {
+    process.env[MARKER_HMAC_SECRET_ENV] = SECRET_A;
+    const body = formatMarker(v2Payload, { version: 1 });
+    expect(body.startsWith(`${MARKER_PREFIX}v1:`)).toBe(true);
+    // No warn — explicit `opts.version` short-circuits the missing-secret
+    // banner branch.
+  });
+
+  it('honors explicit opts.secret override (env-independent)', () => {
+    // No env, but caller passes a secret directly → v2 still emitted.
+    const body = formatMarker(v2Payload, { secret: SECRET_A });
+    expect(body.startsWith(`${MARKER_PREFIX}v2:`)).toBe(true);
+  });
+
+  it('throws when v2 is requested but no secret is available (no silent v2-without-key)', () => {
+    expect(() => formatMarker(v2Payload, { version: 2 })).toThrow(
+      /v2 requires a non-empty MARKER_HMAC_SECRET/,
+    );
+  });
+
+  it('treats empty-string secret as missing (CI-env "" handling)', () => {
+    process.env[MARKER_HMAC_SECRET_ENV] = '';
+    const body = formatMarker(v2Payload);
+    // Empty string ≠ "secret present" — fall back to v1, not crash.
+    expect(body.startsWith(`${MARKER_PREFIX}v1:`)).toBe(true);
+  });
+});
+
+describe('parseMarker — v2 HMAC validation (AISDLC-146 AC #2)', () => {
+  it('parses a v2 marker with a valid HMAC under the same secret', () => {
+    process.env[MARKER_HMAC_SECRET_ENV] = SECRET_A;
+    const body = formatMarker(v2Payload);
+    const parsed = parseMarker(body);
+    expect(parsed).toEqual(v2Payload);
+  });
+
+  it('rejects a v2 marker whose HMAC has been tampered with (single-char flip)', () => {
+    process.env[MARKER_HMAC_SECRET_ENV] = SECRET_A;
+    const body = formatMarker(v2Payload);
+    // Flip the LAST hex char of the HMAC — minimal corruption that any
+    // honest verifier must catch. base64url + hmac segments are
+    // delimited by `:`; the suffix ` -->` is fixed.
+    const suffix = MARKER_SUFFIX;
+    const lastChar = body.charAt(body.length - suffix.length - 1);
+    const flipped = lastChar === 'f' ? '0' : 'f';
+    const tampered = body.slice(0, body.length - suffix.length - 1) + flipped + suffix;
+    expect(parseMarker(tampered)).toBeNull();
+  });
+
+  it('rejects a v2 marker whose payload was tampered + HMAC re-signed under a DIFFERENT secret', () => {
+    // Attacker controls the wire — they MUTATE the payload (flip a
+    // contentHash bit) AND recompute the HMAC under their best-guess
+    // secret. Without timing-safe HMAC verification under the bot's
+    // real secret, this would parse cleanly. We must reject.
+    process.env[MARKER_HMAC_SECRET_ENV] = SECRET_A;
+    const tamperedPayload: MarkerPayload = {
+      ...v2Payload,
+      contentHash: 'f'.repeat(64), // attacker's chosen hash
+    };
+    const json = JSON.stringify(tamperedPayload);
+    const b64 = Buffer.from(json, 'utf-8').toString('base64url');
+    const hmacUnderWrongSecret = refHmac(json, SECRET_B);
+    const forged = `${MARKER_PREFIX}v2:${b64}:${hmacUnderWrongSecret}${MARKER_SUFFIX}`;
+    expect(parseMarker(forged)).toBeNull();
+  });
+
+  it('rejects a v2 marker when the verifier has no secret (cannot verify)', () => {
+    // Bot signed the marker with SECRET_A, but the verifier process
+    // doesn't have MARKER_HMAC_SECRET set — must reject (do not parse
+    // an unverifiable signed payload).
+    const body = formatMarker(v2Payload, { secret: SECRET_A });
+    expect(parseMarker(body)).toBeNull(); // no env → reject
+  });
+
+  it('warns ONCE when rejecting v2 markers due to missing secret (operator visibility)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const body = formatMarker(v2Payload, { secret: SECRET_A });
+    parseMarker(body);
+    parseMarker(body);
+    parseMarker(body);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/v2 marker.*MARKER_HMAC_SECRET/);
+    warnSpy.mockRestore();
+  });
+
+  it('rejects v2 marker whose HMAC segment is the wrong length (structural guard)', () => {
+    process.env[MARKER_HMAC_SECRET_ENV] = SECRET_A;
+    const json = JSON.stringify(v2Payload);
+    const b64 = Buffer.from(json, 'utf-8').toString('base64url');
+    // 32-hex-char HMAC (half-length) — rejected by the regex guard
+    // before timingSafeEqual.
+    const shortHmac = '1234567890abcdef'.repeat(2);
+    const body = `${MARKER_PREFIX}v2:${b64}:${shortHmac}${MARKER_SUFFIX}`;
+    expect(parseMarker(body)).toBeNull();
+  });
+
+  it('rejects v2 marker missing the hmac segment entirely', () => {
+    process.env[MARKER_HMAC_SECRET_ENV] = SECRET_A;
+    const json = JSON.stringify(v2Payload);
+    const b64 = Buffer.from(json, 'utf-8').toString('base64url');
+    // No `:hmac` segment after the base64.
+    const body = `${MARKER_PREFIX}v2:${b64}${MARKER_SUFFIX}`;
+    expect(parseMarker(body)).toBeNull();
+  });
+
+  it('honors opts.secret override on parse (test ergonomics + custom-source callers)', () => {
+    // Caller threads the secret in directly (e.g. read from a vault
+    // rather than env). Symmetry with formatMarker's opts.secret.
+    const body = formatMarker(v2Payload, { secret: SECRET_A });
+    expect(parseMarker(body, { secret: SECRET_A })).toEqual(v2Payload);
+    expect(parseMarker(body, { secret: SECRET_B })).toBeNull(); // wrong secret
+  });
+});
+
+describe('parseMarker — v1 backward-compat (AISDLC-146 AC #2 + #6)', () => {
+  it('AC #4 + #6 — parses an explicit v1 marker (transition compat) with deprecation warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const body = formatMarker(v2Payload, { version: 1 });
+    // No env secret needed; v1 has no HMAC.
+    const parsed = parseMarker(body);
+    expect(parsed).toEqual(v2Payload);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/v1 .*deprecated/);
+    warnSpy.mockRestore();
+  });
+
+  it('parses pre-AISDLC-146 markers (no version prefix) as v1 for transition', () => {
+    // Wire shape PRE-AISDLC-146 was `<prefix><base64><suffix>` (no
+    // `v1:` segment). PRs that already carry such a marker must NOT
+    // strand on the next push — accept silently as v1.
+    const json = JSON.stringify(v2Payload);
+    const b64 = Buffer.from(json, 'utf-8').toString('base64url');
+    const legacyBody = `${MARKER_PREFIX}${b64}${MARKER_SUFFIX}`;
+    const parsed = parseMarker(legacyBody);
+    expect(parsed).toEqual(v2Payload);
+  });
+
+  it('warns ONCE about v1 deprecation across multiple parses (no log spam)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const body = formatMarker(v2Payload, { version: 1 });
+    parseMarker(body);
+    parseMarker(body);
+    parseMarker(body);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+
+  it('AC #6 — operator-posted v1 marker by trusted author + valid contentHash is still respected', () => {
+    // Threat-model adjacent assertion: a trusted-author v1 marker (e.g.
+    // an in-flight marker written by the previous workflow run before
+    // AISDLC-146 deployed) MUST still be honoured during the transition
+    // window. Otherwise every PR with a pre-existing v1 marker re-runs
+    // FULL review on the first post-deploy push (mass cost regression).
+    const v1Body = formatMarker(v2Payload, { version: 1 });
+    const comments: CommentWithAuthor[] = [
+      {
+        authorLogin: 'github-actions',
+        authorAssociation: 'CONTRIBUTOR',
+        body: v1Body,
+      },
+    ];
+    const m = findTrustedMarkerInComments(comments);
+    expect(m).not.toBeNull();
+    expect(m?.contentHash).toBe(v2Payload.contentHash);
+    expect(m?.reviewedSha).toBe(v2Payload.reviewedSha);
+  });
+});
+
+describe('findMarkerInComments — HMAC-aware filtering (AISDLC-146 AC #3)', () => {
+  it('returns null when the only candidate marker fails HMAC validation', () => {
+    process.env[MARKER_HMAC_SECRET_ENV] = SECRET_A;
+    // Forged marker — payload signed under SECRET_B, but verifier has SECRET_A.
+    const json = JSON.stringify(v2Payload);
+    const b64 = Buffer.from(json, 'utf-8').toString('base64url');
+    const forged = `${MARKER_PREFIX}v2:${b64}:${refHmac(json, SECRET_B)}${MARKER_SUFFIX}`;
+    expect(findMarkerInComments([forged])).toBeNull();
+  });
+
+  it('skips a forged v2 marker and returns the older valid v2 marker beneath it', () => {
+    // findMarkerInComments scans newest-first (last-occurrence-wins).
+    // If the freshest comment carries a forged marker, it must be
+    // rejected and the search must continue to the next candidate —
+    // NOT short-circuit "freshest-wins" into "freshest-attacker-wins".
+    process.env[MARKER_HMAC_SECRET_ENV] = SECRET_A;
+    const validBody = formatMarker(v2Payload); // valid v2
+    const forgedJson = JSON.stringify({
+      ...v2Payload,
+      contentHash: '9'.repeat(64),
+    });
+    const forgedB64 = Buffer.from(forgedJson, 'utf-8').toString('base64url');
+    const forgedBody = `${MARKER_PREFIX}v2:${forgedB64}:${refHmac(forgedJson, SECRET_B)}${MARKER_SUFFIX}`;
+    const out = findMarkerInComments([validBody, forgedBody]);
+    // Forged marker rejected; older valid marker survives.
+    expect(out?.contentHash).toBe(v2Payload.contentHash);
+  });
+
+  it('threads opts.secret through to parseMarker (no env reliance)', () => {
+    const body = formatMarker(v2Payload, { secret: SECRET_A });
+    expect(findMarkerInComments([body], { secret: SECRET_A })).toEqual(v2Payload);
+    expect(findMarkerInComments([body], { secret: SECRET_B })).toBeNull();
   });
 });

--- a/pipeline-cli/src/incremental-review/incremental.ts
+++ b/pipeline-cli/src/incremental-review/incremental.ts
@@ -38,12 +38,61 @@
  * @module incremental-review/incremental
  */
 
-import { createHash } from 'node:crypto';
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 
 /** Marker substring used to locate the last-reviewed-contenthash PR comment. */
 export const MARKER_PREFIX = '<!-- ai-sdlc:last-reviewed-contenthash:';
 /** Closing token for the marker so the parser can isolate the encoded payload. */
 export const MARKER_SUFFIX = ' -->';
+
+/**
+ * Env var name holding the HMAC-SHA256 secret used to sign + verify v2
+ * markers (AISDLC-146). When present, `formatMarker` defaults to v2; when
+ * missing, `formatMarker` falls back to v1 with a warning. `parseMarker`
+ * REQUIRES the secret to accept any v2 marker — without it, v2 markers are
+ * rejected (cannot verify the signature).
+ *
+ * Operator setup (one time): generate 32+ random bytes and add as a GitHub
+ * secret on the repo:
+ *
+ *   gh secret set MARKER_HMAC_SECRET --body "$(openssl rand -hex 32)"
+ *
+ * Then ensure the `analyze` + `report` jobs in `.github/workflows/ai-sdlc-review.yml`
+ * forward the secret via env (already wired by AISDLC-146).
+ */
+export const MARKER_HMAC_SECRET_ENV = 'MARKER_HMAC_SECRET';
+
+/**
+ * Marker version tags. v1 is the legacy AISDLC-142 wire format (no HMAC);
+ * v2 is the AISDLC-146 HMAC-signed wire format. New writes default to v2
+ * when `MARKER_HMAC_SECRET` is set; v1 stays accepted on read for one or
+ * two PR cycles so the trusted-author-posted v1 markers in the wild
+ * self-migrate without an abrupt cutover.
+ */
+export type MarkerVersion = 1 | 2;
+
+/**
+ * Module-level latch so the v1 deprecation warning (and v2-without-secret
+ * warnings) only fire ONCE per process. The pre-flight, the workflow, and
+ * the slash-command body all reach into this module repeatedly per push;
+ * without the latch, CI logs get spammed with the same banner.
+ *
+ * Exported `_resetWarnLatchForTests` resets the latch so tests can assert
+ * the "warns once" semantic deterministically without process-isolation
+ * acrobatics.
+ */
+const warnLatch: { v1Deprecation: boolean; v2NoSecret: boolean; missingSecretFormat: boolean } = {
+  v1Deprecation: false,
+  v2NoSecret: false,
+  missingSecretFormat: false,
+};
+
+/** Test-only — reset the warning latch between cases. NOT for production code. */
+export function _resetWarnLatchForTests(): void {
+  warnLatch.v1Deprecation = false;
+  warnLatch.v2NoSecret = false;
+  warnLatch.missingSecretFormat = false;
+}
 
 /**
  * Default delta-size threshold (lines). When the delta diff exceeds this, fall
@@ -119,55 +168,260 @@ export type IncrementalReason =
 // ── Marker parse / format ────────────────────────────────────────────
 
 /**
- * Encode the marker payload as a single-line HTML comment. Format (load-bearing
- * — the workflows search for the prefix substring to locate the comment):
- *
- *   <!-- ai-sdlc:last-reviewed-contenthash:<base64url(json)> -->
- *
- * base64url avoids `+/=` chars that markdown sometimes mangles in comments,
- * and JSON-inside-base64 keeps the marker forward-compatible (we can add
- * fields without breaking parsers that only key off the comment prefix).
+ * Compute the HMAC-SHA256 of `payloadJson` keyed by `secret`, returning the
+ * lowercase hex digest. Wrapped so call sites stay one-liners + the unit
+ * tests have a reference impl to pin the algorithm. NOT exported by the
+ * package barrel — internal helper only.
  */
-export function formatMarker(payload: MarkerPayload): string {
+function computeMarkerHmac(payloadJson: string, secret: string): string {
+  return createHmac('sha256', secret).update(payloadJson, 'utf-8').digest('hex');
+}
+
+/**
+ * Constant-time comparison of two equal-length lowercase-hex digests.
+ * Resilient to length mismatch (returns false rather than throwing) so
+ * callers don't have to wrap every check in try/catch.
+ *
+ * SECURITY: `string === string` is variable-time and leaks timing info on a
+ * sufficiently determined attacker, even for short hex strings. We pay the
+ * cost of `timingSafeEqual` here because the marker check is the v2
+ * authorization gate.
+ */
+function safeHmacEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(a, 'utf-8'), Buffer.from(b, 'utf-8'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Encode the marker payload as a single-line HTML comment. Format
+ * (load-bearing — the workflows search for the prefix substring to locate
+ * the comment):
+ *
+ *   v1 (legacy):  <!-- ai-sdlc:last-reviewed-contenthash:v1:<base64url(json)> -->
+ *   v2 (HMAC):    <!-- ai-sdlc:last-reviewed-contenthash:v2:<base64url(json)>:<hmac-sha256-hex> -->
+ *
+ * v2 is the default when `process.env.MARKER_HMAC_SECRET` is set. When the
+ * env var is missing, we fall back to v1 with a one-time `console.warn` so
+ * the operator can plumb the secret in. base64url avoids `+/=` chars that
+ * markdown sometimes mangles in comments; JSON-inside-base64 keeps the
+ * payload schema forward-compatible.
+ *
+ * The HMAC input is the EXACT `JSON.stringify(payload)` string we just
+ * encoded — so verifying re-decodes the base64, re-stringifies the JSON,
+ * and recomputes the HMAC. The 4th `:`-segment is the lowercase hex
+ * digest.
+ *
+ * @param payload The contentHash + reviewedSha + reviewedAt to encode.
+ * @param opts    Test/override hooks. `version` forces v1/v2 (skipping the
+ *                env-driven default). `secret` overrides the env var (used
+ *                in tests + by callers that read the secret from a
+ *                different source).
+ */
+export function formatMarker(
+  payload: MarkerPayload,
+  opts: { version?: MarkerVersion; secret?: string } = {},
+): string {
   const json = JSON.stringify(payload);
   const b64 = Buffer.from(json, 'utf-8').toString('base64url');
-  return `${MARKER_PREFIX}${b64}${MARKER_SUFFIX}`;
+
+  // Resolve the HMAC secret. Explicit override wins; env fallback is the
+  // production path. An empty string is treated as "no secret" — yargs/CI
+  // env handling sometimes hands through "" and we don't want a zero-length
+  // HMAC key to silently sign a v2 marker.
+  const secret =
+    typeof opts.secret === 'string' && opts.secret.length > 0
+      ? opts.secret
+      : (process.env[MARKER_HMAC_SECRET_ENV] ?? '');
+
+  // Default version: v2 when we have a secret, v1 otherwise. Explicit
+  // `opts.version` short-circuits both branches (test ergonomics).
+  const version: MarkerVersion = opts.version ?? (secret.length > 0 ? 2 : 1);
+
+  if (version === 2) {
+    if (secret.length === 0) {
+      // Caller asked for v2 but didn't supply a secret. Refuse to emit an
+      // unverifiable marker — it'd be wire-compatible with v2 but every
+      // verifier would reject it (defense-in-depth path is "drop on
+      // unverifiable", not "treat as v1"). Throw so the caller fixes the
+      // env wiring rather than silently degrading to a marker that always
+      // fails downstream.
+      throw new Error(
+        'formatMarker: v2 requires a non-empty MARKER_HMAC_SECRET (env or opts.secret).',
+      );
+    }
+    const hmac = computeMarkerHmac(json, secret);
+    return `${MARKER_PREFIX}v2:${b64}:${hmac}${MARKER_SUFFIX}`;
+  }
+
+  // v1 fallback. When we got here because no secret was provisioned, warn
+  // once per process so the operator can spot the gap in CI logs without
+  // drowning every push in a banner.
+  if (secret.length === 0 && opts.version === undefined && !warnLatch.missingSecretFormat) {
+    warnLatch.missingSecretFormat = true;
+    console.warn(
+      `[incremental-review] MARKER_HMAC_SECRET env var is not set; ` +
+        `formatMarker is emitting v1 (no HMAC integrity). Set MARKER_HMAC_SECRET ` +
+        `via 'gh secret set MARKER_HMAC_SECRET --body "$(openssl rand -hex 32)"' ` +
+        `and forward it to the analyze + report jobs to enable v2 (AISDLC-146).`,
+    );
+  }
+  return `${MARKER_PREFIX}v1:${b64}${MARKER_SUFFIX}`;
+}
+
+/**
+ * Validate the JSON-decoded payload conforms to the `MarkerPayload` schema.
+ * Pure helper — no side effects, no warnings — so we can call it from both
+ * v1 + v2 parse branches.
+ */
+function validatePayload(parsed: Record<string, unknown>): MarkerPayload | null {
+  if (
+    typeof parsed.contentHash !== 'string' ||
+    !/^[0-9a-f]{64}$/i.test(parsed.contentHash) ||
+    typeof parsed.reviewedSha !== 'string' ||
+    !/^[0-9a-f]{40}$/i.test(parsed.reviewedSha) ||
+    typeof parsed.reviewedAt !== 'string'
+  ) {
+    return null;
+  }
+  return {
+    contentHash: parsed.contentHash.toLowerCase(),
+    reviewedSha: parsed.reviewedSha.toLowerCase(),
+    reviewedAt: parsed.reviewedAt,
+  };
 }
 
 /**
  * Locate + parse the marker inside `commentBody`. Returns `null` when no
- * marker is present OR when the encoded payload is malformed (defensive —
- * a corrupted marker should fall back to full review, NOT crash the
- * workflow).
+ * marker is present, the encoded payload is malformed, OR (v2) the HMAC
+ * signature does not verify. Defensive — a corrupted/tampered marker
+ * should fall back to full review, NOT crash the workflow.
+ *
+ * Version handling (AISDLC-146):
+ *   - v1 markers (no HMAC) parse normally + emit a one-time deprecation
+ *     warning. Acceptance window is intentionally narrow: drop v1 support
+ *     after the in-flight markers self-migrate (one or two PR cycles).
+ *   - v2 markers REQUIRE a `MARKER_HMAC_SECRET` env var (or `opts.secret`
+ *     override). Without it the parser cannot verify the signature, so
+ *     the marker is rejected.
+ *   - Tampered v2 markers (any single hex char of the HMAC flipped, or
+ *     payload mutated under the same secret, or payload + HMAC re-signed
+ *     under a DIFFERENT secret) all return `null`.
+ *
+ * @param commentBody The PR comment body text to scan.
+ * @param opts        `secret` overrides the env var (test ergonomics).
  */
-export function parseMarker(commentBody: string): MarkerPayload | null {
+export function parseMarker(
+  commentBody: string,
+  opts: { secret?: string } = {},
+): MarkerPayload | null {
   const start = commentBody.indexOf(MARKER_PREFIX);
   if (start === -1) return null;
   const payloadStart = start + MARKER_PREFIX.length;
   const end = commentBody.indexOf(MARKER_SUFFIX, payloadStart);
   if (end === -1) return null;
-  const b64 = commentBody.slice(payloadStart, end).trim();
+  const inner = commentBody.slice(payloadStart, end).trim();
+  if (inner.length === 0) return null;
+
+  // Resolve secret the same way formatMarker does — explicit override
+  // wins; empty string treated as missing.
+  const secret =
+    typeof opts.secret === 'string' && opts.secret.length > 0
+      ? opts.secret
+      : (process.env[MARKER_HMAC_SECRET_ENV] ?? '');
+
+  // ── Version dispatch ────────────────────────────────────────────────
+  // The wire format starts with `v1:` or `v2:` followed by base64url. We
+  // accept ALSO the AISDLC-142 pre-version format (no `vN:` prefix) by
+  // treating it as v1 — that's the one-comment-on-an-old-PR transition
+  // case. Without that compat hop, the very first push under v2 against
+  // a PR with an existing AISDLC-142 marker would fail the parse and the
+  // skip path would silently regress to FULL review.
+  let version: MarkerVersion;
+  let rest: string;
+  if (inner.startsWith('v2:')) {
+    version = 2;
+    rest = inner.slice(3);
+  } else if (inner.startsWith('v1:')) {
+    version = 1;
+    rest = inner.slice(3);
+  } else {
+    // Pre-AISDLC-146 format — treat as v1 for backward compat (silent;
+    // the v1 deprecation warning handles operator notification).
+    version = 1;
+    rest = inner;
+  }
+
+  let b64: string;
+  let providedHmac = '';
+  if (version === 2) {
+    // Wire shape: <base64>:<hmac-hex>. Split on the LAST `:` so a base64url
+    // string (which never contains `:`, but we belt-and-brace it) can't
+    // shift the hmac segment.
+    const lastColon = rest.lastIndexOf(':');
+    if (lastColon === -1) return null;
+    b64 = rest.slice(0, lastColon);
+    providedHmac = rest.slice(lastColon + 1).toLowerCase();
+    if (!/^[0-9a-f]{64}$/.test(providedHmac)) return null;
+  } else {
+    b64 = rest;
+  }
   if (b64.length === 0) return null;
+
+  // Decode + structural validate.
+  let json: string;
+  let parsed: Record<string, unknown>;
   try {
-    const json = Buffer.from(b64, 'base64url').toString('utf-8');
-    const parsed = JSON.parse(json) as Record<string, unknown>;
-    if (
-      typeof parsed.contentHash !== 'string' ||
-      !/^[0-9a-f]{64}$/i.test(parsed.contentHash) ||
-      typeof parsed.reviewedSha !== 'string' ||
-      !/^[0-9a-f]{40}$/i.test(parsed.reviewedSha) ||
-      typeof parsed.reviewedAt !== 'string'
-    ) {
-      return null;
-    }
-    return {
-      contentHash: parsed.contentHash.toLowerCase(),
-      reviewedSha: parsed.reviewedSha.toLowerCase(),
-      reviewedAt: parsed.reviewedAt,
-    };
+    json = Buffer.from(b64, 'base64url').toString('utf-8');
+    parsed = JSON.parse(json) as Record<string, unknown>;
   } catch {
     return null;
   }
+  const validated = validatePayload(parsed);
+  if (validated === null) return null;
+
+  if (version === 2) {
+    if (secret.length === 0) {
+      // Cannot verify a v2 marker without the key. Reject, but warn ONCE so
+      // the operator sees the gap rather than silently regressing to FULL
+      // reviews on every push.
+      if (!warnLatch.v2NoSecret) {
+        warnLatch.v2NoSecret = true;
+        console.warn(
+          `[incremental-review] received v2 marker but ${MARKER_HMAC_SECRET_ENV} ` +
+            `is not set; rejecting (cannot verify signature). Set the env var to ` +
+            `restore incremental-review skip path (AISDLC-146).`,
+        );
+      }
+      return null;
+    }
+    const expected = computeMarkerHmac(json, secret);
+    if (!safeHmacEquals(expected, providedHmac)) {
+      // Signature mismatch — payload tampered, wrong secret, or both.
+      // Silent rejection: the trusted-author filter is Layer 1; HMAC is
+      // Layer 2. A noisy warning here would let a malicious-but-trusted
+      // collaborator probe for the secret by watching CI logs. Any v2
+      // failure routes to "no marker → FULL review", the safe default.
+      return null;
+    }
+    return validated;
+  }
+
+  // v1 — emit the deprecation warning once per process. The warning is
+  // operator-facing only (CI log line); the parse still succeeds so
+  // in-flight markers don't strand the next push in FULL-review mode.
+  if (!warnLatch.v1Deprecation) {
+    warnLatch.v1Deprecation = true;
+    console.warn(
+      `[incremental-review] parsed a v1 (no-HMAC) marker — v1 is deprecated and will ` +
+        `be removed in a future release (AISDLC-146). New writes default to v2 when ` +
+        `${MARKER_HMAC_SECRET_ENV} is set.`,
+    );
+  }
+  return validated;
 }
 
 /**
@@ -185,9 +439,12 @@ export function parseMarker(commentBody: string): MarkerPayload | null {
  * The fix lives at the FETCH boundary — see the `gh pr view --jq` filter
  * in `.github/workflows/ai-sdlc-review.yml` and `ai-sdlc-plugin/commands/execute.md`.
  */
-export function findMarkerInComments(commentBodies: string[]): MarkerPayload | null {
+export function findMarkerInComments(
+  commentBodies: string[],
+  opts: { secret?: string } = {},
+): MarkerPayload | null {
   for (let i = commentBodies.length - 1; i >= 0; i--) {
-    const m = parseMarker(commentBodies[i]);
+    const m = parseMarker(commentBodies[i], opts);
     if (m !== null) return m;
   }
   return null;
@@ -282,8 +539,9 @@ export function filterTrustedComments(comments: readonly CommentWithAuthor[]): s
  */
 export function findTrustedMarkerInComments(
   comments: readonly CommentWithAuthor[],
+  opts: { secret?: string } = {},
 ): MarkerPayload | null {
-  return findMarkerInComments(filterTrustedComments(comments));
+  return findMarkerInComments(filterTrustedComments(comments), opts);
 }
 
 // ── ContentHashV3 (mirror of orchestrator/src/runtime/attestations.ts) ─

--- a/pipeline-cli/src/index.ts
+++ b/pipeline-cli/src/index.ts
@@ -19,6 +19,7 @@ export * from './deps/index.js';
 export { executePipeline } from './execute-pipeline.js';
 
 // AISDLC-142 — incremental review primitives (skip / delta-only / full).
+// AISDLC-146 — HMAC-signed v2 markers (Layer 2 defense-in-depth).
 export {
   buildAutoApprovedVerdict,
   collectChangedFileDeltaEntries,
@@ -27,6 +28,7 @@ export {
   DEFAULT_MAX_DELTA_LINES,
   findMarkerInComments,
   formatMarker,
+  MARKER_HMAC_SECRET_ENV,
   MARKER_PREFIX,
   MARKER_SUFFIX,
   parseMarker,
@@ -37,6 +39,7 @@ export {
   type IncrementalDecision,
   type IncrementalReason,
   type MarkerPayload,
+  type MarkerVersion,
   type RunGit,
 } from './incremental-review/incremental.js';
 


### PR DESCRIPTION
## Summary

Layer 2 defense-in-depth for the AISDLC-142 incremental-review marker. Adds HMAC-SHA256 wire-format integrity (v2 marker), signed by `MARKER_HMAC_SECRET`, so a malicious-but-trusted COLLABORATOR can't post a manual marker comment with a forged contentHash binding and skip review on co-authored PRs.

- v1 (legacy AISDLC-142, no HMAC) accepted on read with one-time deprecation warning so in-flight markers don't strand the next push in FULL-review mode
- v2 (HMAC-signed) emitted by default when `MARKER_HMAC_SECRET` is provisioned; falls back to v1 + `console.warn` when unset
- Pre-AISDLC-146 markers (no `vN:` tag) silently accepted as v1 for transition

## Threat closed

The AISDLC-142 trusted-author filter (Layer 1) blocks EXTERNAL contributors from posting forged markers. But a TRUSTED COLLABORATOR could still:

1. Post a marker comment manually with a forged `contentHash` binding the publicly-computable current `contentHashV3`.
2. Layer 1 lets it through (the collaborator IS in the trusted set).
3. Skip-when-unchanged path trusts the contentHash → all 3 reviewers skipped → auto-approve.

HMAC keyed by a secret only the bot knows (`MARKER_HMAC_SECRET`) closes the gap. Manual marker comments lack the right signature and get rejected.

## Operator setup (one time, REQUIRED for HMAC integrity)

Generate a 32-byte random secret and add it as a GitHub repo secret:

```bash
gh secret set MARKER_HMAC_SECRET --body "$(openssl rand -hex 32)"
```

Without this, the workflow runs in v1 fallback mode (functional but no HMAC integrity); a `core.warning` in the report job makes the gap visible in CI logs.

## Wire format

| Version | Format | Use |
|---------|--------|-----|
| v0 (legacy AISDLC-142) | `<!-- ai-sdlc:last-reviewed-contenthash:<base64-json> -->` | Accepted on read for in-flight markers; never written by new code |
| v1 (transition) | `<!-- ai-sdlc:last-reviewed-contenthash:v1:<base64-json> -->` | Written when `MARKER_HMAC_SECRET` is unset |
| v2 (HMAC) | `<!-- ai-sdlc:last-reviewed-contenthash:v2:<base64-json>:<hmac-sha256-hex> -->` | Default when `MARKER_HMAC_SECRET` is set |

The HMAC input is the EXACT `JSON.stringify(payload)` string that gets base64'd. Verifier re-decodes the base64, re-derives the JSON string, and recomputes the HMAC under the shared secret.

## Test plan

- [ ] Verify CI green on this PR (analyze + report jobs use the existing v1 path until `MARKER_HMAC_SECRET` is provisioned)
- [ ] Operator runs `gh secret set MARKER_HMAC_SECRET --body "$(openssl rand -hex 32)"`
- [ ] Push a follow-up commit; verify the marker comment is now `:v2:` form and the HMAC segment is 64 hex chars
- [ ] Manually edit the marker comment to flip a single HMAC hex char; push again; verify the analyze job logs `received v2 marker but ...rejecting` and routes to FULL review (failsafe)