### PR TITLE
feat(dashboard): DoR calibration page (AISDLC-162)

### DIFF
--- a/backlog/completed/aisdlc-162 - DoR-calibration-page-on-the-operator-dashboard.md
+++ b/backlog/completed/aisdlc-162 - DoR-calibration-page-on-the-operator-dashboard.md
@@ -1,0 +1,181 @@
+---
+id: AISDLC-162
+title: 'DoR calibration page on the operator dashboard'
+status: Done
+assignee: []
+created_date: '2026-05-02'
+labels:
+  - dashboard
+  - dor
+  - observability
+  - rfc-0011
+milestone: m-3
+dependencies:
+  - AISDLC-161
+references:
+  - backlog/completed/aisdlc-161 - Wire-up-DoR-calibration-data-collection-in-CI-and-enable-hybrid-Phase-8-promotion-path.md
+  - backlog/tasks/aisdlc-115 - RFC-0011-Definition-of-Ready-Gate-for-Pipeline-Admission.md
+  - pipeline-cli/src/cli/dor-corpus.ts
+  - docs/operations/dor-promotion.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Closes AISDLC-115 parent AC #5: "DoR calibration log feeds metrics
+dashboard."
+
+AISDLC-161 shipped the `cli-dor-corpus aggregate` aggregator that reads
+N downloaded `_dor/calibration.jsonl` artifacts and produces a per-gate
+FP-rate report + recommendation envelope (`safe-to-enforce` /
+`continue-soak` / `insufficient-data`). What was missing: an operator
+view inside the existing `dashboard/` Next.js app so the same data is
+visible in the UI alongside Cost / Autonomy / Audit, not only via a
+manual `gh run download` + CLI invocation.
+
+This task adds the `/dor` page. The page reuses the **same** aggregator
+code path the CLI uses (no second implementation) by exposing
+`pipeline-cli/src/cli/dor-corpus.ts` via a new `./dor-corpus` package
+export and wiring `@ai-sdlc/pipeline-cli` as a workspace dep of
+`dashboard`. Source-of-truth resolution: `DOR_CORPUS_DIR` env var →
+`<cwd>/artifacts/_dor` fallback. When the directory is absent, the
+page renders an operator hint pointing at
+`docs/operations/dor-promotion.md`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 New dashboard page at `dashboard/src/app/dor/page.tsx` (Next.js App Router convention) registered as `/dor`
+- [x] #2 Page renders per-gate breakdown (gate id, N, overrides, FP rate, override rate) + aggregate recommendation badge (safe-to-enforce green / continue-soak yellow / insufficient-data gray) + collapsible last-N raw entries table for operator spot-checking
+- [x] #3 Data source reuses the AISDLC-161 aggregator (`aggregateCorpus` / `findCalibrationFiles` / `loadCorpus`) via the new `@ai-sdlc/pipeline-cli/dor-corpus` workspace export — single source of truth, no duplicated FP-rate math
+- [x] #4 Navigation link added to `coreNavItems` in `dashboard/src/lib/nav-items.ts` so the page is reachable from the existing layout sidebar
+- [x] #5 Hermetic test coverage: empty / missing corpus dir, single-file aggregation, continue-soak path with worst-offender gate, freshest-entries-first ordering, multi-file gh-run-download layout, malformed-line skip counter
+- [x] #6 Pre-flight passes: `pnpm --filter dashboard build && test` + repo-wide `pnpm lint && pnpm format:check`
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add `./dor-corpus` export to `pipeline-cli/package.json` and
+   re-export `CalibrationEntry` from `pipeline-cli/src/cli/dor-corpus.ts`
+   so the dashboard can import the aggregator + the entry shape from
+   one path.
+2. Add `@ai-sdlc/pipeline-cli` as a workspace dep of `dashboard`.
+3. Create `dashboard/src/lib/dor-data.ts` — wraps the aggregator with
+   source-of-truth resolution (`DOR_CORPUS_DIR` env → `cwd/artifacts/_dor`
+   default) and returns the corpus report + freshest-N entries for the
+   page.
+4. Create `dashboard/src/components/cards/recommendation-badge.tsx` —
+   reusable color-coded badge for the three recommendation states.
+5. Create `dashboard/src/app/dor/page.tsx` — header, stat cards,
+   aggregate section with badge + reason + worst-offender, per-gate
+   table, collapsible recent-entries table.
+6. Wire `/dor` into `coreNavItems`.
+7. Tests: `dor-data.test.ts`, `dor/page.test.tsx`,
+   `recommendation-badge.test.tsx`; update `nav-items.test.ts`.
+8. Pre-flight + commit.
+<!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:SUMMARY:BEGIN -->
+## Summary
+
+Shipped the operator-facing `/dor` page on the Next.js dashboard so
+AISDLC-161's aggregator output is visible in the UI alongside the
+existing Cost / Autonomy / Audit pages. The page reads the corpus from
+`DOR_CORPUS_DIR` (or `<cwd>/artifacts/_dor` by default) and reuses the
+exact same `aggregateCorpus` / `findCalibrationFiles` / `loadCorpus`
+functions the CLI uses by importing from a new
+`@ai-sdlc/pipeline-cli/dor-corpus` workspace export — no duplicated
+FP-rate math. Closes AISDLC-115 parent AC #5.
+
+## Changes
+
+- `pipeline-cli/package.json` (modified): added `./dor-corpus` export
+  pointing at the compiled `dist/cli/dor-corpus.js` so external
+  consumers can import the aggregator without going through the CLI
+  shim.
+- `pipeline-cli/src/cli/dor-corpus.ts` (modified): re-export
+  `CalibrationEntry` so consumers get aggregator + entry shape from one
+  import path.
+- `dashboard/package.json` (modified): added `@ai-sdlc/pipeline-cli`
+  workspace dep.
+- `dashboard/src/lib/dor-data.ts` (new): `loadDorData()` wrapper +
+  `resolveCorpusRoot()` helper. Returns `null` when the dir is absent
+  so the page renders a setup hint instead of a stack trace; otherwise
+  returns `{ corpusRoot, report, recentEntries }`.
+- `dashboard/src/lib/dor-data.test.ts` (new): hermetic coverage —
+  resolution order, null path, empty dir, single-file, continue-soak
+  worst-offender, freshest-first ordering, recentLimit cap, multi-file
+  gh-run-download layout, malformed-line skip counter.
+- `dashboard/src/components/cards/recommendation-badge.tsx` (new):
+  reusable color-coded badge (green / yellow / gray).
+- `dashboard/src/components/cards/recommendation-badge.test.tsx`
+  (new): all three variants + n-suffix render.
+- `dashboard/src/app/dor/page.tsx` (new): the page itself —
+  empty-state hint, stat cards, aggregate-recommendation block,
+  per-gate breakdown table (FP rate ≥ 10% highlighted red), collapsible
+  recent-entries table.
+- `dashboard/src/app/dor/page.test.tsx` (new): mocked `loadDorData`,
+  exercises empty / safe-to-enforce / continue-soak / insufficient-data
+  paths.
+- `dashboard/src/lib/nav-items.ts` (modified): registered
+  `{ href: '/dor', label: 'DoR Calibration' }`.
+- `dashboard/src/lib/nav-items.test.ts` (modified): asserts the
+  6th nav item exists and routes to `/dor`.
+
+## Design decisions
+
+- **Reuse the aggregator, not re-implement** — the dashboard imports
+  `aggregateCorpus` from `@ai-sdlc/pipeline-cli/dor-corpus` rather than
+  shelling out to the CLI or duplicating the FP-rate math. Single
+  source of truth: when AISDLC-115.8 tunes thresholds in the
+  aggregator, the dashboard inherits the change with no porting work.
+- **Workspace export over child_process** — exposing `dor-corpus` as a
+  package subpath keeps the dashboard pure server-side TypeScript
+  (no spawn, no JSON-parsing of stdout, no path-to-CLI resolution).
+  Trade-off: the dashboard now requires `pipeline-cli` to be built
+  (`dist/cli/dor-corpus.js`); this is already true for any workspace
+  consumer of pipeline-cli's TS exports and is enforced by the CI's
+  `pnpm build` step.
+- **`null` return for missing corpus dir, not synthesised empty
+  report** — distinguishes "operator hasn't set up corpus" (render the
+  `gh run download` hint) from "directory exists but no entries yet"
+  (render the natural insufficient-data badge). The empty-aggregate
+  shape is reachable via the second path; the null short-circuit only
+  fires when the dir is truly absent.
+- **`DOR_CORPUS_DIR` env var** — the conventional pattern across the
+  pipeline (`ARTIFACTS_DIR`, `AI_SDLC_DB_PATH`). Operators can point
+  the dashboard at a `gh run download --pattern dor-calibration-*`
+  output without touching the dashboard's start command.
+- **Recommendation badge as a separate component** — the same color
+  semantics (green/yellow/gray) will appear in the planned RFC-0011
+  Phase 5 Slack digest and any future cron summary; extracting now
+  beats refactoring later.
+
+## Verification
+
+- `pnpm --filter @ai-sdlc/pipeline-cli build` — clean
+- `pnpm --filter @ai-sdlc/pipeline-cli test` — 1091 tests passing
+  (no aggregator regressions from the `CalibrationEntry` re-export)
+- `pnpm --filter dashboard build` — clean (Next.js 15, `/dor` route
+  built as dynamic server-rendered)
+- `pnpm --filter dashboard test` — 148 tests passing (12 new
+  dor-data tests, 5 new badge tests, 4 new page tests, 1 updated
+  nav-items test)
+- `pnpm lint` — clean
+- `pnpm format:check` — clean
+
+## Follow-up
+
+- Plumb the recommendation envelope into the planned RFC-0011 Phase 5
+  Slack digest so the operator gets notified when
+  `safe-to-enforce` is reached without having to refresh the dashboard
+- Optional GET `/api/dor` JSON route mirroring the page so external
+  monitors can poll the recommendation envelope (currently only the
+  page surfaces it)
+- AISDLC-115.9 owner now has a UI surface to confirm the
+  `safe-to-enforce` recommendation before flipping `evaluationMode`
+<!-- SECTION:SUMMARY:END -->

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@ai-sdlc/orchestrator": "workspace:*",
+    "@ai-sdlc/pipeline-cli": "workspace:*",
     "better-sqlite3": "^11.0.0",
     "next": "^15.0.0",
     "react": "^19.0.0",

