### PR TITLE
chore(spec): close AISDLC-160 — RFC-0010 sub-tasks already exist

### DIFF
--- a/backlog/completed/aisdlc-160 - Create-RFC-0010-phase-sub-tasks-AISDLC-70.1-through-70.9.md
+++ b/backlog/completed/aisdlc-160 - Create-RFC-0010-phase-sub-tasks-AISDLC-70.1-through-70.9.md
@@ -1,0 +1,79 @@
+---
+id: AISDLC-160
+title: 'Create RFC-0010 phase sub-tasks AISDLC-70.1 through 70.9'
+status: Done
+assignee: []
+created_date: '2026-05-02 22:00'
+updated_date: '2026-05-02 22:05'
+labels:
+  - meta
+  - scaffolding
+  - rfc-0010
+milestone: m-2
+dependencies: []
+references:
+  - spec/rfcs/RFC-0010-parallel-execution-worktree-pooling.md
+  - backlog/completed/aisdlc-70.1 - Phase-1-Foundations-port-allocator-worktree-ownership-schemas.md
+  - backlog/completed/aisdlc-70.2 - Phase-2-Worktree-pool-manager.md
+  - backlog/completed/aisdlc-70.3 - Phase-2.5-Per-stage-model-routing-conditional-review-fan-out.md
+  - backlog/completed/aisdlc-70.4 - Phase-2.7-Harness-adapter-framework-Codex-adapter.md
+  - backlog/completed/aisdlc-70.5 - Phase-2.8-Subscription-aware-scheduling-ledger.md
+  - backlog/completed/aisdlc-70.6 - Phase-3-Concurrency-merge-gate.md
+  - backlog/completed/aisdlc-70.7 - Phase-4-Artifacts-observability.md
+  - backlog/completed/aisdlc-70.8 - Phase-5-Hardening.md
+  - backlog/completed/aisdlc-70.9 - Phase-6-Database-isolation.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Per CLAUDE.md "Create-before-execution: when a plan spans multiple tasks, create them ALL via mcp__backlog__task_create first." This task tracks creation of the 9 sub-task files for RFC-0010 (Parallel Execution and Worktree Pooling) phases 1-6, so the dispatch frontier is populated and no team-member is blind to the parallel-execution work plan.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Sub-task files exist for AISDLC-70.1 through 70.9 with frontmatter (id, title, status, labels, milestone, dependencies, parent_task_id, priority)
+- [x] #2 Acceptance criteria for each sub-task derived from RFC-0010 §17 and corresponding implementation sections
+- [x] #3 Dependency declarations match RFC §17 table (70.2 -> 70.1, 70.3 -> 70.1, 70.4 -> 70.1, 70.5 -> 70.4, 70.6 -> 70.2, 70.7 -> 70.6, 70.8 -> 70.7, 70.9 -> 70.6)
+- [x] #4 backlog-drift check exits 0 across the new task files
+- [x] #5 AISDLC-160 itself filed under backlog/completed/ as meta-scaffolding
+<!-- AC:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+## Summary
+No-op confirmation. The 9 RFC-0010 phase sub-task files (AISDLC-70.1 through 70.9) were created in a prior sprint and have already shipped through the full lifecycle to status `Done` in `backlog/completed/`. All RFC-0010 phases 1-6 are implemented in code under `orchestrator/src/{runtime,harness,scheduling,database}/` with passing test suites. AISDLC-160 as originally scoped (create the sub-task files) is therefore a no-op; this receipt documents the discovery and closes the task without duplicating already-existing work.
+
+## Investigation
+- `backlog/completed/aisdlc-70.1` through `aisdlc-70.9` exist on `origin/main` with status `Done` and detailed final-summary blocks.
+- Git history shows real implementation commits: `feat(orchestrator): rfc-0010 phase 2 worktree pool manager` (554034a/13e3135), `feat(orchestrator): rfc-0010 phase 3 worker pool + merge gate + requeue` (6fe1b75/355a9cd), `feat(orchestrator): rfc-0010 phase 4 artifacts + observability` (93a41f1/279292e), `docs: rfc-0010 phase 5 hardening — runbook recoveries + chaos test plan` (fd28850/625661c), `feat(orchestrator): rfc-0010 phase 6 database isolation` (d44597f/4defae9).
+- `orchestrator/src/runtime/{port-allocator,worktree,worktree-pool,parallelism-flag}.ts`, `orchestrator/src/harness/{registry,independence,version-probe,adapters/}`, `orchestrator/src/scheduling/{ledger,burn-down,off-peak,schedule-decision,calibration}.ts`, `orchestrator/src/database/{registry,topology,connection-injection,types,adapters/}.ts` are all present in the tree.
+- The dispatch frontier (`node pipeline-cli/bin/cli-deps.mjs frontier`) shows AISDLC-70 (the parent) directly as ready — no child blockers.
+
+## Outstanding follow-up
+The parent task `backlog/tasks/aisdlc-70 - RFC-0010-Parallel-Execution-and-Worktree-Pooling.md` is still status `To Do` with unchecked acceptance criteria, despite all 9 children being Done. A separate task (or a small chore) should:
+1. Check off the four parent ACs (sub-tasks done; AI_SDLC_PARALLELISM promoted; dogfood pipeline migrated; runbook extended).
+2. Move AISDLC-70 to `backlog/completed/` once the four ACs are genuinely satisfied. ACs #2-#4 may not yet be true (parallelism flag default-on / runbook extension); those need verification before flipping the parent.
+
+This receipt deliberately does NOT modify AISDLC-70, since updating its status is out of scope and AC #2-#4 verification needs operator judgement.
+
+## Why no duplicate sub-task files were created
+Creating new `backlog/tasks/aisdlc-70.N - ...md` entries for sub-tasks already in `backlog/completed/` would:
+- Pollute the open backlog with To-Do entries for shipped work.
+- Cause the dispatch frontier to point developers at code that's already implemented.
+- Conflict with the `id: AISDLC-70.N` uniqueness expectation across the backlog tree.
+- Waste reviewer cycles and erode trust in the backlog as ground truth.
+
+The correct read of the original task description (which assumed sub-task files didn't exist) is: it was filed before the prior sprint's completion was visible, and the work is now done.
+
+## Verification
+- `ls backlog/completed/ | grep aisdlc-70.` -> 9 files (70.1 through 70.9)
+- `ls backlog/tasks/ | grep aisdlc-70` -> 1 file (parent only)
+- `git ls-tree origin/main backlog/completed/ | grep '70\.' ` -> all 9 files present on main
+- `node pipeline-cli/bin/cli-deps.mjs frontier --format table --work-dir .` -> AISDLC-70 listed as ready (no sub-task blockers)
+
+## Follow-up
+- Operator: validate AISDLC-70 parent ACs #2/#3/#4 (parallelism default-on; dogfood migration; runbook extension) and flip AISDLC-70 to Done if satisfied.
+<!-- SECTION:FINAL_SUMMARY:END -->


### PR DESCRIPTION
## Summary

- AISDLC-160 asked to create the 9 RFC-0010 phase sub-tasks (AISDLC-70.1 through 70.9) so the dispatch frontier can pull from a populated queue.
- Investigation found those sub-task files already exist in `backlog/completed/` with status `Done`, and RFC-0010 phases 1-6 are implemented in `orchestrator/src/{runtime,harness,scheduling,database}/` with passing tests.
- This PR ships only the AISDLC-160 receipt under `backlog/completed/`, documenting the no-op and listing the verified-existing sub-tasks. No duplicate task files were created.

## Why no sub-task files were added

Creating new `backlog/tasks/aisdlc-70.N - ...md` entries for sub-tasks already in `backlog/completed/` would:
- Pollute the open backlog with To-Do entries for shipped work
- Cause the dispatch frontier to point developers at code that's already implemented
- Conflict with the `id: AISDLC-70.N` uniqueness expectation across the backlog tree

## Outstanding follow-up (not in this PR)

The parent task `backlog/tasks/aisdlc-70 - RFC-0010-Parallel-Execution-and-Worktree-Pooling.md` is still status `To Do` with unchecked acceptance criteria, despite all 9 children being Done. A separate task should:
1. Verify parent ACs #2 (`AI_SDLC_PARALLELISM` default-on), #3 (dogfood pipeline migrated to parallel execution), and #4 (operator runbook extended with new failure modes).
2. Move AISDLC-70 to `backlog/completed/` once those ACs are genuinely satisfied.

## Test plan

- [x] `npx backlog-drift@0.1.3 check --task AISDLC-160` exits 0
- [x] `bash scripts/check-backlog-ascii.sh` exits 0 (filename ASCII)
- [x] `node pipeline-cli/bin/cli-deps.mjs frontier --format table --work-dir .` lists AISDLC-70 (parent) as ready; no incomplete sub-task blockers
- [x] `pnpm build` clean (workspace-wide)

## Related

- Parent: AISDLC-70 (`backlog/tasks/aisdlc-70 - RFC-0010-Parallel-Execution-and-Worktree-Pooling.md`)
- Sub-tasks (already Done): `backlog/completed/aisdlc-70.{1..9} - ...md`
- RFC: `spec/rfcs/RFC-0010-parallel-execution-worktree-pooling.md`

Generated with [Claude Code](https://claude.com/claude-code)