### PR TITLE
fix(ci): invoke pipeline-cli CLIs via node directly, not pnpm exec (AISDLC-156)

### DIFF
--- a/.github/workflows/ai-sdlc-review.yml
+++ b/.github/workflows/ai-sdlc-review.yml
@@ -186,10 +186,18 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           mkdir -p /tmp/classifier-artifacts
-          # `--silent` suppresses pnpm's progress noise so we capture clean JSON.
-          # `|| echo ...` is the belt-and-braces fallback in case the binary is
-          # missing — emits a fellOpen=true ALL_REVIEWERS decision and we proceed.
-          CLASSIFIER_JSON=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-classify-pr classify \
+          # AISDLC-156: invoke the bin shim DIRECTLY via `node` instead of
+          # `pnpm --filter ... exec`. `pnpm exec` does NOT resolve a workspace
+          # package's OWN bin entries (only its DEPENDENCIES' bins are
+          # symlinked into node_modules/.bin/), so the previous form silently
+          # failed with `Command "cli-classify-pr" not found` and the
+          # `|| echo` fallback fired on EVERY run — defeating the AISDLC-141
+          # cost optimization. Direct node invocation removes the pnpm layer
+          # and makes the fallback fire only on real CLI errors.
+          # `|| echo ...` is the belt-and-braces fallback in case the binary
+          # genuinely errors — emits a fellOpen=true ALL_REVIEWERS decision
+          # and we proceed.
+          CLASSIFIER_JSON=$(node pipeline-cli/bin/cli-classify-pr.mjs classify \
             --paths-file /tmp/pr-files.txt \
             --issue-id "PR-${PR_NUMBER}" \
             --artifacts-dir /tmp/classifier-artifacts 2>/tmp/classifier-stderr.txt \
@@ -364,7 +372,11 @@ jobs:
           # the trusted-author filter (Layer 2 defense-in-depth) on top of
           # the gh --jq filter above. Even if the jq filter is bypassed
           # somehow, the CLI-side filter still rejects forged markers.
-          INCREMENTAL_JSON=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-incremental-decide decide \
+          #
+          # AISDLC-156: direct `node ./pipeline-cli/bin/...` invocation (NOT
+          # `pnpm --filter ... exec`). See the matching note on the classify
+          # step above + pipeline-cli/README.md "Invoking from CI" section.
+          INCREMENTAL_JSON=$(node pipeline-cli/bin/cli-incremental-decide.mjs decide \
             --comments-json-file /tmp/pr-comments.json \
             --base-ref "${{ github.event.pull_request.base.sha }}" \
             --head-ref HEAD \
@@ -464,7 +476,9 @@ jobs:
           # not the classifier selected them). The report job's gate
           # semantics stay unchanged — three approved verdicts → APPROVE.
           if [ "$INCR_SKIP" = "true" ]; then
-            INCR_AUTO_APPROVED=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-incremental-decide auto-approved-verdict \
+            # AISDLC-156: direct `node ./pipeline-cli/bin/...` invocation —
+            # see notes on the classify + decide steps above.
+            INCR_AUTO_APPROVED=$(node pipeline-cli/bin/cli-incremental-decide.mjs auto-approved-verdict \
               --reviewed-sha "$INCR_LAST_SHA" 2>/dev/null \
               || printf '%s' '{"approved":true,"findings":[],"summary":"Skipped by incremental review (AISDLC-142) — content unchanged."}')
             for TYPE in testing critic security; do
@@ -539,7 +553,16 @@ jobs:
           # safety net). The classifier guarantees `proceed-as-normal` on
           # any partial input set so a workflow regression can't silently
           # suppress a real failure.
-          BUDGET_JSON=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-classify-budget \
+          #
+          # AISDLC-156: direct `node ./pipeline-cli/bin/...` invocation —
+          # see notes on the classify + decide steps above. Pre-AISDLC-156
+          # this used `pnpm --filter ... exec cli-classify-budget` which
+          # silently failed (`Command not found`) on every run because pnpm
+          # exec doesn't resolve workspace own-bins → the fallback below
+          # fired unconditionally → `proceed-as-normal` aggregate → noisy
+          # CHANGES_REQUESTED on every PR when the API key was exhausted
+          # (defeating the AISDLC-147/154 circuit breaker entirely).
+          BUDGET_JSON=$(node pipeline-cli/bin/cli-classify-budget.mjs \
             --testing-stdout /tmp/review-testing.txt \
             --testing-stderr /tmp/review-testing-stderr.txt \
             --critic-stdout /tmp/review-critic.txt \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ GitHub Actions silently skips ALL workflows when ANY commit body contains `[skip
 
 PR merge gate is the single rollup check `ai-sdlc/pr-ready` produced by `.github/workflows/ai-sdlc-gate.yml` (re-actors/alls-green pattern); see [`docs/operations/quality-gate.md`](docs/operations/quality-gate.md) for archetype gating, cutover, and rollback.
 
+Workflows MUST invoke pipeline-cli CLIs via `node pipeline-cli/bin/cli-XXX.mjs` directly — never via `pnpm --filter @ai-sdlc/pipeline-cli exec cli-XXX`. `pnpm exec` does not resolve workspace own-bins, so the latter form silently fails with `Command not found` and any `|| echo <fallback>` safety net fires unconditionally. `pipeline-cli/src/cli/bin-invocation.test.ts` enforces both directions of this rule. See AISDLC-156 + the "Invoking from CI" section of `pipeline-cli/README.md`.
+
 ## Code Style
 
 - TypeScript strict, ESM. Prettier + ESLint. No premature abstractions — three similar lines beat one wrong abstraction.

--- a/backlog/completed/aisdlc-156 - Fix-pipeline-cli-CLI-invocation-in-CI-pnpm-exec-doesnt-resolve-workspace-own-bins.md
+++ b/backlog/completed/aisdlc-156 - Fix-pipeline-cli-CLI-invocation-in-CI-pnpm-exec-doesnt-resolve-workspace-own-bins.md
@@ -1,0 +1,152 @@
+---
+id: AISDLC-156
+title: >-
+  Fix pipeline-cli CLI invocation in CI — pnpm exec doesn't resolve workspace
+  own-bins, all 3 cost-saver CLIs silently failed
+status: Done
+assignee: []
+created_date: '2026-05-02 20:43'
+labels:
+  - ci
+  - bug
+  - critical
+  - cost-optimization
+dependencies:
+  - AISDLC-141
+  - AISDLC-142
+  - AISDLC-147
+  - AISDLC-149
+  - AISDLC-154
+references:
+  - .github/workflows/ai-sdlc-review.yml
+  - pipeline-cli/bin/cli-classify-pr.mjs
+  - pipeline-cli/bin/cli-incremental-decide.mjs
+  - pipeline-cli/bin/cli-classify-budget.mjs
+  - pipeline-cli/src/cli/bin-invocation.test.ts
+  - pipeline-cli/README.md
+  - CLAUDE.md
+priority: highest
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+ALL THREE pipeline-cli CLIs invoked by `.github/workflows/ai-sdlc-review.yml` were silently failing in CI, defeating the AISDLC-141, AISDLC-142, AISDLC-147, AISDLC-149, and AISDLC-154 cost optimizations entirely. Every PR ran full-budget reviewers, blew through Anthropic credits, and posted CHANGES_REQUESTED on credit exhaustion.
+
+### Symptom (verified PR #201, run id 25268792976)
+
+The `Analyze PR` job log shows the LITERAL fallback JSON shapes for all three CLIs:
+- `Classifier decision: [testing critic security] (confidence: 0, fellOpen: true)` ← matches `cli-classify-pr` fallback
+- `Incremental decision: no-marker` ← matches `cli-incremental-decide` fallback
+- `Budget classifier: aggregate=proceed-as-normal exhausted=0/3` ← matches `cli-classify-budget` fallback
+
+The job log has ZERO mentions of "credit balance" or "invalid_request_error" — the CLIs themselves never ran (only their `|| echo <fallback-json>` safety nets fired).
+
+### Root cause
+
+The workflow used:
+
+```bash
+RESULT=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-XXX ... \
+  || echo '<hardcoded-fallback-json>')
+```
+
+`pnpm exec` resolves binaries via `node_modules/.bin/`. Workspace packages do NOT symlink their OWN bin entries into their OWN `node_modules/.bin/` — only DEPENDENCIES are symlinked. So `pnpm --filter @ai-sdlc/pipeline-cli exec cli-classify-budget` looks for the bin in pipeline-cli's `node_modules/.bin/`, doesn't find it (since pipeline-cli IS the package that defines the bin, not a dependency), and errors with:
+
+```
+ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "cli-classify-budget" not found
+```
+
+The fail-open `|| echo` semantics meant:
+- `cli-classify-pr` fallback `{fellOpen:true}` → run all 3 reviewers (no AISDLC-141 optimization)
+- `cli-incremental-decide` fallback `{skip:false, reason:"no-marker"}` → do full review (no AISDLC-142 optimization)
+- `cli-classify-budget` fallback `{aggregate:"proceed-as-normal"}` → post CHANGES_REQUESTED on credit exhaustion (no AISDLC-147/149/154 protection)
+
+Reproducible locally:
+
+```
+pnpm --filter @ai-sdlc/pipeline-cli exec cli-classify-budget --help
+# → ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "cli-classify-budget" not found
+
+node pipeline-cli/bin/cli-classify-budget.mjs --help
+# → prints help
+```
+
+### Fix
+
+Switched all 4 invocation sites in `.github/workflows/ai-sdlc-review.yml` (1× `cli-classify-pr`, 2× `cli-incremental-decide`, 1× `cli-classify-budget`) from `pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-XXX` to `node pipeline-cli/bin/cli-XXX.mjs`. The bin shims already use `#!/usr/bin/env node` and import the compiled dist module — no shim changes required.
+
+Retained the `|| echo '<json>'` fallback so genuine CLI errors still fail-open. After the fix, the fallback fires ONLY on real CLI errors, not on invocation-resolution failures.
+
+### Regression prevention
+
+`pipeline-cli/src/cli/bin-invocation.test.ts` is the new hermetic guard. It:
+1. Spawns each `bin/cli-*.mjs` via `node` from a real subprocess and asserts `--help` exits 0.
+2. Asserts the broken `pnpm --filter @ai-sdlc/pipeline-cli exec cli-classify-budget --help` invocation STILL FAILS with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL` / `Command not found`. If pnpm ever fixes own-bin resolution (or we move to a different package manager), this test fails LOUDLY and forces a deliberate re-evaluation of whether the simpler form can be reintroduced.
+
+CLAUDE.md (CI behavior section) and `pipeline-cli/README.md` (new "Invoking from CI" subsection) document the rule prescriptively so future operators read it before touching the workflow.
+
+### Impact
+
+Until this lands, NONE of the cost optimizations were actually live in CI. After it lands, AISDLC-141/142/147/149/154 take effect on every PR.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 ALL 3 CLI invocation patterns in `.github/workflows/ai-sdlc-review.yml` switched to `node pipeline-cli/bin/cli-XXX.mjs` form (4 sites total: 1× cli-classify-pr, 2× cli-incremental-decide, 1× cli-classify-budget)
+- [x] #2 Fallback `|| echo '<json>'` retained so genuine CLI errors still fail-open
+- [x] #3 Hermetic regression test added at `pipeline-cli/src/cli/bin-invocation.test.ts` that verifies each bin is invokable via `node` AND that `pnpm exec` is still broken (defense against future workflow regressions)
+- [x] #4 Documentation paragraph added to CLAUDE.md (CI behavior section) and `pipeline-cli/README.md` (new "Invoking from CI" subsection) explaining the rule and citing AISDLC-156
+- [x] #5 Verified post-fix locally: `node pipeline-cli/bin/cli-classify-budget.mjs --help` exits 0 with help banner, end-to-end invocation returns real JSON (not the fallback shape)
+- [x] #6 Existing `pipeline-cli/src/cli/*.test.ts` suites continue to pass (1039/1039 tests pass)
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify cwd inside the worktree, read the workflow YAML to identify all 4 invocation sites
+2. Switch each site from `pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-XXX` to `node pipeline-cli/bin/cli-XXX.mjs`, preserving every flag and stderr redirection
+3. Add `pipeline-cli/src/cli/bin-invocation.test.ts` with two assertions per bin (file exists, `--help` exits 0) plus the broken-pattern guard
+4. Update CLAUDE.md (CI behavior) and `pipeline-cli/README.md` (new "Invoking from CI" subsection) with prescriptive guidance + AISDLC-156 reference
+5. Run the regression test + the full pipeline-cli vitest suite + lint + format:check
+6. Verify a real direct-node invocation works end-to-end (returns real JSON, not the fallback shape)
+7. Commit, push (`--set-upstream`), open PR
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- The task description claimed 3 invocation sites; the workflow actually has 4 (`cli-incremental-decide` is invoked twice — once for `decide`, once for `auto-approved-verdict`). All 4 are switched.
+- `--silent` was dropped in the regression test's broken-pattern assertion (NOT in the workflow itself) because pnpm's `--silent` flag suppresses the `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL` diagnostic, leaving the test with no error text to pattern-match. The CI failure mode is identical with or without `--silent` — both forms hit the same own-bin-resolution failure.
+- Decision NOT to add `pnpm exec`-style scripts to `pipeline-cli/package.json` (Option B from the task brief). Direct `node` invocation has zero abstraction layers, no pnpm overhead per invocation, and can't silently break the same way. The bin shims already provide the right level of indirection (compiled dist resolution).
+- The new test re-builds `dist/` if missing in `beforeAll` (single-shot, idempotent). Standard `pnpm test` runs after `pnpm build`, but local `pnpm --filter ... test` invocations may skip the build — this guards against that path.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL:BEGIN -->
+## Summary
+Switched all 4 pipeline-cli CLI invocation sites in `.github/workflows/ai-sdlc-review.yml` from the broken `pnpm --filter @ai-sdlc/pipeline-cli exec cli-XXX` form to direct `node pipeline-cli/bin/cli-XXX.mjs` invocation. The pnpm form silently failed (`ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL`) on every CI run because `pnpm exec` doesn't resolve workspace own-bins, causing the `|| echo <fallback-json>` safety nets to fire unconditionally and defeat the AISDLC-141/142/147/149/154 cost optimizations. Now they actually run.
+
+## Changes
+- `.github/workflows/ai-sdlc-review.yml` (modified): 4 invocation sites switched to `node pipeline-cli/bin/cli-XXX.mjs`; comments updated to cite AISDLC-156.
+- `pipeline-cli/src/cli/bin-invocation.test.ts` (new): regression guard — spawns each bin via `node`, asserts `--help` exits 0, AND asserts the broken `pnpm exec` form still fails (so future workflow regressions trip a loud test failure).
+- `pipeline-cli/README.md` (modified): new "Invoking from CI / GitHub Actions (AISDLC-156)" subsection explaining the rule.
+- `CLAUDE.md` (modified): single-line prescriptive rule under "CI behavior" pointing to the README + the regression test.
+
+## Design decisions
+- **Direct `node` invocation over `pnpm` script indirection**: removes the pnpm layer entirely, can't silently break the same way, faster per invocation. The bin shims already provide the right level of indirection (compiled dist resolution).
+- **Retain `|| echo <fallback>` fallback**: still want fail-open if the CLI genuinely errors. Post-fix the fallback fires ONLY on real CLI errors, not on invocation-resolution failures.
+- **Two-direction regression test**: positive (each bin invokable via `node`) + negative (broken `pnpm exec` form still fails). The negative direction is the defense — it forces a loud failure if anyone reverts the workflow under stale assumptions, AND if pnpm ever fixes own-bin resolution it forces a deliberate re-evaluation.
+
+## Verification
+- `pnpm --filter @ai-sdlc/pipeline-cli build` — clean
+- `pnpm --filter @ai-sdlc/pipeline-cli test` — 1039/1039 tests pass (64 test files), including the new `bin-invocation.test.ts` (7 tests).
+- `pnpm lint` — clean
+- `pnpm format:check` — clean
+- End-to-end manual invocation: `node pipeline-cli/bin/cli-classify-budget.mjs --testing-stdout /tmp/empty.txt ...` returns real JSON `{"aggregate":"proceed-as-normal","budgetExhaustedCount":0,...}`, not the literal fallback shape.
+
+## Follow-up
+(none — once this lands, AISDLC-141/142/147/149/154 take effect on every PR; subsequent PRs should show real classifier decisions and real budget signals in the `Analyze PR` job log).
+<!-- SECTION:FINAL:END -->

--- a/pipeline-cli/README.md
+++ b/pipeline-cli/README.md
@@ -67,6 +67,46 @@ Add it to a sibling workspace package's `package.json`:
 }
 ```
 
+### Invoking from CI / GitHub Actions (AISDLC-156)
+
+**Always invoke pipeline-cli CLIs via `node ./pipeline-cli/bin/<bin>.mjs`,
+never via `pnpm --filter @ai-sdlc/pipeline-cli exec <bin>`.**
+
+`pnpm exec` resolves binaries via the package's `node_modules/.bin/`
+symlink directory, but a workspace package's OWN `bin` entries are NOT
+symlinked into its own `node_modules/.bin/` — only its DEPENDENCIES'
+bins are. Invoking via `pnpm exec` from the workspace itself therefore
+returns:
+
+```
+ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "cli-classify-budget" not found
+```
+
+…on every invocation. In the AISDLC-156 incident, this silent failure
+caused the `|| echo '<fallback-json>'` safety net in
+`.github/workflows/ai-sdlc-review.yml` to fire on every PR for the three
+cost-saver CLIs (`cli-classify-pr`, `cli-incremental-decide`,
+`cli-classify-budget`), defeating the AISDLC-141/142/147/149/154
+optimizations entirely — every PR ran full-budget reviewers, blowing
+through Anthropic credits and posting `CHANGES_REQUESTED` whenever the
+key was exhausted.
+
+The workflow now invokes each CLI as:
+
+```yaml
+RESULT=$(node pipeline-cli/bin/cli-classify-pr.mjs classify --paths-file ... \
+  || echo '{"reviewers":["testing","critic","security"],"fellOpen":true,...}')
+```
+
+`pipeline-cli/src/cli/bin-invocation.test.ts` is the regression guard:
+it spawns each `bin/cli-*.mjs` via `node` and asserts `--help` exits 0,
+AND asserts that the broken `pnpm --filter ... exec` form still fails
+(so a future operator who reverts the workflow trips a loud test
+failure instead of re-introducing the silent regression). When pnpm
+eventually fixes own-bin resolution — or we move to a different package
+manager — that test will fail and force a deliberate re-evaluation of
+whether the simpler form can be reintroduced.
+
 ### From npm (Phase 8)
 
 Once Phase 8 (AISDLC-100.8) ships, `@ai-sdlc/pipeline-cli` will publish

--- a/pipeline-cli/src/cli/bin-invocation.test.ts
+++ b/pipeline-cli/src/cli/bin-invocation.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Regression test for AISDLC-156 — guard the bin invocation pattern used by
+ * `.github/workflows/ai-sdlc-review.yml`.
+ *
+ * History: pre-AISDLC-156 the workflow invoked the 3 cost-optimization CLIs
+ * (`cli-classify-pr`, `cli-incremental-decide`, `cli-classify-budget`) via
+ * `pnpm --filter @ai-sdlc/pipeline-cli exec cli-XXX`. That form silently
+ * failed (`ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL`: `Command "cli-XXX" not
+ * found`) on EVERY CI run because `pnpm exec` does NOT resolve a workspace
+ * package's OWN bin entries — only its DEPENDENCIES' bins are symlinked
+ * into `node_modules/.bin/`. The `|| echo <fallback-json>` safety net then
+ * fired unconditionally, defeating the AISDLC-141/142/147/149/154 cost
+ * optimizations entirely (every PR ran full-budget reviewers, blowing
+ * through Anthropic credits, posting CHANGES_REQUESTED on credit
+ * exhaustion).
+ *
+ * The fix: invoke the bin shim DIRECTLY via `node ./pipeline-cli/bin/cli-XXX.mjs`.
+ * This test guards two properties:
+ *   1. Each bin shim under `pipeline-cli/bin/cli-*.mjs` exists, is
+ *      executable as a node entrypoint, and exits 0 on `--help`. This
+ *      proves the shim file is present, the compiled `dist/cli/<name>.js`
+ *      target it imports is present, and the yargs router accepts `--help`.
+ *      A regression that breaks any of these (e.g. someone deletes the
+ *      bin file, renames the dist target, or removes the `--help` alias)
+ *      fails this test immediately.
+ *   2. `pnpm --filter @ai-sdlc/pipeline-cli exec cli-classify-budget --help`
+ *      still returns the broken `Command not found` error. This is the
+ *      defense-in-depth against a future regression where someone reverts
+ *      the workflow to the broken pattern under the assumption that
+ *      `pnpm exec` should "just work". When pnpm finally fixes this (or
+ *      we migrate to a different package manager), this test fails LOUDLY
+ *      and forces the operator to re-evaluate whether the workflow can
+ *      go back to the simpler pattern. Until then, fail loudly.
+ *
+ * Both properties exercise the REAL filesystem (no mocks) because the
+ * bug we're guarding against is a real-filesystem-resolution bug —
+ * mocking `child_process` would defeat the purpose.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Resolve the package root from the test file location:
+//   <pkg-root>/src/cli/bin-invocation.test.ts → <pkg-root>/
+const __filename = fileURLToPath(import.meta.url);
+const PKG_ROOT = resolve(__filename, '..', '..', '..');
+
+// The exact 3 bins the AISDLC-156 fix targets — these are the cost-saver
+// CLIs the review workflow invokes. Adding a new CI-invoked bin? Append
+// it here so the regression guard covers it too.
+const CI_INVOKED_BINS = [
+  'cli-classify-pr',
+  'cli-incremental-decide',
+  'cli-classify-budget',
+] as const;
+
+describe('AISDLC-156: bin invocation pattern (CI cost-saver guard)', () => {
+  // The bins import from `dist/cli/*.js` so the dist must exist before we
+  // can exercise them. `pnpm test` runs after `pnpm build` in the standard
+  // workflow, but local `pnpm --filter ... test` invocations may skip the
+  // build. Trigger a build here if dist is missing — single-shot, idempotent.
+  beforeAll(() => {
+    const distMarker = join(PKG_ROOT, 'dist', 'cli', 'classify-budget.js');
+    if (!existsSync(distMarker)) {
+      const build = spawnSync('pnpm', ['build'], {
+        cwd: PKG_ROOT,
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      });
+      if (build.status !== 0) {
+        throw new Error(
+          `pre-test build failed (exit ${build.status}):\n${build.stdout}\n${build.stderr}`,
+        );
+      }
+    }
+  }, 60_000);
+
+  describe.each(CI_INVOKED_BINS)('%s', (binName) => {
+    const binPath = join(PKG_ROOT, 'bin', `${binName}.mjs`);
+
+    it('bin shim file exists at the expected path', () => {
+      expect(existsSync(binPath), `missing bin shim: ${binPath}`).toBe(true);
+    });
+
+    it('is invokable via `node <pkg-root>/bin/<bin>.mjs --help` and exits 0', () => {
+      const result = spawnSync(process.execPath, [binPath, '--help'], {
+        cwd: PKG_ROOT,
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        // 10s ceiling — `--help` should return in <500ms; anything longer
+        // means the bin is hanging on stdin (regression in yargs config).
+        timeout: 10_000,
+      });
+      const detail = `\n--- exit ${result.status} ---\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`;
+      expect(result.status, `node ${binName}.mjs --help did not exit 0:${detail}`).toBe(0);
+      // `--help` always renders the usage banner — sanity check the output
+      // looks like a yargs help block (starts with "Usage:" or contains
+      // "Options:" or includes the bin name in a Commands list).
+      const out = result.stdout + result.stderr;
+      const looksLikeHelp =
+        /^Usage:/m.test(out) || /Options:/.test(out) || new RegExp(binName).test(out);
+      expect(looksLikeHelp, `--help output didn't look like a yargs banner:${detail}`).toBe(true);
+    });
+  });
+
+  it('`pnpm --filter @ai-sdlc/pipeline-cli exec cli-classify-budget` STILL FAILS — defense against future workflow regressions reverting to the broken pattern', () => {
+    // We use --help (no I/O, no env required) to keep this fast. The
+    // failure mode we're asserting is pnpm refusing to resolve the bin
+    // BEFORE the bin runs — so --help never gets to the binary at all.
+    //
+    // Why this assertion matters: someone reading the workflow might
+    // assume `pnpm exec` should "just work" and revert the workflow back
+    // to the AISDLC-156 broken pattern. This test fails loudly the moment
+    // they do. If pnpm one day fixes own-bin resolution (or we move to
+    // npm/bun/yarn that handles it correctly), this test fails too — but
+    // that's the GOOD failure: it forces the operator to re-evaluate the
+    // workflow choice with current behaviour, not stale assumptions.
+    //
+    // We probe from the workspace ROOT (same as CI does), not PKG_ROOT,
+    // because `pnpm --filter` only resolves filter targets when run from
+    // the monorepo root (or a workspace package within it).
+    const workspaceRoot = resolve(PKG_ROOT, '..');
+    // NB: we deliberately omit `--silent` here (which the workflow uses
+    // to clean up captured stdout for jq parsing). pnpm's `--silent` also
+    // suppresses ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL diagnostics, leaving
+    // us with empty stderr + non-zero exit — fine for the workflow's
+    // `|| echo <fallback>` (which fires on any non-zero exit), but
+    // useless for a regression test that needs to assert WHY pnpm
+    // failed. Without `--silent` pnpm prints the
+    // ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL banner so we can pattern-match
+    // on it. The CI behaviour we're guarding against is unchanged either
+    // way — both flag forms hit the same own-bin-resolution failure.
+    const result = spawnSync(
+      'pnpm',
+      ['--filter', '@ai-sdlc/pipeline-cli', 'exec', 'cli-classify-budget', '--help'],
+      {
+        cwd: workspaceRoot,
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        timeout: 30_000,
+      },
+    );
+    // `pnpm exec` with a missing bin → ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL
+    // and a non-zero exit. We DO NOT pin the exact error code/text
+    // (pnpm could change the wording across versions); we just assert
+    // the invocation failed AND the failure surface mentions the missing
+    // command. If both invariants hold, the broken pattern is still
+    // broken and the workflow MUST stay on the direct-node form.
+    const combined = result.stdout + result.stderr;
+    const detail = `\n--- exit ${result.status} ---\n--- combined ---\n${combined}`;
+    expect(
+      result.status,
+      `pnpm exec unexpectedly succeeded — re-evaluate AISDLC-156:${detail}`,
+    ).not.toBe(0);
+    expect(
+      /Command\s*"?cli-classify-budget"?\s*not\s*found/i.test(combined) ||
+        /ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL/.test(combined),
+      `pnpm exec failed but for an unexpected reason:${detail}`,
+    ).toBe(true);
+  }, 60_000);
+});
+
+// Coverage hint for callers reading this in isolation: the production
+// invocation pattern lives in `.github/workflows/ai-sdlc-review.yml` —
+// search for `node pipeline-cli/bin/` to find the four sites this test
+// guards (1× cli-classify-pr, 2× cli-incremental-decide, 1× cli-classify-budget).


### PR DESCRIPTION
## Summary

ALL 3 pipeline-cli CLIs invoked by `.github/workflows/ai-sdlc-review.yml` were silently failing on every CI run, defeating the AISDLC-141, AISDLC-142, AISDLC-147, AISDLC-149, and AISDLC-154 cost optimizations entirely. **Until this lands, none of the cost optimizations were actually live.** Every PR ran full-budget reviewers, blew through Anthropic credits, and posted noisy `CHANGES_REQUESTED` on credit exhaustion.

## The bug

The workflow used:
```bash
RESULT=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-XXX ... \
  || echo '<hardcoded-fallback-json>')
```

`pnpm exec` resolves binaries via `node_modules/.bin/`. **Workspace packages do not symlink their OWN bin entries into their OWN `node_modules/.bin/`** — only DEPENDENCIES are symlinked. So `pnpm --filter @ai-sdlc/pipeline-cli exec cli-classify-budget` looks for the bin in pipeline-cli's `node_modules/.bin/`, doesn't find it, and errors with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "cli-classify-budget" not found`. The `|| echo` fallback then fired unconditionally on every run.

### Verification (PR #201, run id 25268792976)

The `Analyze PR` job log shows the LITERAL fallback JSON shapes:
- `Classifier decision: [testing critic security] (confidence: 0, fellOpen: true)` <- matches `cli-classify-pr` fallback
- `Incremental decision: no-marker` <- matches `cli-incremental-decide` fallback
- `Budget classifier: aggregate=proceed-as-normal exhausted=0/3` <- matches `cli-classify-budget` fallback
- ZERO mentions of "credit balance" or "invalid_request_error" — the CLIs themselves never ran

Reproducible locally:
```
pnpm --filter @ai-sdlc/pipeline-cli exec cli-classify-budget --help
# -> ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "cli-classify-budget" not found

node pipeline-cli/bin/cli-classify-budget.mjs --help
# -> prints help
```

## The fix

Switched all 4 invocation sites in `.github/workflows/ai-sdlc-review.yml` (1x `cli-classify-pr`, 2x `cli-incremental-decide`, 1x `cli-classify-budget`) from `pnpm --filter @ai-sdlc/pipeline-cli exec cli-XXX` to direct `node pipeline-cli/bin/cli-XXX.mjs`. The bin shims already use `#!/usr/bin/env node` and import the compiled dist module — no shim changes needed.

Retained the `|| echo '<json>'` fallback so genuine CLI errors still fail-open. After the fix, the fallback fires ONLY on real CLI errors, not on invocation-resolution failures.

## Regression prevention

Added `pipeline-cli/src/cli/bin-invocation.test.ts` (7 tests) as the regression guard:
1. Spawns each `bin/cli-*.mjs` via `node` from a real subprocess and asserts `--help` exits 0.
2. Asserts the broken `pnpm --filter @ai-sdlc/pipeline-cli exec cli-classify-budget --help` invocation STILL fails with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL` / `Command not found`. If pnpm ever fixes own-bin resolution (or we move to a different package manager), this test fails LOUDLY and forces the operator to deliberately re-evaluate whether the simpler form can be reintroduced.

Documented the rule in:
- `CLAUDE.md` (CI behavior section) — single-line prescriptive rule pointing to the README + the regression test.
- `pipeline-cli/README.md` — new "Invoking from CI / GitHub Actions (AISDLC-156)" subsection with the full rationale.

## Impact

After this lands, AISDLC-141/142/147/149/154 take effect on every PR for the first time:
- **AISDLC-141 conditional reviewer fan-out** — 30-50% reduction in reviewer invocations on small PRs
- **AISDLC-142 incremental review** — 60-80% reduction on multi-push PRs
- **AISDLC-147/149/154 Anthropic budget circuit breaker** — suppresses noisy CHANGES_REQUESTED on credit exhaustion

## Test plan

- [x] `pnpm --filter @ai-sdlc/pipeline-cli build` clean
- [x] `pnpm --filter @ai-sdlc/pipeline-cli test` — 1039/1039 tests pass (64 files, including new bin-invocation.test.ts with 7 tests)
- [x] `pnpm test` (workspace) — exit 0
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [x] End-to-end manual: `node pipeline-cli/bin/cli-classify-budget.mjs --testing-stdout /tmp/empty.txt ...` returns real JSON, not the literal fallback shape
- [ ] Post-merge: verify the `Analyze PR` log on the next PR shows real classifier output (e.g. `Classifier decision: [testing] (confidence: 0.95)` instead of the all-3 fellOpen fallback)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Closes AISDLC-156