### PR TITLE
feat(spec): strengthen developer subagent prompt — push + PR are required (AISDLC-164)

### DIFF
--- a/ai-sdlc-plugin/agents/developer.md
+++ b/ai-sdlc-plugin/agents/developer.md
@@ -14,7 +14,38 @@ model: inherit
 harness: claude-code
 ---
 
-You are an AI-SDLC developer agent. You implement a single backlog task end-to-end inside an isolated git worktree, then return a structured summary so the orchestrating command can run reviews and open a PR.
+You are an AI-SDLC developer agent. You implement a single backlog task end-to-end inside an isolated git worktree: plan, implement, verify, commit, **push**, and **open a pull request**, then return a structured summary.
+
+## Definition of Done — read this FIRST and last
+
+A task is NOT done until you have:
+
+1. Committed the work
+2. **Pushed the branch to `origin`**
+3. **Opened a pull request via `gh pr create` and captured the PR URL**
+
+> **Hard rule: you MUST push and open the PR. Returning without pushing or without opening the PR is INCORRECT.** It is not "the orchestrator's job" — it is YOUR job. Push + PR are not optional cleanup; they are core deliverables on equal footing with the commit itself. A run that ends at the commit step has produced an unreachable artifact and wasted the operator's time.
+
+If you find yourself thinking "my role ends at commit, the orchestrator handles push + PR" — that thought is **wrong** and is the exact failure mode this prompt was rewritten to eliminate. Push the branch. Open the PR. Capture the URL.
+
+### CORRECT behavior (what to do)
+
+```
+[ai-sdlc-progress] commit: a1b2c3d feat(spec): add docs sync (AISDLC-68)
+[ai-sdlc-progress] push: pushed ai-sdlc/aisdlc-68-docs-sync to origin
+[ai-sdlc-progress] pr: opened https://github.com/org/repo/pull/4321
+... return JSON with prUrl: "https://github.com/org/repo/pull/4321"
+```
+
+### WRONG behavior (observed in AISDLC-160, 161, 162 — do NOT repeat)
+
+```
+[ai-sdlc-progress] commit: a1b2c3d feat(spec): add docs sync (AISDLC-68)
+... return JSON with commitSha set, prUrl: null
+... notes: "commit landed on the feature branch; orchestrator handles push + PR"
+```
+
+That return is a failed run. The orchestrator now treats `prUrl: null` as a hard failure. Even if push or `gh pr create` fail for an environmental reason, you must attempt them and report the failure in `notes` — never silently skip them on the assumption they are someone else's responsibility.
 
 ## Your environment
 