--- a/dashboard/src/app/dor/page.test.tsx
+++ b/dashboard/src/app/dor/page.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CalibrationEntry, CorpusReport } from '@ai-sdlc/pipeline-cli/dor-corpus';
+
+const mockLoad = vi.fn();
+
+vi.mock('@/lib/dor-data', () => ({
+  loadDorData: () => mockLoad(),
+}));
+
+vi.mock('@/components/layout/header', () => ({
+  Header: ({ title, subtitle }: { title: string; subtitle?: string }) => ({
+    type: 'mock-header',
+    props: { title, subtitle },
+  }),
+}));
+
+vi.mock('@/components/cards/stat-card', () => ({
+  StatCard: (props: Record<string, unknown>) => ({
+    type: 'mock-stat-card',
+    props,
+  }),
+}));
+
+vi.mock('@/components/cards/recommendation-badge', () => ({
+  RecommendationBadge: (props: Record<string, unknown>) => ({
+    type: 'mock-recommendation-badge',
+    props,
+  }),
+}));
+
+function makeReport(overrides: Partial<CorpusReport['aggregate']> = {}): CorpusReport {
+  return {
+    perGate: [],
+    aggregate: {
+      n: 0,
+      meanFpRate: 0,
+      overrideRate: 0,
+      worstGate: null,
+      recommendation: 'insufficient-data',
+      reason: 'no data',
+      skipped: 0,
+      filesRead: 0,
+      ...overrides,
+    },
+  };
+}
+
+function makeEntry(overrides: Partial<CalibrationEntry> = {}): CalibrationEntry {
+  return {
+    ts: '2026-05-01T00:00:00.000Z',
+    issueId: 'AISDLC-test',
+    rubricVersion: 'v1',
+    evaluatorVersion: 'test',
+    overallVerdict: 'admit',
+    failedGates: [],
+    outcome: '',
+    verdict: {
+      issueId: 'AISDLC-test',
+      rubricVersion: 'v1',
+      overallVerdict: 'admit',
+      gates: [],
+      signedAt: '2026-05-01T00:00:00.000Z',
+      evaluatorVersion: 'test',
+      summary: '',
+      questions: [],
+    },
+    ...overrides,
+  };
+}
+
+describe('DorPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the empty-state hint when no corpus is found', async () => {
+    mockLoad.mockReturnValueOnce(null);
+    const { default: DorPage } = await import('./page');
+    const result = DorPage();
+    expect(result).toBeTruthy();
+    expect(result.type).toBe('div');
+  });
+
+  it('renders the safe-to-enforce path with per-gate data', async () => {
+    mockLoad.mockReturnValueOnce({
+      corpusRoot: '/tmp/dor',
+      report: {
+        perGate: [
+          { gate: 1, n: 100, overrides: 5, fpRate: 0.05, overrideRate: 0.05 },
+          { gate: 3, n: 200, overrides: 18, fpRate: 0.09, overrideRate: 0.09 },
+        ],
+        aggregate: {
+          n: 1000,
+          meanFpRate: 0.07,
+          overrideRate: 0.018,
+          worstGate: { gate: 3, fpRate: 0.09 },
+          recommendation: 'safe-to-enforce',
+          reason: 'all clear',
+          skipped: 0,
+          filesRead: 5,
+        },
+      },
+      recentEntries: [
+        makeEntry({ issueId: 'AISDLC-1', outcome: 'admit' }),
+        makeEntry({ issueId: 'AISDLC-2', outcome: 'override', failedGates: [3] }),
+      ],
+    });
+    const { default: DorPage } = await import('./page');
+    const result = DorPage();
+    expect(result).toBeTruthy();
+  });
+
+  it('renders the continue-soak path with a worst-offender gate', async () => {
+    mockLoad.mockReturnValueOnce({
+      corpusRoot: '/tmp/dor',
+      report: makeReport({
+        n: 60,
+        meanFpRate: 0.5,
+        overrideRate: 0.16,
+        worstGate: { gate: 2, fpRate: 0.5 },
+        recommendation: 'continue-soak',
+        reason: 'gate-2 fpRate=50% exceeds threshold=10%',
+        filesRead: 1,
+      }),
+      recentEntries: [makeEntry()],
+    });
+    const { default: DorPage } = await import('./page');
+    const result = DorPage();
+    expect(result).toBeTruthy();
+  });
+
+  it('renders insufficient-data with empty perGate + entries', async () => {
+    mockLoad.mockReturnValueOnce({
+      corpusRoot: '/tmp/dor',
+      report: makeReport({ filesRead: 0 }),
+      recentEntries: [],
+    });
+    const { default: DorPage } = await import('./page');
+    const result = DorPage();
+    expect(result).toBeTruthy();
+  });
+});

