### PR TITLE
fix: use js-yaml for frontmatter parsing in slug computation (AISDLC-180)

### DIFF
--- a/pipeline-cli/package.json
+++ b/pipeline-cli/package.json
@@ -86,9 +86,11 @@
     "cli": "node bin/ai-sdlc-pipeline.mjs"
   },
   "dependencies": {
+    "js-yaml": "^4.1.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "@types/yargs": "^17.0.33",
     "@vitest/coverage-v8": "^3.2.4",

--- a/pipeline-cli/src/steps/01-validate.test.ts
+++ b/pipeline-cli/src/steps/01-validate.test.ts
@@ -140,6 +140,41 @@ describe('Step 1 — helpers', () => {
     expect(parseSimpleYaml(yaml).id).toBe('X');
   });
 
+  // AISDLC-180 — js-yaml-backed parser handles block-scalar titles correctly.
+  it('parseSimpleYaml decodes folded block-scalar (>-) titles to the unwrapped string', () => {
+    const yaml =
+      `id: AISDLC-178.1\n` +
+      `title: >-\n` +
+      `  Phase 1: Skeleton — cli-tui binary, Ink scaffold, Overview Mode placeholder\n` +
+      `  panes\n` +
+      `status: To Do\n`;
+    const parsed = parseSimpleYaml(yaml);
+    expect(parsed.id).toBe('AISDLC-178.1');
+    // The legacy line-based parser would have captured `>-` here; js-yaml
+    // unwraps the folded scalar into a single-line string with single spaces
+    // joining wrapped lines.
+    expect(parsed.title).toBe(
+      'Phase 1: Skeleton — cli-tui binary, Ink scaffold, Overview Mode placeholder panes',
+    );
+    expect(parsed.status).toBe('To Do');
+  });
+
+  it('parseSimpleYaml decodes literal block-scalar (|-) titles preserving line breaks', () => {
+    const yaml = `title: |-\n  line one\n  line two\n`;
+    const parsed = parseSimpleYaml(yaml);
+    expect(parsed.title).toBe('line one\nline two');
+  });
+
+  it('parseSimpleYaml returns {} for empty input rather than throwing', () => {
+    expect(parseSimpleYaml('')).toEqual({});
+    expect(parseSimpleYaml('   \n  \n')).toEqual({});
+  });
+
+  it('parseSimpleYaml throws on malformed YAML', () => {
+    // Tab indentation in a list — js-yaml rejects this with a clear error.
+    expect(() => parseSimpleYaml('foo:\n\t- bad\n')).toThrow(/YAML parse error/);
+  });
+
   it('parseTaskFile picks up permittedExternalPaths', () => {
     const path = writeTaskFile(tmp, {
       id: 'AISDLC-11',

--- a/pipeline-cli/src/steps/01-validate.ts
+++ b/pipeline-cli/src/steps/01-validate.ts
@@ -16,6 +16,7 @@
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { load as yamlLoad } from 'js-yaml';
 import type { TaskSpec, ValidateResult } from '../types.js';
 
 export interface ValidateTaskOptions {
@@ -104,61 +105,37 @@ export function parseTaskFile(filePath: string): TaskSpec {
 }
 
 /**
- * Tiny YAML subset parser sufficient for backlog task frontmatter:
- * scalar `key: value`, `key: 'value'`, `key: "value"`, and YAML list
- * (`key:` followed by `  - item` lines). Doesn't handle nested objects or
- * flow style — Backlog.md doesn't emit those for the keys we read.
+ * Parse a YAML frontmatter block into a flat `Record<string, unknown>`.
+ *
+ * Backed by `js-yaml` (vs. the line-based regex parser that previously lived
+ * here, AISDLC-180) so block-scalar titles (`title: >- \n  long wrapped …`)
+ * decode to the actual string instead of capturing the indicator literal
+ * `>-` as the value. The slug computer in `02-compute-branch.ts` and the
+ * `cli-deps frontier` display both depended on this — the regex parser
+ * silently produced empty slugs and stripped frontier titles to `>-`.
+ *
+ * Returns `{}` for empty / whitespace-only input or when the document parses
+ * to a non-object scalar (e.g. a bare string), so callers can keep treating
+ * the result as a key-lookup map without a typeof guard. Throws on YAML
+ * syntax errors — call sites already wrap parse failures in `try/catch` and
+ * surface a `failed to parse task file` reason.
+ *
+ * Lists of nested objects (e.g. `externalDependencies:`) ARE returned via
+ * js-yaml as arrays of `Record<string, unknown>`, so the dedicated walker
+ * in `parseExternalDependenciesBlock` is no longer strictly necessary —
+ * left in place for backwards-compat while RFC-0014 callers migrate.
  */
 export function parseSimpleYaml(raw: string): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  const lines = raw.split('\n');
-  let currentList: string | null = null;
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (!line.trim() || line.trim().startsWith('#')) {
-      currentList = null;
-      continue;
-    }
-
-    // List continuation? `  - <item>`
-    const listItem = line.match(/^\s+- (.*)$/);
-    if (listItem && currentList) {
-      const arr = (out[currentList] as unknown[]) ?? [];
-      arr.push(stripQuotes(listItem[1]));
-      out[currentList] = arr;
-      continue;
-    }
-
-    // Scalar `key: value` or list opener `key:`
-    const kv = line.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
-    if (!kv) {
-      currentList = null;
-      continue;
-    }
-    const key = kv[1];
-    const value = kv[2].trim();
-    if (value === '') {
-      // Could be opening a list OR opening an object. Initialise as empty list;
-      // stripping unknown nested objects below.
-      out[key] = [];
-      currentList = key;
-    } else {
-      out[key] = stripQuotes(value);
-      currentList = null;
-    }
+  if (!raw.trim()) return {};
+  let parsed: unknown;
+  try {
+    parsed = yamlLoad(raw);
+  } catch (err) {
+    throw new Error(`YAML parse error: ${(err as Error).message}`);
   }
-  return out;
-}
-
-function stripQuotes(s: string): string {
-  const trimmed = s.trim();
-  if (
-    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
-    (trimmed.startsWith('"') && trimmed.endsWith('"'))
-  ) {
-    return trimmed.slice(1, -1);
-  }
-  return trimmed;
+  if (parsed === null || parsed === undefined) return {};
+  if (typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+  return parsed as Record<string, unknown>;
 }
 
 export async function validateTask(opts: ValidateTaskOptions): Promise<ValidateResult> {

--- a/pipeline-cli/src/steps/02-compute-branch.test.ts
+++ b/pipeline-cli/src/steps/02-compute-branch.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdirSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { computeBranchName, readBranchPattern, slugify } from './02-compute-branch.js';
+import { parseTaskFile } from './01-validate.js';
 import { cleanupTmpProject, makeTmpProject } from '../__test-helpers/make-task.js';
 import type { TaskSpec } from '../types.js';
 
@@ -70,6 +72,119 @@ describe('Step 2 — slugify', () => {
 
   it('strips leading/trailing dashes', () => {
     expect(slugify('--abc--')).toBe('abc');
+  });
+});
+
+// AISDLC-180 — guard against the witness-test regression where YAML
+// block-scalar titles slipped past slug normalisation as `>-` and produced
+// branch names like `ai-sdlc/aisdlc-178.1-` (trailing dash, no slug body).
+describe('Step 2 — slugify (AISDLC-180 fixtures)', () => {
+  it('handles short single-word titles', () => {
+    expect(slugify('Demo')).toBe('demo');
+  });
+
+  it('handles long titles with em-dashes (AISDLC-178.1 reproducer)', () => {
+    const title =
+      'Phase 1: Skeleton — cli-tui binary, Ink scaffold, Overview Mode placeholder panes';
+    const slug = slugify(title);
+    expect(slug).not.toBe('');
+    expect(slug.startsWith('phase-1-skeleton')).toBe(true);
+    // Em-dash is non-alphanumeric so it gets collapsed into a `-`.
+    expect(slug).not.toContain('—');
+    // 50-char cap still applies.
+    expect(slug.length).toBeLessThanOrEqual(50);
+  });
+
+  it('handles titles with assorted special chars + unicode punctuation', () => {
+    const title = 'API: don\'t break — "quoted" things & ™symbols / slashes (parens) [brackets]';
+    const slug = slugify(title);
+    expect(slug).toMatch(/^api-don-t-break/);
+    // Every special char run collapses to a single `-`; no doubled dashes.
+    expect(slug).not.toMatch(/--/);
+  });
+
+  it('returns empty string for a title with no alphanumeric chars (caller fails loud)', () => {
+    expect(slugify('>-')).toBe('');
+    expect(slugify('— — —')).toBe('');
+    expect(slugify('!!!')).toBe('');
+  });
+});
+
+describe('Step 2 — computeBranchName fail-loud (AISDLC-180)', () => {
+  it('throws when slug normalisation produces empty string', async () => {
+    const evilTask: TaskSpec = {
+      id: 'AISDLC-EMPTY',
+      // The exact pre-fix bug: legacy parser captured `>-` as the title.
+      title: '>-',
+      status: 'To Do',
+      acceptanceCriteria: ['a'],
+      acceptanceCriteriaChecked: [false],
+      description: '',
+      rawBody: '',
+      filePath: '',
+    };
+    await expect(
+      computeBranchName({ taskId: 'AISDLC-EMPTY', task: evilTask, workDir: tmp }),
+    ).rejects.toThrow(/slug normalisation produced empty string/);
+  });
+
+  it('does NOT throw when the branch pattern omits {slug}', async () => {
+    const evilTask: TaskSpec = {
+      id: 'AISDLC-EMPTY',
+      title: '!!!',
+      status: 'To Do',
+      acceptanceCriteria: ['a'],
+      acceptanceCriteriaChecked: [false],
+      description: '',
+      rawBody: '',
+      filePath: '',
+    };
+    // Slug-less pattern is fine even when the title produces empty slug.
+    const r = await computeBranchName({
+      taskId: 'AISDLC-EMPTY',
+      task: evilTask,
+      workDir: tmp,
+      defaultPattern: 'manual/{issueIdLower}',
+    });
+    expect(r.branch).toBe('manual/aisdlc-empty');
+    expect(r.slug).toBe('');
+  });
+});
+
+// Regression: parse every backlog task on disk and confirm slug computation
+// produces a non-empty result. Catches the AISDLC-178.1-shape regression and
+// any future title shape that survives slugify() to an empty string. Runs
+// against the live repo by walking up from the test file's URL.
+describe('Step 2 — backlog regression (AISDLC-180)', () => {
+  it('every backlog/tasks/aisdlc-*.md file produces a non-empty slug', async () => {
+    const repoRoot = resolve(fileURLToPath(import.meta.url), '..', '..', '..', '..');
+    const tasksDir = join(repoRoot, 'backlog', 'tasks');
+    const files = readdirSync(tasksDir).filter((n) => n.endsWith('.md'));
+    expect(files.length).toBeGreaterThan(0);
+
+    const failures: { file: string; title: string; slug: string }[] = [];
+    for (const name of files) {
+      const filePath = join(tasksDir, name);
+      let task: TaskSpec;
+      try {
+        task = parseTaskFile(filePath);
+      } catch {
+        // Files that don't parse aren't slug-able — surface them as failures.
+        failures.push({ file: name, title: '<parse-error>', slug: '' });
+        continue;
+      }
+      const slug = slugify(task.title);
+      if (slug === '') {
+        failures.push({ file: name, title: task.title, slug });
+      }
+    }
+
+    if (failures.length > 0) {
+      const detail = failures
+        .map((f) => `  ${f.file} → title=${JSON.stringify(f.title)} slug=${JSON.stringify(f.slug)}`)
+        .join('\n');
+      throw new Error(`${failures.length} backlog task(s) produced an empty slug:\n${detail}`);
+    }
   });
 });
 

--- a/pipeline-cli/src/steps/02-compute-branch.ts
+++ b/pipeline-cli/src/steps/02-compute-branch.ts
@@ -55,8 +55,30 @@ export function readBranchPattern(workDir: string, fallback: string = DEFAULT_PA
 
 export async function computeBranchName(opts: ComputeBranchOptions): Promise<ComputeBranchResult> {
   const taskIdLower = opts.taskId.toLowerCase();
-  const slug = slugify(opts.task.title);
   const pattern = readBranchPattern(opts.workDir, opts.defaultPattern ?? DEFAULT_PATTERN);
+  const slug = slugify(opts.task.title);
+
+  // AISDLC-180 — fail loud when the slug normalisation strips the title to
+  // an empty string. The previous behaviour silently produced branches like
+  // `ai-sdlc/aisdlc-178.1-` (trailing dash, no slug body), which then broke
+  // worktree creation across multiple tasks (every empty-slug task tried to
+  // claim the same `ai-sdlc/aisdlc-NNN-` branch shape) and made PR titles
+  // unhelpful. The most common trigger was a YAML block-scalar title
+  // (`title: >- \n  long wrapped …`) that the legacy line-based frontmatter
+  // parser captured as the literal indicator `>-` — that path is now fixed
+  // by the js-yaml parser in `parseSimpleYaml`, but we still guard here so
+  // any future title shape that produces an empty slug surfaces with a
+  // clear error rather than a malformed branch name.
+  if (slug === '' && pattern.includes('{slug}')) {
+    throw new Error(
+      `slug normalisation produced empty string from title ${JSON.stringify(opts.task.title)} ` +
+        `(task ${opts.taskId}); branch pattern ${JSON.stringify(pattern)} requires a non-empty {slug}. ` +
+        `The title is missing alphanumeric characters after kebab-case normalisation — ` +
+        `if the title field uses YAML block-scalar (>- or |-), confirm the frontmatter parser ` +
+        `decodes it to the unwrapped string before slugify().`,
+    );
+  }
+
   const branch = pattern.replace(/\{issueIdLower\}/g, taskIdLower).replace(/\{slug\}/g, slug);
   const worktreePath = join(opts.workDir, '.worktrees', taskIdLower);
   return { branch, worktreePath, slug, taskIdLower };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,10 +230,16 @@ importers:
 
   pipeline-cli:
     dependencies:
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.1
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
     devDependencies:
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.9
@@ -1189,6 +1195,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -3604,6 +3613,8 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 


### PR DESCRIPTION
Closes AISDLC-180.

The line-based regex frontmatter parser was treating YAML block-scalar literals (`title: >-`) as the title itself, then slug normalization stripped `>-` to empty, producing branch names like `ai-sdlc/aisdlc-178.1-` (trailing dash, no slug).

Fix: use js-yaml to parse the frontmatter properly. Also fail-loud when the computed slug is empty post-normalization.

37 tests pass (20 in 01-validate + 17 in 02-compute-branch — new tests cover the YAML block-scalar case + the empty-slug-throws case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)