### PR TITLE
chore(backlog): file AISDLC-179 + 180 (orchestrator bugs from dogfood test)

### DIFF
--- a/backlog/tasks/aisdlc-179 - Orchestrator-tick-loop-re-dispatches-tasks-already-In-Progress-no-in-flight-tracking.md
+++ b/backlog/tasks/aisdlc-179 - Orchestrator-tick-loop-re-dispatches-tasks-already-In-Progress-no-in-flight-tracking.md
@@ -1,0 +1,75 @@
+---
+id: AISDLC-179
+title: >-
+  Orchestrator: tick loop re-dispatches tasks already In Progress (no in-flight
+  tracking)
+status: To Do
+assignee: []
+created_date: '2026-05-04 02:48'
+labels:
+  - bug
+  - orchestrator
+  - rfc-0015
+  - framework-bug
+  - critical
+dependencies: []
+references:
+  - pipeline-cli/src/orchestrator/loop.ts
+  - pipeline-cli/src/orchestrator/index.ts
+  - pipeline-cli/src/deps/
+  - spec/rfcs/RFC-0015-autonomous-pipeline-orchestrator.md
+  - spec/rfcs/RFC-0025-framework-quality-monitoring.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem
+
+Witness test of `cli-orchestrator start` (2026-05-04 ~02:30 UTC) on AISDLC-178.1: tick 1 dispatched the task, completed Steps 0-5 (worktree created, status flipped to In Progress, dev subagent prompt built — Step 5 is async dev subagent dispatch). Tick 2 fired 30s later and **re-dispatched the same AISDLC-178.1**, failing at Step 3 with "branch already exists" because tick 1's worktree was still occupied. Tick 3 fired and did the same. Each failed tick wastes a frontier-resolve + dispatch attempt.
+
+## Root cause
+
+The orchestrator's tick loop polls the frontier independently each tick. The frontier resolver (`cli-deps frontier` semantics) excludes tasks in `backlog/completed/` but does NOT exclude tasks with `status: In Progress`. With `maxConcurrent: 1` and a single in-flight task, EVERY subsequent tick sees the same task on top of the frontier and re-dispatches.
+
+Looking at the data: the orchestrator's "in-flight" tracking should be:
+- Either an in-memory map of `taskId → currentDispatch` consulted before each dispatch
+- Or filter the frontier by `status != 'In Progress'`
+- Or both
+
+Today: neither. Tick 1's dev subagent runs asynchronously; tick 2 has no idea it's still running.
+
+## Stderr observed
+
+```
+Likely cause: branch already exists. Run `/ai-sdlc cleanup AISDLC-178.1` first or pick a different task.
+[orchestrator] escalation: task=AISDLC-178.1 reason=git worktree add failed for branch 'ai-sdlc/aisdlc-178.1-': ... branch named 'ai-sdlc/aisdlc-178.1-' already exists
+```
+
+## Severity
+
+**Critical.** This makes `cli-orchestrator start` (the autonomous polling loop, RFC-0015 Phase 1's primary surface) effectively unusable — it spirals into wasted-dispatch loops the moment ANY dispatch takes longer than the tick interval (30s default). Real dispatches always take longer (dev subagent + reviewers + PR open is 5-15 min). So the loop fires 10-30 wasted dispatches per real one.
+
+Per RFC-0025 framework-quality taxonomy: this is `framework-contract-violated` + `framework-silent-failure` — the orchestrator silently retries instead of recognizing in-flight state.
+
+## Composes with AISDLC-175, 176, 177
+
+- AISDLC-175 (orphan-parent filter) — separate concern
+- AISDLC-176 (dev JSON contract retry) — separate concern  
+- AISDLC-177 (rollback on dev-failed) — separate but adjacent: 177 cleans up after failures; THIS bug prevents the original dispatch from completing in the first place
+
+This bug should ship FIRST among 175-177 + this one — without in-flight tracking, the others' fixes can't be tested cleanly because the orchestrator dispatches in parallel storms.
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- SECTION:DESCRIPTION:END -->
+
+- [ ] #1 pipeline-cli/src/orchestrator/loop.ts maintains an in-memory map of in-flight task dispatches (taskId → dispatchPromise/state)
+- [ ] #2 Pre-dispatch filter chain rejects any task whose ID is in the in-flight map; emits OrchestratorTaskAlreadyInFlight event with the existing dispatch ID
+- [ ] #3 Frontier resolver additionally filters tasks with status: In Progress (defense in depth in case in-flight map is lost on restart)
+- [ ] #4 On dispatch completion (success OR failure), task is removed from in-flight map
+- [ ] #5 On orchestrator restart, in-flight map is reconstructed from filesystem (active worktree presence) so a restart doesn't re-dispatch tasks whose worktrees are still around
+- [ ] #6 Unit tests cover: concurrent tick attempts on same task, restart-recovery, in-flight map cleanup on success + failure
+- [ ] #7 Witness regression test: cli-orchestrator start with tick-interval-sec=2 and a fixture task that takes 10s; verify only ONE dispatch fires across the 5 ticks the test runs
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-180 - Pipeline-branch-slug-computation-produces-empty-garbled-slug-for-YAML-block-scalar-titles.md
+++ b/backlog/tasks/aisdlc-180 - Pipeline-branch-slug-computation-produces-empty-garbled-slug-for-YAML-block-scalar-titles.md
@@ -1,0 +1,72 @@
+---
+id: AISDLC-180
+title: >-
+  Pipeline: branch slug computation produces empty/garbled slug for YAML
+  block-scalar titles
+status: To Do
+assignee: []
+created_date: '2026-05-04 02:49'
+labels:
+  - bug
+  - pipeline-cli
+  - framework-bug
+dependencies: []
+references:
+  - pipeline-cli/src/steps/
+  - .ai-sdlc/pipeline-backlog.yaml
+  - >-
+    backlog/tasks/aisdlc-178.1 -
+    Phase-1-Skeleton-—-cli-tui-binary-Ink-scaffold-Overview-Mode-placeholder-panes.md
+  - spec/rfcs/RFC-0025-framework-quality-monitoring.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem
+
+Witness test of `cli-orchestrator start` on AISDLC-178.1 (2026-05-04) created a worktree on branch `ai-sdlc/aisdlc-178.1-` — note the **trailing dash with no slug**. The branch pattern is `ai-sdlc/{issueIdLower}-{slug}` from `.ai-sdlc/pipeline-backlog.yaml`. The slug came out empty.
+
+## Root cause
+
+The task file's title field uses YAML block-scalar literal:
+
+```yaml
+title: >-
+  Phase 1: Skeleton — cli-tui binary, Ink scaffold, Overview Mode placeholder
+  panes
+```
+
+The `>-` indicator means "folded scalar, strip trailing newlines." The actual title string is `"Phase 1: Skeleton — cli-tui binary, Ink scaffold, Overview Mode placeholder panes"`.
+
+But the orchestrator's slug computation likely reads the raw frontmatter line `title: >-` and treats `>-` as the title (plus the next line as continuation). Then slug normalization (`tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g'`) strips `>-` → empty string → trailing dash with no body.
+
+Same root cause as a previously-noted cosmetic issue: `cli-deps frontier` displays such tasks with title `>-`. The cosmetic bug now has a critical real-world consequence — broken branch names break PR creation, attestation signing (which uses branch name as part of the contentHash context), and worktree-to-task mapping.
+
+## Reproducer
+
+Any task created via `mcp__backlog__task_create` with a long title gets the YAML block-scalar treatment by the backlog.md serializer. Several recently-created tasks have this shape: AISDLC-174, 175, 176, 177, 178.1, 178.2 (all decimal-suffix sub-tasks created in this session).
+
+## Fix
+
+The frontmatter parser used by the slug computer (and by `cli-deps` for display) MUST use a real YAML parser (`js-yaml` or equivalent) to handle block scalars correctly. The shell-pipeline approach in `.ai-sdlc/pipeline-backlog.yaml` for slug computation is the wrong tool — slug should be computed in TS code that already imports a YAML parser.
+
+Suggested location: `pipeline-cli/src/steps/02-compute-branch.ts` (or wherever Step 2 lives) should parse the task file with `js-yaml.load()` and read `parsed.title` instead of any line-based regex.
+
+## Severity
+
+**High.** Every task with a long title (most operator-created tasks) currently produces a malformed branch. PRs would fail to open with the broken slug; even if they opened, the branch name is unhelpful for PR review (just `ai-sdlc/aisdlc-178.1-` tells the reviewer nothing).
+
+Per RFC-0025 taxonomy: `framework-contract-violated` (branch pattern contract is `{slug}` non-empty) + `framework-determinism-violated` (same task title producing different branch results across runs depending on parser).
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+<!-- SECTION:DESCRIPTION:END -->
+
+- [ ] #1 pipeline-cli/src/steps/ slug computation uses js-yaml (or equivalent real YAML parser) to read task title; never line-regex-based parsing of frontmatter
+- [ ] #2 Slug normalization preserves at least 1 alphanumeric character; if input title produces empty slug, fail loud with clear error (don't silently emit empty)
+- [ ] #3 cli-deps frontier displays unwrapped multi-line titles correctly (cosmetic fix that falls out of the same parser correction)
+- [ ] #4 Unit tests cover: short title, long title with em-dashes (matches AISDLC-178.1 case), title with all special chars, title that would produce empty slug post-normalization (must fail loud)
+- [ ] #5 Regression test: parse all existing backlog/tasks/aisdlc-* files; verify slug computation produces non-empty slugs for every one
+<!-- AC:END -->


### PR DESCRIPTION
Two critical framework bugs surfaced during the autonomous orchestrator dogfood (2026-05-04 ~02:30 UTC) on AISDLC-178.1.

## AISDLC-179 — concurrent re-dispatch (no in-flight tracking)
Tick loop re-picks tasks already In Progress. Fired 3 wasted dispatches in 90s before manual SIGTERM. Makes `cli-orchestrator start` effectively unusable until fixed. **Should ship FIRST** among 175/176/177/179.

## AISDLC-180 — empty branch slug from YAML block-scalar titles
Branch came out as `ai-sdlc/aisdlc-178.1-` (trailing dash). Affects every task with a long title (most operator-created). Root cause: line-regex on frontmatter instead of real YAML parser.

Both classified per RFC-0025 taxonomy. Witness logs preserved on the dogfood machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)