--- a/dashboard/src/app/dor/page.tsx
+++ b/dashboard/src/app/dor/page.tsx
@@ -1,0 +1,218 @@
+/**
+ * DoR calibration page (AISDLC-162) — closes AISDLC-115 AC #5
+ * "DoR calibration log feeds metrics dashboard."
+ *
+ * Reads the corpus of `_dor/calibration.jsonl` files via
+ * `loadDorData()` (which wraps the AISDLC-161 `cli-dor-corpus`
+ * aggregator) and renders:
+ *
+ *   - Aggregate recommendation badge (safe-to-enforce / continue-soak /
+ *     insufficient-data) — drives the AISDLC-115.9 promotion decision
+ *   - Per-gate breakdown table (gate id, n, overrides, FP rate)
+ *   - Last-N raw entries for operator spot-checking (collapsed `<details>`
+ *     so the page stays scannable when the corpus is large)
+ *
+ * Data source defaults to `<cwd>/artifacts/_dor` (the conventional
+ * local calibration log path); the operator can point at a different
+ * directory via the `DOR_CORPUS_DIR` env var (e.g. a `gh run download`
+ * output of `dor-calibration-*` workflow artifacts). See
+ * `docs/operations/dor-promotion.md`.
+ */
+
+export const dynamic = 'force-dynamic';
+
+import { Header } from '@/components/layout/header';
+import { StatCard } from '@/components/cards/stat-card';
+import { RecommendationBadge, type Recommendation } from '@/components/cards/recommendation-badge';
+import { loadDorData } from '@/lib/dor-data';
+
+export default function DorPage() {
+  const data = loadDorData();
+
+  if (data === null) {
+    return (
+      <div>
+        <Header
+          title="DoR Calibration"
+          subtitle="Definition-of-Ready false-positive rate + promotion readiness"
+        />
+        <section
+          style={{
+            padding: 16,
+            border: '1px dashed #cbd5e1',
+            borderRadius: 8,
+            color: '#475569',
+            fontSize: 14,
+          }}
+        >
+          <p style={{ margin: 0, marginBottom: 8 }}>
+            <strong>No DoR calibration corpus found.</strong>
+          </p>
+          <p style={{ margin: 0 }}>
+            Set <code>DOR_CORPUS_DIR</code> to a directory containing one or more{' '}
+            <code>calibration.jsonl</code> files (see{' '}
+            <a href="https://github.com/ai-sdlc-framework/ai-sdlc/blob/main/docs/operations/dor-promotion.md">
+              <code>docs/operations/dor-promotion.md</code>
+            </a>{' '}
+            for the <code>gh run download</code> recipe), or run the local pipeline so{' '}
+            <code>artifacts/_dor/calibration.jsonl</code> exists.
+          </p>
+        </section>
+      </div>
+    );
+  }
+
+  const { corpusRoot, report, recentEntries } = data;
+  const a = report.aggregate;
+  const recommendation = a.recommendation as Recommendation;
+
+  const recommendationColor =
+    recommendation === 'safe-to-enforce'
+      ? '#16a34a'
+      : recommendation === 'continue-soak'
+        ? '#d97706'
+        : '#64748b';
+
+  return (
+    <div>
+      <Header
+        title="DoR Calibration"
+        subtitle="Definition-of-Ready false-positive rate + promotion readiness"
+      />
+
+      <div style={{ display: 'flex', gap: 16, marginBottom: 24, flexWrap: 'wrap' }}>
+        <StatCard label="Recommendation" value={recommendation} color={recommendationColor} />
+        <StatCard label="Corpus N" value={a.n} />
+        <StatCard label="Files Read" value={a.filesRead} />
+        <StatCard label="Mean FP Rate" value={`${(a.meanFpRate * 100).toFixed(1)}%`} />
+        <StatCard label="Override Rate" value={`${(a.overrideRate * 100).toFixed(1)}%`} />
+        <StatCard label="Skipped" value={a.skipped} />
+      </div>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 8 }}>Aggregate</h2>
+        <div
+          style={{
+            padding: 16,
+            border: '1px solid #e2e8f0',
+            borderRadius: 8,
+            display: 'flex',
+            gap: 16,
+            alignItems: 'center',
+            flexWrap: 'wrap',
+          }}
+        >
+          <RecommendationBadge recommendation={recommendation} n={a.n} />
+          <div style={{ fontSize: 13, color: '#475569' }}>{a.reason}</div>
+          {a.worstGate && (
+            <div style={{ fontSize: 12, color: '#94a3b8' }}>
+              worst gate: gate-{a.worstGate.gate} ({(a.worstGate.fpRate * 100).toFixed(1)}%)
+            </div>
+          )}
+        </div>
+        <p style={{ fontSize: 12, color: '#94a3b8', marginTop: 4 }}>
+          Source: <code>{corpusRoot}</code>
+        </p>
+      </section>
+
+      <section style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, marginBottom: 12 }}>Per-gate breakdown</h2>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+          <thead>
+            <tr style={{ borderBottom: '1px solid #e2e8f0' }}>
+              <th style={{ textAlign: 'left', padding: 8 }}>Gate</th>
+              <th style={{ textAlign: 'right', padding: 8 }}>N</th>
+              <th style={{ textAlign: 'right', padding: 8 }}>Overrides</th>
+              <th style={{ textAlign: 'right', padding: 8 }}>FP Rate</th>
+              <th style={{ textAlign: 'right', padding: 8 }}>Override Rate</th>
+            </tr>
+          </thead>
+          <tbody>
+            {report.perGate.length === 0 ? (
+              <tr>
+                <td colSpan={5} style={{ padding: 24, textAlign: 'center', color: '#94a3b8' }}>
+                  No gates have fired yet — every entry passed Stage A cleanly.
+                </td>
+              </tr>
+            ) : (
+              report.perGate.map((g) => {
+                const fpColor = g.fpRate >= 0.1 ? '#dc2626' : '#0f172a';
+                return (
+                  <tr key={g.gate} style={{ borderBottom: '1px solid #f1f5f9' }}>
+                    <td style={{ padding: 8 }}>gate-{g.gate}</td>
+                    <td style={{ textAlign: 'right', padding: 8 }}>{g.n}</td>
+                    <td style={{ textAlign: 'right', padding: 8 }}>{g.overrides}</td>
+                    <td style={{ textAlign: 'right', padding: 8, color: fpColor }}>
+                      {(g.fpRate * 100).toFixed(1)}%
+                    </td>
+                    <td style={{ textAlign: 'right', padding: 8 }}>
+                      {(g.overrideRate * 100).toFixed(1)}%
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <details>
+          <summary
+            style={{
+              cursor: 'pointer',
+              fontSize: 16,
+              fontWeight: 600,
+              marginBottom: 12,
+              color: '#0f172a',
+            }}
+          >
+            Recent entries ({recentEntries.length})
+          </summary>
+          <table
+            style={{
+              width: '100%',
+              borderCollapse: 'collapse',
+              fontSize: 12,
+              marginTop: 12,
+            }}
+          >
+            <thead>
+              <tr style={{ borderBottom: '1px solid #e2e8f0' }}>
+                <th style={{ textAlign: 'left', padding: 6 }}>Timestamp</th>
+                <th style={{ textAlign: 'left', padding: 6 }}>Issue</th>
+                <th style={{ textAlign: 'left', padding: 6 }}>Verdict</th>
+                <th style={{ textAlign: 'left', padding: 6 }}>Outcome</th>
+                <th style={{ textAlign: 'left', padding: 6 }}>Failed Gates</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recentEntries.length === 0 ? (
+                <tr>
+                  <td colSpan={5} style={{ padding: 24, textAlign: 'center', color: '#94a3b8' }}>
+                    No calibration entries yet.
+                  </td>
+                </tr>
+              ) : (
+                recentEntries.map((e, idx) => (
+                  <tr
+                    key={`${e.ts}-${e.issueId}-${idx}`}
+                    style={{ borderBottom: '1px solid #f1f5f9' }}
+                  >
+                    <td style={{ padding: 6, fontFamily: 'monospace' }}>{e.ts}</td>
+                    <td style={{ padding: 6 }}>{e.issueId}</td>
+                    <td style={{ padding: 6 }}>{e.overallVerdict}</td>
+                    <td style={{ padding: 6 }}>{e.outcome || '(live)'}</td>
+                    <td style={{ padding: 6, fontFamily: 'monospace' }}>
+                      {e.failedGates.length === 0 ? '—' : e.failedGates.join(', ')}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </details>
+      </section>
+    </div>
+  );
+}

--- a/dashboard/src/components/cards/recommendation-badge.test.tsx
+++ b/dashboard/src/components/cards/recommendation-badge.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { RecommendationBadge } from './recommendation-badge';
+
+describe('RecommendationBadge', () => {
+  it('renders the safe-to-enforce variant', () => {
+    const result = RecommendationBadge({ recommendation: 'safe-to-enforce' });
+    expect(result).toBeTruthy();
+    expect(result.props.children[0]).toBe('safe to enforce');
+  });
+
+  it('renders the continue-soak variant', () => {
+    const result = RecommendationBadge({ recommendation: 'continue-soak' });
+    expect(result).toBeTruthy();
+    expect(result.props.children[0]).toBe('continue soak');
+  });
+
+  it('renders the insufficient-data variant', () => {
+    const result = RecommendationBadge({ recommendation: 'insufficient-data' });
+    expect(result).toBeTruthy();
+    expect(result.props.children[0]).toBe('insufficient data');
+  });
+
+  it('appends the n=count when provided', () => {
+    const result = RecommendationBadge({ recommendation: 'safe-to-enforce', n: 42 });
+    expect(result.props.children[1]).toBe(' · n=42');
+  });
+
+  it('omits n when not provided', () => {
+    const result = RecommendationBadge({ recommendation: 'continue-soak' });
+    expect(result.props.children[1]).toBe('');
+  });
+});

--- a/dashboard/src/components/cards/recommendation-badge.tsx
+++ b/dashboard/src/components/cards/recommendation-badge.tsx
@@ -1,0 +1,45 @@
+/**
+ * Recommendation badge for the DoR calibration page (AISDLC-162).
+ *
+ * Color semantics match the operator runbook in
+ * `docs/operations/dor-promotion.md`:
+ *   - safe-to-enforce  → green  (dispatch AISDLC-115.9)
+ *   - continue-soak    → yellow (keep gathering data)
+ *   - insufficient-data → gray  (operator may use override path)
+ */
+
+export type Recommendation = 'insufficient-data' | 'safe-to-enforce' | 'continue-soak';
+
+interface RecommendationBadgeProps {
+  recommendation: Recommendation;
+  /** Optional sample count surfaced inline (e.g. "n=42"). */
+  n?: number;
+}
+
+const STYLES: Record<Recommendation, { bg: string; fg: string; label: string }> = {
+  'safe-to-enforce': { bg: '#dcfce7', fg: '#166534', label: 'safe to enforce' },
+  'continue-soak': { bg: '#fef9c3', fg: '#854d0e', label: 'continue soak' },
+  'insufficient-data': { bg: '#f1f5f9', fg: '#475569', label: 'insufficient data' },
+};
+
+export function RecommendationBadge({ recommendation, n }: RecommendationBadgeProps) {
+  const { bg, fg, label } = STYLES[recommendation];
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '2px 8px',
+        borderRadius: 4,
+        backgroundColor: bg,
+        color: fg,
+        fontSize: 12,
+        fontWeight: 600,
+        textTransform: 'lowercase',
+        letterSpacing: '0.02em',
+      }}
+    >
+      {label}
+      {typeof n === 'number' ? ` · n=${n}` : ''}
+    </span>
+  );
+}

--- a/dashboard/src/lib/dor-data.test.ts
+++ b/dashboard/src/lib/dor-data.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for the DoR calibration loader (AISDLC-162).
+ *
+ * Hermetic — every test seeds a tmpdir of fixture JSONL files and
+ * drives `loadDorData()` end to end (the same pattern used by the
+ * `cli-dor-corpus` aggregator's own tests in
+ * `pipeline-cli/src/cli/dor-corpus.test.ts`).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CalibrationEntry } from '@ai-sdlc/pipeline-cli/dor-corpus';
+import { loadDorData, resolveCorpusRoot } from './dor-data';
+
+let tmp: string;
+let savedEnv: string | undefined;
+let savedCwd: typeof process.cwd;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'dor-dashboard-'));
+  savedEnv = process.env.DOR_CORPUS_DIR;
+  savedCwd = process.cwd;
+  delete process.env.DOR_CORPUS_DIR;
+});
+
+afterEach(() => {
+  process.cwd = savedCwd;
+  if (savedEnv === undefined) delete process.env.DOR_CORPUS_DIR;
+  else process.env.DOR_CORPUS_DIR = savedEnv;
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+});
+
+function entry(opts: {
+  ts?: string;
+  issueId?: string;
+  failedGates?: number[];
+  outcome?: 'admit' | 'needs-clarification' | 'override' | '';
+  overallVerdict?: 'admit' | 'needs-clarification';
+}): CalibrationEntry {
+  return {
+    ts: opts.ts ?? '2026-05-01T00:00:00.000Z',
+    issueId: opts.issueId ?? 'AISDLC-test',
+    rubricVersion: 'v1',
+    evaluatorVersion: 'test',
+    overallVerdict: opts.overallVerdict ?? 'admit',
+    failedGates: opts.failedGates ?? [],
+    outcome: opts.outcome ?? '',
+    verdict: {
+      issueId: opts.issueId ?? 'AISDLC-test',
+      rubricVersion: 'v1',
+      overallVerdict: opts.overallVerdict ?? 'admit',
+      gates: [],
+      signedAt: opts.ts ?? '2026-05-01T00:00:00.000Z',
+      evaluatorVersion: 'test',
+      summary: '',
+      questions: [],
+    },
+  };
+}
+
+function writeJsonl(name: string, entries: unknown[]): string {
+  const path = join(tmp, name);
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, entries.map((e) => JSON.stringify(e)).join('\n') + '\n', 'utf8');
+  return path;
+}
+
+describe('resolveCorpusRoot', () => {
+  it('honors explicit corpusRoot first', () => {
+    process.env.DOR_CORPUS_DIR = '/env/path';
+    expect(resolveCorpusRoot({ corpusRoot: '/explicit' })).toBe('/explicit');
+  });
+
+  it('falls back to DOR_CORPUS_DIR env var', () => {
+    process.env.DOR_CORPUS_DIR = '/env/path';
+    expect(resolveCorpusRoot()).toBe('/env/path');
+  });
+
+  it('treats empty DOR_CORPUS_DIR as unset', () => {
+    process.env.DOR_CORPUS_DIR = '';
+    const root = resolveCorpusRoot();
+    expect(root.endsWith(join('artifacts', '_dor'))).toBe(true);
+  });
+
+  it('defaults to <cwd>/artifacts/_dor', () => {
+    const root = resolveCorpusRoot();
+    expect(root).toBe(join(process.cwd(), 'artifacts', '_dor'));
+  });
+});
+
+describe('loadDorData', () => {
+  it('returns null when the corpus root does not exist', () => {
+    const result = loadDorData({ corpusRoot: join(tmp, 'does-not-exist') });
+    expect(result).toBeNull();
+  });
+
+  it('returns insufficient-data report when directory is empty', () => {
+    const result = loadDorData({ corpusRoot: tmp });
+    expect(result).not.toBeNull();
+    expect(result!.report.aggregate.recommendation).toBe('insufficient-data');
+    expect(result!.report.aggregate.n).toBe(0);
+    expect(result!.report.aggregate.filesRead).toBe(0);
+    expect(result!.recentEntries).toEqual([]);
+  });
+
+  it('aggregates a single jsonl file', () => {
+    writeJsonl('calibration.jsonl', [
+      entry({ issueId: 'A', outcome: 'admit' }),
+      entry({ issueId: 'B', outcome: 'admit' }),
+    ]);
+    const result = loadDorData({ corpusRoot: tmp, minSamples: 1 });
+    expect(result).not.toBeNull();
+    expect(result!.report.aggregate.n).toBe(2);
+    expect(result!.report.aggregate.recommendation).toBe('safe-to-enforce');
+    expect(result!.report.aggregate.filesRead).toBe(1);
+  });
+
+  it('flags continue-soak when a gate exceeds fpThreshold', () => {
+    const entries: CalibrationEntry[] = [];
+    for (let i = 0; i < 10; i++)
+      entries.push(
+        entry({
+          issueId: `nc-${i}`,
+          outcome: 'needs-clarification',
+          overallVerdict: 'needs-clarification',
+          failedGates: [3],
+        }),
+      );
+    for (let i = 0; i < 10; i++)
+      entries.push(
+        entry({
+          issueId: `ovr-${i}`,
+          outcome: 'override',
+          overallVerdict: 'needs-clarification',
+          failedGates: [3],
+        }),
+      );
+    writeJsonl('calibration.jsonl', entries);
+    const result = loadDorData({ corpusRoot: tmp, minSamples: 5 });
+    expect(result).not.toBeNull();
+    expect(result!.report.aggregate.recommendation).toBe('continue-soak');
+    expect(result!.report.aggregate.worstGate).toEqual({ gate: 3, fpRate: 0.5 });
+  });
+
+  it('returns the freshest entries first via recentEntries', () => {
+    writeJsonl('calibration.jsonl', [
+      entry({ ts: '2026-04-01T00:00:00.000Z', issueId: 'old' }),
+      entry({ ts: '2026-05-01T00:00:00.000Z', issueId: 'new' }),
+      entry({ ts: '2026-04-15T00:00:00.000Z', issueId: 'mid' }),
+    ]);
+    const result = loadDorData({ corpusRoot: tmp, minSamples: 1, recentLimit: 10 });
+    expect(result).not.toBeNull();
+    expect(result!.recentEntries.map((e) => e.issueId)).toEqual(['new', 'mid', 'old']);
+  });
+
+  it('caps recentEntries at recentLimit', () => {
+    const entries = Array.from({ length: 10 }, (_, i) =>
+      entry({
+        ts: `2026-05-${String(i + 1).padStart(2, '0')}T00:00:00.000Z`,
+        issueId: `e-${i}`,
+      }),
+    );
+    writeJsonl('calibration.jsonl', entries);
+    const result = loadDorData({ corpusRoot: tmp, minSamples: 1, recentLimit: 3 });
+    expect(result!.recentEntries).toHaveLength(3);
+    // Freshest are e-9, e-8, e-7
+    expect(result!.recentEntries.map((e) => e.issueId)).toEqual(['e-9', 'e-8', 'e-7']);
+  });
+
+  it('glues together a multi-file gh-run-download layout', () => {
+    // Simulate the `gh run download --pattern dor-calibration-*` shape:
+    // one directory per workflow artifact, each containing a single
+    // calibration.jsonl.
+    mkdirSync(join(tmp, 'dor-calibration-issue-1-A'));
+    mkdirSync(join(tmp, 'dor-calibration-issue-2-A'));
+    writeFileSync(
+      join(tmp, 'dor-calibration-issue-1-A', 'calibration.jsonl'),
+      JSON.stringify(entry({ issueId: 'one', outcome: 'admit' })) + '\n',
+      'utf8',
+    );
+    writeFileSync(
+      join(tmp, 'dor-calibration-issue-2-A', 'calibration.jsonl'),
+      JSON.stringify(entry({ issueId: 'two', outcome: 'admit' })) + '\n',
+      'utf8',
+    );
+    const result = loadDorData({ corpusRoot: tmp, minSamples: 1 });
+    expect(result).not.toBeNull();
+    expect(result!.report.aggregate.n).toBe(2);
+    expect(result!.report.aggregate.filesRead).toBe(2);
+  });
+
+  it('counts skipped entries when JSONL contains malformed lines', () => {
+    const path = join(tmp, 'calibration.jsonl');
+    writeFileSync(
+      path,
+      [JSON.stringify(entry({ issueId: 'good' })), 'not valid json', '{}'].join('\n') + '\n',
+      'utf8',
+    );
+    const result = loadDorData({ corpusRoot: tmp, minSamples: 1 });
+    expect(result).not.toBeNull();
+    expect(result!.report.aggregate.n).toBe(1);
+    expect(result!.report.aggregate.skipped).toBe(2);
+  });
+});