@@ -48,6 +79,14 @@ Stages and the status line each one should produce:
 3. **verify** — Run `pnpm build && pnpm test && pnpm lint && pnpm format:check` (or the project's equivalent). Fix any failures. Emit: `[ai-sdlc-progress] verify: build/test/lint/format clean`
 4. **commit** — Stage only the files you intentionally modified (`git add -- <files>`, never `git add -A`), then commit with a conventional-commit message ending in the `Co-Authored-By` trailer. Emit: `[ai-sdlc-progress] commit: <sha-short> <subject>`
 
+> Steps 1-4 are the implementation arc. They are NOT the whole task. The task is not complete until you have ALSO performed the **Definition of Done** (push + open PR) described above. After step 4, immediately:
+>
+> - `git push -u origin HEAD` (handle pre-push hook re-runs as expected; never `--no-verify`, never `--force` unless `--force-with-lease` is required after a rebase you just performed)
+> - `gh pr create --title <conventional-commit subject> --body <hand-written body explaining why, the failure mode if applicable, and how the diff addresses the ACs>` — write the PR body yourself; you have the mid-stream context that produces a better narrative than the orchestrator can synthesize from a JSON return
+> - Capture the resulting PR URL and put it in the `prUrl` field of your return JSON
+>
+> Emit: `[ai-sdlc-progress] push: pushed <branch> to origin` and `[ai-sdlc-progress] pr: opened <url>`. These two lines are mandatory.
+
 ## Commit message format
 
 ```
@@ -74,6 +113,7 @@ Return a JSON object as your final message (no other text):
   "filesChanged": ["path/in/worktree.ts", "..."],
   "filesChangedExternal": [{"repo": "/abs/sibling/path", "files": ["..."]}],
   "commitSha": "abc1234",
+  "prUrl": "https://github.com/<org>/<repo>/pull/<n>",
   "verifications": {
     "build": "passed | failed | skipped",
     "test": "passed | failed | skipped",
@@ -85,4 +125,14 @@ Return a JSON object as your final message (no other text):
 }
 ```
 
-If you cannot complete the task (blocked, ambiguous, infeasible), still return the JSON with `commitSha: null`, `verifications` reflecting what you ran, and `notes` explaining the blocker. The orchestrator handles failure routing — don't try to escalate yourself.
+### Required fields
+
+`prUrl` is **REQUIRED** for any successful run. The orchestrator treats `prUrl: null` as a failed run regardless of how many ACs you met or whether the commit landed cleanly.
+
+> **If you returned without `prUrl`, you have failed the task.** Re-read the Definition of Done section at the top of this prompt and execute the push + `gh pr create` you skipped. The fact that the diff is committed locally is irrelevant if no one can review or merge it.
+
+### Failure / blocker returns
+
+If you cannot complete the task (blocked, ambiguous, infeasible) AND you genuinely cannot commit anything reviewable, return the JSON with `commitSha: null`, `prUrl: null`, `verifications` reflecting what you ran, and `notes` explaining the blocker. The orchestrator handles failure routing — don't try to escalate yourself. This null-`prUrl` exemption ONLY applies when there is no commit to push; it is NOT an escape hatch for "I committed but skipped push."
+
+If push or `gh pr create` itself fails (network, permissions, hook rejection you cannot resolve) AFTER you have committed, return `commitSha` populated, `prUrl: null`, and a `notes` field with the exact failure output and what you tried. This signals environmental failure, distinct from skipping the step.

--- a/backlog/completed/aisdlc-164 - Strengthen-developer-subagent-prompt-push-and-PR-are-required.md
+++ b/backlog/completed/aisdlc-164 - Strengthen-developer-subagent-prompt-push-and-PR-are-required.md
@@ -1,0 +1,69 @@
+---
+id: AISDLC-164
+title: 'Strengthen developer subagent prompt — push + PR are required, not optional'
+status: Done
+assignee: []
+created_date: '2026-05-02'
+labels:
+  - spec
+  - plugin
+  - agent-prompt
+  - devloop
+dependencies: []
+references:
+  - ai-sdlc-plugin/agents/developer.md
+  - backlog/completed/aisdlc-160 - Create-RFC-0010-phase-sub-tasks-AISDLC-70.1-through-70.9.md
+  - backlog/completed/aisdlc-161 - Wire-up-DoR-calibration-data-collection-in-CI-and-enable-hybrid-Phase-8-promotion-path.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Multiple recent dev runs (AISDLC-160, 161, 162, etc.) returned with the commit landed but no push and no PR opened — citing "my role ends at commit, the orchestrator handles push + PR." This cost ~30s/run of orchestrator overhead per task AND lost the developer subagent's mid-stream context that produces a richer PR body than the orchestrator can synthesize from the JSON return alone.
+
+The system prompt at `ai-sdlc-plugin/agents/developer.md` already said to push + open the PR (Step 8 in the typical workflow). The model was interpreting it as optional cleanup, mentally bucketing it as "the orchestrator's job."
+
+This task tightens the prompt so push + PR are framed as core deliverables on equal footing with the commit itself: a prominent **Definition of Done** section, a hard rule statement, an explicit anti-pattern callout naming the prior failures, a `prUrl` REQUIRED field in the JSON return schema, and a CORRECT-vs-WRONG behavior example pair. The intent is zero plausible re-interpretation surface for "push is optional."
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 `ai-sdlc-plugin/agents/developer.md` has a clear, prominent "Hard rule: you MUST push and open the PR. Returning without pushing or without opening the PR is INCORRECT." statement
+- [x] #2 Push + PR step moved out of the workflow numbered list and into a top-level "Definition of Done" section so it cannot be mentally bucketed as optional cleanup
+- [x] #3 JSON return schema makes `prUrl` REQUIRED (not optional) with note: "if you returned without `prUrl`, you have failed the task"
+- [x] #4 CORRECT behavior example + WRONG interpretation example (citing the AISDLC-160/161/162 failure mode verbatim) included so the model has explicit anti-pattern coverage
+- [x] #5 Rest of the agent's responsibilities unchanged — only the push + PR contract was tightened
+<!-- AC:END -->
+
+## Implementation Notes
+<!-- SECTION:NOTES:BEGIN -->
+Single-file edit to `ai-sdlc-plugin/agents/developer.md`:
+
+- New top-level "Definition of Done — read this FIRST and last" section placed BEFORE "Your environment" so it lands in the model's working set early, with the hard-rule statement formatted as a blockquote for visual prominence.
+- CORRECT and WRONG behavior code blocks side-by-side, with the WRONG block quoting the exact "orchestrator handles push + PR" rationalization observed in AISDLC-160/161/162 returns.
+- Workflow section: kept the existing 4-step plan/implement/verify/commit list intact, then added a blockquote callout immediately after listing push + PR as mandatory follow-on stages with explicit `git push -u origin HEAD` and `gh pr create` commands plus the two required progress lines (`[ai-sdlc-progress] push:` and `[ai-sdlc-progress] pr:`).
+- Return schema: added `prUrl` field to the JSON example, then a "Required fields" subsection asserting `prUrl` is required and quoting the "you have failed the task" line. A "Failure / blocker returns" subsection distinguishes the legitimate `prUrl: null` exemption (no commit to push) from the illegitimate one (committed but skipped push).
+
+No other prompt content changed — file budget = 1.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+## Summary
+Tightened the developer subagent prompt (`ai-sdlc-plugin/agents/developer.md`) to eliminate the re-interpretation surface that made multiple recent dev runs (AISDLC-160, 161, 162) return at commit-landed-but-no-PR. Push + `gh pr create` are now framed as core deliverables on equal footing with the commit, with a prominent Definition of Done section, an anti-pattern example pair, and a required `prUrl` field in the JSON return schema.
+
+## Changes
+- `ai-sdlc-plugin/agents/developer.md` (modified): added Definition of Done section with hard-rule statement and CORRECT/WRONG examples; promoted push + `gh pr create` from workflow step 8 to mandatory follow-on stages with explicit commands; made `prUrl` REQUIRED in the JSON schema and added a Failure/blocker subsection that distinguishes legitimate `prUrl: null` (no commit to push) from illegitimate (committed but skipped push).
+
+## Design decisions
+- **Definition-of-Done framing over additional workflow step**: a numbered step buries the requirement; a top-level section with a blockquote hard rule lands in the model's attention budget early and re-anchors at the return-schema section.
+- **Verbatim quote of the prior rationalization**: explicitly naming the "my role ends at commit, the orchestrator handles push + PR" phrasing in the WRONG example gives the model exact anti-pattern coverage rather than a generic "don't skip the PR" hedge.
+- **Two-tier null-`prUrl` semantics**: distinguishing "no commit, no PR — legitimate blocker" from "committed but skipped PR — failure" prevents the model from using the blocker exemption as an escape hatch.
+
+## Verification
+- `pnpm lint` — clean
+- `pnpm format:check` — clean
+
+## Follow-up
+(none) — observe whether subsequent dev runs return with `prUrl` populated; if regressions persist, consider an orchestrator-side preflight that refuses to accept a return JSON without `prUrl` and re-prompts the subagent with a citation of the failure.


### PR DESCRIPTION
## Summary

Multiple recent dev runs (AISDLC-160, 161, 162) returned with the commit landed but **no push and no PR opened**, citing "my role ends at commit, the orchestrator handles push + PR." That re-interpretation cost ~30s of orchestrator overhead per run AND lost the developer subagent's mid-stream context — the subagent has the freshest understanding of the diff and produces a richer PR body than the orchestrator can synthesize from a JSON return alone.

The system prompt at `ai-sdlc-plugin/agents/developer.md` already said to push + open the PR (it was Step 8 in the typical workflow). The model was interpreting that as optional cleanup that "the orchestrator handles." This PR removes that interpretation surface.

**META: this PR is dogfood.** It was authored by the developer subagent against the very prompt being strengthened. If the PR exists and you are reading this, the subagent complied with its new contract.

## The failure mode

Observed return shape from AISDLC-160/161/162:

```
[ai-sdlc-progress] commit: a1b2c3d feat(spec): ...
... return JSON with commitSha set, prUrl: null
... notes: "commit landed on the feature branch; orchestrator handles push + PR"
```

Diagnosis: the prompt's workflow had push + PR buried as Step 8 of a numbered list, easily mentally bucketed as "optional follow-on" the way "cleanup tmpdirs" or "log final state" gets bucketed. The JSON schema also marked `prUrl` as effectively optional (no required-fields callout), and the failure-return pathway tacitly permitted skipping it under the guise of "cannot complete the task."

## The fix

Single-file edit to `ai-sdlc-plugin/agents/developer.md`:

1. **New top-level `Definition of Done — read this FIRST and last` section** placed BEFORE `Your environment` so it lands in the model's working set immediately. Contains the verbatim hard-rule statement: *"you MUST push and open the PR. Returning without pushing or without opening the PR is INCORRECT."*
2. **CORRECT vs WRONG behavior examples** — the WRONG block quotes the exact "orchestrator handles push + PR" rationalization observed in 160/161/162 returns. Explicit anti-pattern coverage rather than a generic "don't skip the PR" hedge.
3. **Push + `gh pr create` promoted out of the workflow numbered list** into a mandatory follow-on callout right after the commit step. Includes explicit commands (`git push -u origin HEAD`, `gh pr create --title ... --body ...`) and two new required progress lines (`[ai-sdlc-progress] push:` and `[ai-sdlc-progress] pr:`).
4. **`prUrl` is now REQUIRED in the JSON return schema.** New "Required fields" subsection asserts: *"if you returned without `prUrl`, you have failed the task."* The orchestrator treats `prUrl: null` as a failed run regardless of how many ACs the subagent claims to have met.
5. **New "Failure / blocker returns" subsection** distinguishes the legitimate `prUrl: null` exemption (no commit to push because the task is genuinely blocked / infeasible / ambiguous) from the illegitimate one (committed but skipped push). The former is allowed; the latter is the failure mode this PR exists to prevent.

Rest of the agent's responsibilities (file budget, hard rules, commit message format, cross-repo writes) unchanged — only the push + PR contract was tightened.

## Acceptance criteria

- [x] AC1 — prominent "Hard rule: you MUST push and open the PR. Returning without pushing or without opening the PR is INCORRECT." statement (in the Definition of Done blockquote)
- [x] AC2 — push + PR step moved out of the workflow numbered list into a top-level "Definition of Done" section
- [x] AC3 — JSON return schema makes `prUrl` REQUIRED with note "if you returned without `prUrl`, you have failed the task"
- [x] AC4 — CORRECT and WRONG behavior examples included; WRONG example cites the AISDLC-160/161/162 failure mode verbatim
- [x] AC5 — only the push + PR contract changed; rest of the agent's responsibilities untouched

## Verification

- `pnpm lint` — clean
- `pnpm format:check` — clean
- (build/test not required for a docs-only change to a subagent prompt)

## Test plan

- [ ] Reviewer confirms `ai-sdlc-plugin/agents/developer.md` reads cleanly end-to-end with no internal contradictions
- [ ] Reviewer confirms the Definition of Done section is unmissable (placement + bold + blockquote)
- [ ] Reviewer confirms `prUrl` REQUIRED note + the failure-vs-blocker distinction is unambiguous
- [ ] Observe next 3-5 dev runs; expectation is `prUrl` populated on every successful return
- [ ] If regressions persist, follow-up: orchestrator-side preflight that refuses to accept a return JSON without `prUrl` and re-prompts the subagent with a citation of the failure (mentioned in the task's Follow-up section)