### PR TITLE
chore(spec): create RFC-0014 phase sub-tasks AISDLC-167.1-5 + parent

### DIFF
--- a/backlog/tasks/aisdlc-167 - RFC-0014-Dependency-Graph-Composition.md
+++ b/backlog/tasks/aisdlc-167 - RFC-0014-Dependency-Graph-Composition.md
@@ -1,0 +1,83 @@
+---
+id: AISDLC-167
+title: 'RFC-0014: Dependency Graph Composition'
+status: To Do
+assignee: []
+created_date: '2026-05-03'
+labels:
+  - rfc-0014
+  - dependency-graph
+  - composition
+  - parent
+milestone: m-3
+dependencies: []
+references:
+  - spec/rfcs/RFC-0014-dependency-graph-composition.md
+  - pipeline-cli/src/deps/
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Parent task for the RFC-0014 implementation. Splits the 5-phase plan from RFC §11 into trackable sub-tasks (AISDLC-167.1 through 167.5). All phases ship behind feature flag `AI_SDLC_DEPS_COMPOSITION`. Total wall-clock ~3 weeks (Phase 5 soak duration is corpus-driven, not calendar-driven per maintainer directive 2026-05-01).
+
+## Scope
+
+RFC-0014 promotes the dependency graph (AISDLC-117 `cli-deps` foundation) to a first-class pipeline object and composes it with three existing subsystems:
+
+1. **PPA × Graph** (Phase 2) — depth-aware priority. A high-PPA task whose blocker is a low-PPA task auto-bumps the blocker via `effectivePriority = priority(task) + maxDownstreamPriority(task)` so critical-path leaves bubble to the top.
+2. **DoR × Graph** (Phase 3) — blast-radius surfacing. The DoR clarification comment + calibration log gain blast-radius fields so authors see "this gates N downstream tasks" and the calibration loop distinguishes false-positives on leaves vs chain roots.
+3. **Graph × Observability** (Phase 4) — critical-path digest in Slack weekly digest + interactive operator dashboard.
+
+## Phase breakdown (per RFC §11)
+
+| Sub-task | Phase | Wall-clock | Depends on |
+|---|---|---|---|
+| AISDLC-167.1 | Phase 1: Snapshot artifact | 0.5 wk | — |
+| AISDLC-167.2 | Phase 2: PPA composition | 1 wk | 167.1 |
+| AISDLC-167.3 | Phase 3: DoR composition | 0.5 wk | 167.2 |
+| AISDLC-167.4 | Phase 4: Slack + dashboard digest | 1 wk | 167.2 |
+| AISDLC-167.5 | Phase 5: Soak + flag promotion | corpus-driven | 167.3, 167.4 |
+
+Critical path: 167.1 → 167.2 → 167.3/167.4 (parallelizable) → 167.5.
+
+## In-flight cross-reference
+
+AISDLC-166 is doing the **Phase 1 work in flight** (developer was dispatched directly against AISDLC-166 before this parent task tree was created). When AISDLC-166's PR merges, it satisfies AISDLC-167.1 — close 167.1 then with a back-pointer to 166.
+
+## Dependencies
+
+- AISDLC-117 (`cli-deps` foundation) — DONE. Provides the in-memory graph computer + `frontier|blockers|impact|validate|graph` CLI surface this RFC's compositions consume.
+- RFC-0008 PPA scoring (Phase 2 composes with the dispatcher's priority comparator).
+- RFC-0011 DoR gate (Phase 3 composes with the comment template + calibration log).
+- RFC-0010 cli-status (Phase 4 composes with the existing Slack/dashboard digest pattern).
+
+## Soak policy — corpus-driven, NOT calendar-driven
+
+Per maintainer directive (2026-05-01): RFC-0014 Phase 5 ships when:
+- Dispatch correctness > 95% measured against the pipeline corpus, AND
+- No operator override-rate spike vs PPA-only baseline.
+
+Whichever comes first. Calendar duration is a side-effect, not a gate.
+
+## Open-question resolutions worth carrying forward
+
+All 6 open questions resolved at v3 (RFC §12). The implementations below MUST honor:
+- Q1: dispatcher sort = `effectivePriority DESC → criticalPathLength DESC → recency DESC` (Phase 2).
+- Q2: snapshot retention = 30d rolling + event-tagged permanent; ship `cli-deps gc` + `cli-deps inspect --tag <name>` (Phase 1).
+- Q3: `externalDependencies:` frontmatter array — surfaced in snapshot/DoR comment/blockers, NOT a dispatch gate in v1 (Phase 1 + Phase 3).
+- Q4: no cache; recompute graph every dispatch (Phase 2).
+- Q5: `dor-bypass` admission with high blast radius posts a maintainer-tone FYI variant of the blast-radius comment (Phase 3).
+- Q6: per-task atomic read; "best-effort consistency, validated by consumer" contract documented in `pipeline-cli/docs/deps.md` (Phase 1).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 5 phase sub-tasks (AISDLC-167.1 through 167.5) reach Done status
+- [ ] #2 Feature flag `AI_SDLC_DEPS_COMPOSITION` promoted from `off` (default) → `on` after Phase 5 soak validates dispatch correctness > 95% with no operator-override-rate spike
+- [ ] #3 Dogfood pipeline runs end-to-end with composition ENABLED for at least one full corpus window (issue → PPA × graph → DoR × graph → dispatch → critical-path digest)
+- [ ] #4 All 6 open-question resolutions from RFC §12 v3 honored in shipped phases (Q1-Q6 cross-referenced in sub-task ACs)
+- [ ] #5 Operator runbook extended with composition-specific failure modes (snapshot validation failures, dispatch ordering anomalies, blast-radius callout misfires)
+- [ ] #6 `pipeline-cli/docs/deps.md` documents the snapshot artifact contract, the per-task atomic-read consistency model (Q6), and the `cli-deps gc` / `inspect --tag` retention story (Q2)
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-167.1 - Phase-1-Snapshot-artifact.md
+++ b/backlog/tasks/aisdlc-167.1 - Phase-1-Snapshot-artifact.md
@@ -1,0 +1,47 @@
+---
+id: AISDLC-167.1
+title: 'Phase 1: Snapshot artifact'
+status: To Do
+assignee: []
+created_date: '2026-05-03'
+labels:
+  - rfc-0014
+  - phase-1
+  - snapshot
+  - cli-deps
+milestone: m-3
+dependencies: []
+parent_task_id: AISDLC-167
+references:
+  - spec/rfcs/RFC-0014-dependency-graph-composition.md
+  - pipeline-cli/src/deps/
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase 1 of RFC-0014. Emit a graph snapshot artifact at `$ARTIFACTS_DIR/_deps/snapshot.<timestamp>.jsonl` per pipeline tick using AISDLC-117's in-memory graph computer. The snapshot becomes the canonical input for Phase 2 (PPA composition), Phase 3 (DoR composition), and Phase 4 (digest rendering). Estimated 0.5 week.
+
+## In-flight cross-reference
+
+**AISDLC-166 is doing this work in flight** — the developer was dispatched directly against AISDLC-166 before this sub-task tree was created. When AISDLC-166's PR merges, it satisfies this sub-task. **Action when 166 merges:** close AISDLC-167.1 (move to `backlog/completed/`) with a note pointing back to AISDLC-166's PR/SHA in the final summary. No re-implementation here — this task exists for tree-completeness so the parent (AISDLC-167) has the canonical 5-phase decomposition.
+
+## Open-question resolutions implemented in this phase
+
+- **Q2 (retention):** Snapshot writer accepts `tag: 'rolling' | 'dispatch' | 'calibration' | 'lifecycle-transition'`. Rolling-tagged snapshots are trimmed by mtime > 30d via a new `cli-deps gc` command. Event-tagged snapshots are kept indefinitely; `cli-deps inspect --tag <name>` enumerates them so an operator can audit/prune the permanent tier.
+- **Q3 (external deps):** Snapshot renders each task's `externalDependencies:` frontmatter array (entries: `{ id, description, kind, resolverHint? }`) per task line. Pure signal in v1; not a dispatch gate.
+- **Q6 (consistency):** Per-task atomic `readFile` + sequential walk; "best-effort consistency, validated by consumer" contract documented in `pipeline-cli/docs/deps.md`. Dangling edges are caught downstream by `cli-deps validate`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Snapshot writer emits `$ARTIFACTS_DIR/_deps/snapshot.<timestamp>.jsonl` per pipeline tick, one JSONL line per task with fields `{id, status, dependsOn, unblocks, depth, reach}` per RFC §4.1
+- [ ] #2 `depth` (longest chain from a graph root) and `reach` (transitive closure of `unblocks`) computed in O(V+E) per snapshot
+- [ ] #3 Snapshot validates against a JSON schema published under `spec/schemas/deps-snapshot.v1.schema.json`; readable + parseable by Phase 2/3/4 consumers
+- [ ] #4 Q2 retention: snapshot writer accepts `tag: 'rolling' | 'dispatch' | 'calibration' | 'lifecycle-transition'`; `cli-deps gc` trims rolling > 30d mtime; `cli-deps inspect --tag <name>` enumerates event-tagged snapshots
+- [ ] #5 Q3 external deps: per-task `externalDependencies:` frontmatter array (entries `{ id, description, kind: 'npm-version'|'github-pr'|'url-head'|'manual'|'other', resolverHint? }`) is parsed and rendered into the snapshot per task
+- [ ] #6 Q6 consistency contract: per-task atomic `readFile` + sequential walk implementation; documented in `pipeline-cli/docs/deps.md` ("best-effort consistency, validated by consumer")
+- [ ] #7 Hermetic tests cover snapshot fields, tag-based retention, external-deps rendering, and dangling-edge tolerance (validated downstream, NOT during write)
+- [ ] #8 New code reaches 80%+ patch coverage; full workspace `pnpm build && pnpm test && pnpm lint && pnpm format:check` clean
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-167.2 - Phase-2-PPA-composition.md
+++ b/backlog/tasks/aisdlc-167.2 - Phase-2-PPA-composition.md
@@ -1,0 +1,45 @@
+---
+id: AISDLC-167.2
+title: 'Phase 2: PPA composition'
+status: To Do
+assignee: []
+created_date: '2026-05-03'
+labels:
+  - rfc-0014
+  - phase-2
+  - ppa-composition
+  - dispatcher
+milestone: m-3
+dependencies:
+  - AISDLC-167.1
+parent_task_id: AISDLC-167
+references:
+  - spec/rfcs/RFC-0014-dependency-graph-composition.md
+  - pipeline-cli/src/deps/
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase 2 of RFC-0014. Extend the dispatcher's priority comparator to use `effectivePriority(task) = priority(task) + maxDownstreamPriority(task)` so a low-PPA task that unblocks a high-PPA task inherits the downstream urgency. Critical-path leaves bubble to the top of the dispatch queue automatically. Per RFC §5.
+
+The composition is **read-only for PPA**: per-task PPA scores in the calibration log are unchanged; only the dispatcher's sort order changes. Estimated 1 week.
+
+## Open-question resolutions implemented in this phase
+
+- **Q1 (tiebreak):** Dispatcher sort = `effectivePriority DESC → criticalPathLength DESC → recency DESC`. Structural signal (chain depth) strictly dominates arbitrary signal (recency) when effective priority is tied. An operator can trace "why this one?" as "longest chain → newest commit" without calibrating magic-number weights.
+- **Q4 (no cache):** Recompute graph + `effectivePriority` per dispatch decision. O(V+E) is sub-millisecond at current scale (~150 tasks, ~200 edges). YAGNI on caching — adds invalidation bugs, an extra state surface, and operator confusion when manual edits don't show up immediately. Revisit only if profiling under realistic load shows recompute > 5% of decision time.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `effectivePriority(task) = priority(task) + maxDownstreamPriority(task)` implemented in the dispatcher; `maxDownstreamPriority` is the max PPA priority across `task.unblocks` transitive closure (NOT a sum — bounded by chain max per RFC §5.3)
+- [ ] #2 Dispatcher's priority comparator updated to sort by Q1 resolution: `effectivePriority DESC → criticalPathLength DESC → recency DESC`
+- [ ] #3 PPA per-task scores in the calibration log are UNCHANGED — composition is read-only for PPA per RFC §5.3 (assert via fixture: scores written by PPA scorer match scores read by composition layer)
+- [ ] #4 Composition is monotonic: adding a new dependency edge can only INCREASE effective priority of upstream tasks, never decrease (assert via property test)
+- [ ] #5 Q4 no-cache implementation: graph + `effectivePriority` recomputed per dispatch decision; no TTL state, no invalidation surface
+- [ ] #6 Integration test with chain fixtures: critical-path leaf-of-deep-chain bubbles to top of dispatch queue; leaf-of-shallow-chain stays at its PPA-only rank
+- [ ] #7 Behind feature flag `AI_SDLC_DEPS_COMPOSITION` (default off); when off, dispatcher behaves exactly as PPA-only baseline (assert via fixture comparison)
+- [ ] #8 New code reaches 80%+ patch coverage; full workspace `pnpm build && pnpm test && pnpm lint && pnpm format:check` clean
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-167.3 - Phase-3-DoR-composition.md
+++ b/backlog/tasks/aisdlc-167.3 - Phase-3-DoR-composition.md
@@ -1,0 +1,50 @@
+---
+id: AISDLC-167.3
+title: 'Phase 3: DoR composition'
+status: To Do
+assignee: []
+created_date: '2026-05-03'
+labels:
+  - rfc-0014
+  - phase-3
+  - dor-composition
+  - blast-radius
+milestone: m-3
+dependencies:
+  - AISDLC-167.2
+parent_task_id: AISDLC-167
+references:
+  - spec/rfcs/RFC-0014-dependency-graph-composition.md
+  - .ai-sdlc/dor-config.yaml
+  - ai-sdlc-plugin/agents/refinement-reviewer.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase 3 of RFC-0014. Extend the DoR clarification comment template + calibration log with blast-radius fields so authors see "this gates N downstream tasks" and the calibration loop distinguishes false-positives on leaves vs chain roots. Per RFC §6.
+
+Two comment templates per Q5 resolution:
+1. **Standard verdict** (gates evaluated, returned `Needs Clarification`): existing template + blast-radius callout.
+2. **Bypass verdict** (`dor-bypass` maintainer override on a high-radius task): maintainer-tone FYI variant — different audience, different tone, same data.
+
+Estimated 0.5 week.
+
+## Open-question resolutions implemented in this phase
+
+- **Q3 (external deps):** DoR clarification comment appends a "⚠ External dependencies tracked: N" line when `externalDependencies:` is non-empty. Pure signal in v1; not a dispatch gate.
+- **Q5 (bypass × blast radius):** Standard admission verdicts get the existing "⚠ This issue currently gates N downstream tasks (...). Resolving the questions above unblocks the entire chain." Bypass-admitted high-radius tasks get a maintainer-tone variant: "ℹ This bypass admits a task gating N downstream items (AISDLC-X, AISDLC-Y, ...). Confirm intentional — high blast radius is a strong calibration signal that the rubric may be missing something." Trigger logic = admission verdict source determines which template fires.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 DoR clarification comment template extended with blast-radius callout: "⚠ This issue currently gates N downstream tasks (AISDLC-X, AISDLC-Y, ...). Resolving the questions above unblocks the entire chain." per RFC §6.2
+- [ ] #2 For very large N (>5), the comment lists the top 3 highest-PPA downstream items by name + a "see N total" link to the graph view per RFC §6.2
+- [ ] #3 Q5 bypass variant: bypass-admitted high-radius tasks get a maintainer-tone FYI comment (different template, same data); trigger logic distinguishes admission verdict source (gates-evaluated vs `dor-bypass`)
+- [ ] #4 Q3 external deps: clarification comment appends "⚠ External dependencies tracked: N" line when task `externalDependencies:` is non-empty
+- [ ] #5 DoR calibration log (`$ARTIFACTS_DIR/_dor/calibration.jsonl`) gains `blastRadius` + `highestDownstreamPriority` fields per verdict; backward-compatible with existing readers (additive only)
+- [ ] #6 Vague root-of-chain fixture issue gets blast-radius callout in DoR comment; vague leaf fixture issue gets standard comment WITHOUT blast-radius callout (N=0)
+- [ ] #7 Behind feature flag `AI_SDLC_DEPS_COMPOSITION` (default off); when off, DoR comment + calibration log shape are unchanged from RFC-0011 baseline
+- [ ] #8 New code reaches 80%+ patch coverage; full workspace `pnpm build && pnpm test && pnpm lint && pnpm format:check` clean
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-167.4 - Phase-4-Slack-and-dashboard-digest.md
+++ b/backlog/tasks/aisdlc-167.4 - Phase-4-Slack-and-dashboard-digest.md
@@ -1,0 +1,46 @@
+---
+id: AISDLC-167.4
+title: 'Phase 4: Slack + dashboard digest'
+status: To Do
+assignee: []
+created_date: '2026-05-03'
+labels:
+  - rfc-0014
+  - phase-4
+  - observability
+  - slack-digest
+  - dashboard
+milestone: m-3
+dependencies:
+  - AISDLC-167.2
+parent_task_id: AISDLC-167
+references:
+  - spec/rfcs/RFC-0014-dependency-graph-composition.md
+  - pipeline-cli/src/deps/
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase 4 of RFC-0014. Surface the critical path on the existing Slack weekly digest + render an interactive graph view in the operator dashboard. Per RFC §7.
+
+This phase is parallelizable with Phase 3 (both depend only on Phase 2's `effectivePriority` + the snapshot artifact from Phase 1). Estimated 1 week.
+
+## Components
+
+- **Slack weekly digest** (RFC §7.1): new "🛤️ Critical Path This Week" section listing top 3-5 items by `effectivePriority` with their downstream-blocked count. Composes with the existing weekly digest from RFC-0011 §8 + RFC-0010 cli-status.
+- **Operator dashboard** (RFC §7.2): interactive graph view — click a task → see blockers + downstream + PPA score + DoR verdict. Mermaid-style rendering with color-coding by status (To Do = blue, In Progress = yellow, Needs Clarification = red, Done = green).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Weekly digest gains a "🛤️ Critical Path This Week" section listing top 3-5 items sorted by `effectivePriority` (Phase 2 output) with each item's downstream-blocked count per RFC §7.1
+- [ ] #2 Digest format degrades gracefully when no items qualify (e.g., flat graph, all leaves) — section is omitted entirely rather than rendering an empty header
+- [ ] #3 Dashboard graph view renders the dependency snapshot interactively: click a task → see blockers + downstream + PPA score + DoR verdict per RFC §7.2
+- [ ] #4 Dashboard color-coding by status: To Do = blue, In Progress = yellow, Needs Clarification = red, Done = green per RFC §7.2
+- [ ] #5 Dashboard reads the latest `$ARTIFACTS_DIR/_deps/snapshot.<timestamp>.jsonl` (Phase 1 artifact); honors the Q6 "best-effort consistency" contract — surfaces dangling-edge warnings rather than crashing
+- [ ] #6 Behind feature flag `AI_SDLC_DEPS_COMPOSITION` (default off); when off, weekly digest + dashboard render the pre-RFC-0014 baseline (no critical-path section, no graph view)
+- [ ] #7 Hermetic snapshot test for the digest section (top-3-5 sort, downstream-count rendering, empty-graph degradation)
+- [ ] #8 New code reaches 80%+ patch coverage; full workspace `pnpm build && pnpm test && pnpm lint && pnpm format:check` clean
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-167.5 - Phase-5-Soak-and-flag-promotion.md
+++ b/backlog/tasks/aisdlc-167.5 - Phase-5-Soak-and-flag-promotion.md
@@ -1,0 +1,54 @@
+---
+id: AISDLC-167.5
+title: 'Phase 5: Soak + flag promotion'
+status: To Do
+assignee: []
+created_date: '2026-05-03'
+labels:
+  - rfc-0014
+  - phase-5
+  - soak
+  - flag-promotion
+milestone: m-3
+dependencies:
+  - AISDLC-167.3
+  - AISDLC-167.4
+parent_task_id: AISDLC-167
+references:
+  - spec/rfcs/RFC-0014-dependency-graph-composition.md
+  - docs/operations/operator-runbook.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase 5 of RFC-0014. Run with `AI_SDLC_DEPS_COMPOSITION=off` (default) → operators opt in via env override → measure dispatch quality vs PPA-only baseline → promote flag to default-on when corpus criteria are met. Per RFC §11 Phase 5.
+
+## Soak policy — corpus-driven, NOT calendar-driven
+
+Per maintainer directive (2026-05-01): this phase ships when:
+- **Dispatch correctness > 95%** measured against the pipeline corpus (composition vs PPA-only baseline; "correctness" = dispatcher's top pick matches an operator's manual top pick on a held-out corpus slice), AND
+- **No operator override-rate spike** vs PPA-only baseline (override-rate metric from RFC-0011 §7.4 framework, repurposed for dispatch overrides).
+
+Whichever comes first. Calendar duration is a side-effect, not a gate.
+
+## Promotion mechanics
+
+- Default `AI_SDLC_DEPS_COMPOSITION=off` until corpus criteria met.
+- Operators opt-in via env override (per-session) during soak.
+- When promotion criteria met, flip default to `on` in a single, reviewable PR. Document the corpus measurement that justified promotion.
+- Hybrid corpus-OR-operator-override promotion model available (matches RFC-0011 / AISDLC-161 pattern) if the corpus is too small for statistical confidence within reasonable wall-clock.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Soak harness measures dispatch correctness for composition vs PPA-only baseline against a held-out corpus slice; "correctness" = dispatcher's top pick matches an operator's manual top pick
+- [ ] #2 Soak harness measures operator override-rate (dispatch overrides), composing with the existing RFC-0011 §7.4 override-rate framework where reusable
+- [ ] #3 Operator opt-in path documented: per-session `AI_SDLC_DEPS_COMPOSITION=on` env override; runbook entry in `docs/operations/operator-runbook.md` covering opt-in, observation, and revert
+- [ ] #4 Promotion criteria gate: dispatch correctness > 95% AND no operator-override-rate spike vs PPA-only baseline; both metrics published to the existing dashboard surface
+- [ ] #5 Default-on flip is a separate, reviewable PR that links to the corpus measurement justifying promotion; rollback procedure documented (flip env back to `off`, single-line revert)
+- [ ] #6 Operator runbook (`docs/operations/operator-runbook.md`) extended with composition-specific failure modes: snapshot validation failures, dispatch ordering anomalies, blast-radius callout misfires
+- [ ] #7 Parent AISDLC-167 ACs #2, #3, #5 closed by the work in this sub-task (flag promoted, dogfood pipeline running with composition end-to-end, runbook extended)
+- [ ] #8 Soak measurement methodology + the promotion decision documented in `pipeline-cli/docs/deps.md` so future phases can reuse the corpus-driven pattern
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

Creates the AISDLC-167 parent task + 5 sub-tasks (167.1–167.5) for RFC-0014 (Dependency Graph Composition), closing the Create-Before-Execution gap. AISDLC-166 was dispatched directly against RFC-0014 Phase 1 before this parent task tree existed; once 166's PR merges it should be cross-referenced as also closing AISDLC-167.1.

Mirrors AISDLC-70 (RFC-0010) and AISDLC-115 (RFC-0011) parent-task patterns: parent captures the 5-phase decomposition + critical path; sub-tasks each carry phase-specific ACs derived from RFC-0014 §11 + the relevant section (§4–§9) and honor all 6 Q1–Q6 resolutions from RFC v3 §12.

## Files

- `backlog/tasks/aisdlc-167 - RFC-0014-Dependency-Graph-Composition.md` (parent, 6 ACs)
- `backlog/tasks/aisdlc-167.1 - Phase-1-Snapshot-artifact.md` (8 ACs; honors Q2/Q3/Q6)
- `backlog/tasks/aisdlc-167.2 - Phase-2-PPA-composition.md` (8 ACs; honors Q1/Q4)
- `backlog/tasks/aisdlc-167.3 - Phase-3-DoR-composition.md` (8 ACs; honors Q3/Q5)
- `backlog/tasks/aisdlc-167.4 - Phase-4-Slack-and-dashboard-digest.md` (8 ACs)
- `backlog/tasks/aisdlc-167.5 - Phase-5-Soak-and-flag-promotion.md` (8 ACs)

## Dependencies (per RFC-0014 §11 critical path)

- 167.1 → none (Phase 1 in flight as AISDLC-166; close 167.1 when 166 merges)
- 167.2 → 167.1
- 167.3 → 167.2
- 167.4 → 167.2 (parallelizable with 167.3)
- 167.5 → 167.3, 167.4

## Defaults documented (operator-away)

- **Milestone**: `m-3` (matches RFC-0011 / AISDLC-115; consistent with the modern dispatch/composition phase. RFC-0010 used `m-2`).
- **Open-question coverage**: every resolution in RFC §12 v3 (Q1–Q6) has a corresponding AC in the right phase sub-task; cross-walk:
  - Q1 (tiebreak: depth-then-recency) → 167.2 #2
  - Q2 (30d rolling + event-tagged retention; `cli-deps gc` + `inspect --tag`) → 167.1 #4
  - Q3 (`externalDependencies:` frontmatter, surfaced not blocking) → 167.1 #5 + 167.3 #4
  - Q4 (no cache, recompute per dispatch) → 167.2 #5
  - Q5 (`dor-bypass` × high-radius FYI variant) → 167.3 #3
  - Q6 (per-task atomic read; consistency contract documented) → 167.1 #6
- **Soak policy** (Phase 5): corpus-driven, NOT calendar-driven, per maintainer directive 2026-05-01. Hybrid corpus-OR-operator-override promotion model available (matches RFC-0011 / AISDLC-161).
- **Cross-reference for AISDLC-166 → 167.1**: noted in the parent description AND in 167.1's body. When 166 merges, close 167.1 with a back-pointer to 166's PR/SHA in the final summary; no re-implementation.

## Why I did NOT create an extra "meta-task" file in completed/

The original task prompt step 4 said "Create AISDLC-167 itself (this meta-task) → backlog/completed/aisdlc-167 - ...md" but that conflicts with step 3 which already creates the parent file. AISDLC-70 and AISDLC-115 parent patterns both keep the parent in `backlog/tasks/` with `status: To Do` until all sub-tasks complete — the parent IS the umbrella, not a "create sub-tasks chore" that ships to completed/. I followed the AISDLC-70/115 pattern. If the operator intended a separate self-documenting meta-task, that can be added in a follow-up PR.

## Verification

- `npx backlog-drift@0.1.3 check --task AISDLC-167 [167.1..167.5]` — clean (no drift)
- `bash scripts/check-backlog-ascii.sh` — clean
- All 6 references in parent + sub-task frontmatter resolve to existing paths
- Pre-commit hook ran (lint-staged matched 0 files, typecheck across workspace passed after `pnpm build` materialized `@ai-sdlc/reference`, `@ai-sdlc/orchestrator`, `@ai-sdlc/pipeline-cli` declarations)
- Pushed with `AI_SDLC_SKIP_COVERAGE_GATE=1` (docs-only PR; no code coverage to measure)

## Test plan

- [x] All 6 task files commit cleanly under `backlog/tasks/`
- [x] Drift check passes for all 6 IDs
- [x] Each sub-task references its parent via `parent_task_id: AISDLC-167`
- [x] Each sub-task's `dependencies:` field matches the RFC §11 critical path
- [ ] Operator confirms milestone `m-3` is correct for RFC-0014 (or asks for `m-4` etc.)
- [ ] When AISDLC-166's PR merges, close AISDLC-167.1 with a back-pointer to 166

🤖 Generated with [Claude Code](https://claude.com/claude-code)