--- a/dashboard/src/lib/dor-data.ts
+++ b/dashboard/src/lib/dor-data.ts
@@ -1,0 +1,106 @@
+/**
+ * DoR calibration data loader for the dashboard (AISDLC-162).
+ *
+ * Wraps the `cli-dor-corpus` aggregator from `@ai-sdlc/pipeline-cli`
+ * (AISDLC-161) so the dashboard can render the per-gate FP rate +
+ * recommendation envelope produced by the same code path the CLI uses.
+ *
+ * Source-of-truth resolution (in order):
+ *   1. `DOR_CORPUS_DIR` env var — operator-specified directory (typically
+ *      a `gh run download` output directory of `dor-calibration-*`
+ *      artifacts)
+ *   2. `<process.cwd()>/artifacts/_dor` — the conventional local
+ *      calibration log path used by `cli-dor-stats`
+ *
+ * Returns `null` when the resolved directory is absent or empty so the
+ * page can render a "no data yet" state instead of a stack trace. The
+ * CLI's `aggregateCorpus` returns a synthesised `insufficient-data`
+ * report for an empty corpus — but distinguishing "operator never set
+ * up the dir" from "dir exists but empty" matters for the UI hint we
+ * show the operator, hence the explicit null path.
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  aggregateCorpus,
+  findCalibrationFiles,
+  loadCorpus,
+  type AggregateOpts,
+  type CalibrationEntry,
+  type CorpusReport,
+} from '@ai-sdlc/pipeline-cli/dor-corpus';
+
+export interface DorDataResult {
+  /** Resolved corpus root used for the aggregation (absolute path). */
+  corpusRoot: string;
+  /** Aggregator output (per-gate + aggregate). */
+  report: CorpusReport;
+  /**
+   * Most-recent N calibration entries, sorted descending by `ts`. Used
+   * by the dashboard's collapsible "raw entries" table for operator
+   * spot-checking.
+   */
+  recentEntries: CalibrationEntry[];
+}
+
+export interface LoadDorDataOpts extends AggregateOpts {
+  /** Absolute path override; bypasses env + cwd resolution. */
+  corpusRoot?: string;
+  /** Cap on the recent-entry tail surfaced to the UI. Default 25. */
+  recentLimit?: number;
+}
+
+const DEFAULT_RECENT_LIMIT = 25;
+
+/**
+ * Resolve the corpus root the dashboard should read from. Pure function
+ * (no I/O) so tests can assert the resolution order without touching the
+ * filesystem.
+ */
+export function resolveCorpusRoot(opts: { corpusRoot?: string } = {}): string {
+  if (opts.corpusRoot) return opts.corpusRoot;
+  const env = process.env.DOR_CORPUS_DIR;
+  if (env && env.length > 0) return env;
+  return join(process.cwd(), 'artifacts', '_dor');
+}
+
+/**
+ * Load + aggregate the DoR calibration corpus for the dashboard.
+ *
+ * Returns `null` when the resolved root doesn't exist on disk — the
+ * page treats that as "no data yet" and renders an operator hint
+ * pointing at the `gh run download` recipe in
+ * `docs/operations/dor-promotion.md`.
+ *
+ * When the root exists but contains no readable JSONL, returns a
+ * `DorDataResult` whose `report.aggregate.recommendation` is
+ * `insufficient-data` (the aggregator's natural empty-corpus shape) so
+ * the page renders the gray badge + the "below minSamples" reason.
+ */
+export function loadDorData(opts: LoadDorDataOpts = {}): DorDataResult | null {
+  const corpusRoot = resolveCorpusRoot(opts);
+  if (!existsSync(corpusRoot)) return null;
+
+  const files = findCalibrationFiles(corpusRoot);
+  const { entries, skipped } = loadCorpus(files);
+  const report = aggregateCorpus(
+    entries,
+    {
+      ...(opts.minSamples !== undefined ? { minSamples: opts.minSamples } : {}),
+      ...(opts.fpThreshold !== undefined ? { fpThreshold: opts.fpThreshold } : {}),
+      ...(opts.overrideThreshold !== undefined
+        ? { overrideThreshold: opts.overrideThreshold }
+        : {}),
+    },
+    { skipped, filesRead: files.length },
+  );
+
+  const recentLimit = opts.recentLimit ?? DEFAULT_RECENT_LIMIT;
+  // Sort descending by `ts` so the operator sees the freshest events
+  // first. `ts` is ISO-8601 — string comparison is lexicographically
+  // equivalent to chronological order, which is cheaper than parsing.
+  const recentEntries = [...entries].sort((a, b) => (a.ts < b.ts ? 1 : -1)).slice(0, recentLimit);
+
+  return { corpusRoot, report, recentEntries };
+}

--- a/dashboard/src/lib/nav-items.test.ts
+++ b/dashboard/src/lib/nav-items.test.ts
@@ -9,20 +9,26 @@ describe('nav-items', () => {
   });
 
   describe('coreNavItems', () => {
-    it('has 5 core navigation items', () => {
-      expect(coreNavItems).toHaveLength(5);
+    it('has 6 core navigation items', () => {
+      expect(coreNavItems).toHaveLength(6);
     });
 
     it('includes Overview as the first item', () => {
       expect(coreNavItems[0]).toEqual({ href: '/', label: 'Overview' });
     });
 
-    it('includes Cost, Autonomy, Codebase, and Audit', () => {
+    it('includes Cost, Autonomy, Codebase, Audit, and DoR Calibration', () => {
       const labels = coreNavItems.map((item) => item.label);
       expect(labels).toContain('Cost');
       expect(labels).toContain('Autonomy');
       expect(labels).toContain('Codebase');
       expect(labels).toContain('Audit');
+      expect(labels).toContain('DoR Calibration');
+    });
+
+    it('routes DoR Calibration to /dor', () => {
+      const dor = coreNavItems.find((i) => i.label === 'DoR Calibration');
+      expect(dor).toEqual({ href: '/dor', label: 'DoR Calibration' });
     });
 
     it('all items have href and label', () => {

--- a/dashboard/src/lib/nav-items.ts
+++ b/dashboard/src/lib/nav-items.ts
@@ -15,6 +15,7 @@ export const coreNavItems: NavItem[] = [
   { href: '/autonomy', label: 'Autonomy' },
   { href: '/codebase', label: 'Codebase' },
   { href: '/audit', label: 'Audit' },
+  { href: '/dor', label: 'DoR Calibration' },
 ];
 
 let _cachedItems: NavItem[] | null = null;

--- a/pipeline-cli/package.json
+++ b/pipeline-cli/package.json
@@ -52,6 +52,10 @@
     "./incremental-review": {
       "types": "./dist/incremental-review/index.d.ts",
       "import": "./dist/incremental-review/index.js"
+    },
+    "./dor-corpus": {
+      "types": "./dist/cli/dor-corpus.d.ts",
+      "import": "./dist/cli/dor-corpus.js"
     }
   },
   "publishConfig": {

--- a/pipeline-cli/src/cli/dor-corpus.ts
+++ b/pipeline-cli/src/cli/dor-corpus.ts
@@ -46,6 +46,12 @@ import yargs, { type Argv } from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import type { CalibrationEntry } from '../dor/calibration-log.js';
 
+// Re-export so consumers (e.g. AISDLC-162 dashboard) can import the
+// CalibrationEntry shape alongside the aggregator without a second
+// import path. The aggregator's full surface — pure functions + this
+// type — is the dashboard's contract.
+export type { CalibrationEntry };
+
 /**
  * Default minimum sample count for the `safe-to-enforce` recommendation.
  * Below this, we return `insufficient-data` regardless of the FP rate

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@ai-sdlc/orchestrator':
         specifier: workspace:*
         version: link:../orchestrator
+      '@ai-sdlc/pipeline-cli':
+        specifier: workspace:*
+        version: link:../pipeline-cli
       better-sqlite3:
         specifier: ^11.0.0
         version: 11.10.0


### PR DESCRIPTION
## Summary

Adds the `/dor` operator dashboard page closing AISDLC-115 parent AC #5 ("DoR calibration log feeds metrics dashboard").

## Changes

- New `dashboard/src/app/dor/page.tsx` — per-gate FP rate + override rate + recommendation badge
- New `dashboard/src/components/cards/recommendation-badge.tsx` — `safe-to-enforce` (green) / `continue-soak` (yellow) / `insufficient-data` (gray)
- New `dashboard/src/lib/dor-data.ts` — server-side data load via the new `@ai-sdlc/pipeline-cli/dor-corpus` workspace export
- Source defaults to `<cwd>/artifacts/_dor` with `DOR_CORPUS_DIR` override
- Nav link added
- 21 new tests covering empty, safe-to-enforce, continue-soak, multi-file `gh run download` layout, malformed-line skip paths

## Design decision

Reuses the AISDLC-161 `cli-dor-corpus` aggregator via a new workspace export (`./dor-corpus`) — UI math is computed by the exact same code path the CLI uses. Zero duplicated logic.

## Test plan

- [x] `pnpm --filter @ai-sdlc/dashboard build && test && lint && format:check` — clean
- [x] 21 new tests covering all data-shape branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)