### PR TITLE
fix(orchestrator): filter orphan-parent tasks from frontier dispatch (AISDLC-175)

### DIFF
--- a/pipeline-cli/docs/orchestrator.md
+++ b/pipeline-cli/docs/orchestrator.md
@@ -135,18 +135,43 @@ Returns JSON of the form:
 surface so operators can preview what the loop would pick up before turning
 the flag on.
 
-## Pre-dispatch admission filters (RFC-0015 Phase 3 / §4.3)
+## Pre-dispatch admission filters (RFC-0015 Phase 3 / §4.3, AISDLC-175)
 
 Every tick, BEFORE calling `executePipeline()`, the orchestrator walks each
-candidate through three filters in order. The chain short-circuits on the
+candidate through four filters in order. The chain short-circuits on the
 first failure so downstream filters don't waste work on a candidate that's
 already going to be skipped.
 
 | # | Filter | Reads | Skip event |
 |---|---|---|---|
+| 0 | **OrphanParent** | In-memory dependency graph (`parent_task_id` reverse-index) | `OrchestratorOrphanParent{completedChildren}` |
 | 1 | **DependencyReadiness** | In-memory dependency graph | `OrchestratorBlockedByDependency{blockers}` |
 | 2 | **DorReadiness** | `<artifactsDir>/_dor/calibration.jsonl` (latest entry per task) + frontmatter `labels:` for `dor-bypass` | `OrchestratorBlockedByDor{verdict, signedAt}` |
 | 3 | **ExternalDependencies** | Task frontmatter `externalDependencies:` + `<artifactsDir>/_orchestrator/cleared-external-deps.json` | `OrchestratorAwaitingExternal{externalDeps, allExternalDeps}` |
+
+### Filter 0 — OrphanParent (AISDLC-175)
+
+Detects parent tasks whose every declared child is already in
+`backlog/completed/`. A candidate X is an orphan parent iff ≥1 OTHER task
+carries `parent_task_id: X` AND every such child has `status === 'completed'`.
+The orchestrator skips these candidates so it stops dispatching developer
+subagents to do bookkeeping closures (parent file `git mv` to `completed/`)
+the framework should handle. Witness: 2026-05-04 dogfood run picked up
+AISDLC-70 (RFC-0010 parent with all 9 sub-tasks already in `completed/`)
+even though PR #231 had already shipped its closure.
+
+The filter ADMITS:
+
+- Candidates with no declared children (a leaf task or top-level task
+  without a phased breakdown).
+- Candidates with mixed children (≥1 still open — there's real downstream
+  work the parent is gating).
+- Candidates that themselves carry `parent_task_id` (closing a sub-task is
+  real dispatch work even if the sub-task has its own grandchildren).
+
+Runs first because it's the cheapest filter (constant-time graph lookup)
+AND the most decisive — there's no point asking the other three filters
+about a candidate that isn't real work at all.
 
 ### Filter 1 — DependencyReadiness
 
@@ -216,6 +241,7 @@ Every evaluated candidate writes a structured trace block to the logger:
 
 ```text
 [orchestrator] filter trace for AISDLC-92:
+  - Orphan-parent check: passed
   - Dependency check: passed
   - DoR readiness: passed
   - External deps: failed (1 manual external dep(s) unresolved: sec-review)

--- a/pipeline-cli/src/__test-helpers/make-task.ts
+++ b/pipeline-cli/src/__test-helpers/make-task.ts
@@ -38,6 +38,12 @@ export interface MakeTaskOptions {
    * completed/).
    */
   completed?: boolean;
+  /**
+   * Optional `parent_task_id:` frontmatter value. AISDLC-175 — used by
+   * dependency-graph + orphan-parent filter tests to simulate sub-tasks
+   * pointing at a parent (e.g. AISDLC-70.1 → AISDLC-70).
+   */
+  parentTaskId?: string;
 }
 
 /**
@@ -88,6 +94,9 @@ export function writeTaskFile(workDir: string, opts: MakeTaskOptions): string {
   if (opts.dependencies && opts.dependencies.length > 0) {
     fmLines.push('dependencies:');
     for (const d of opts.dependencies) fmLines.push(`  - ${d}`);
+  }
+  if (opts.parentTaskId) {
+    fmLines.push(`parent_task_id: ${opts.parentTaskId}`);
   }
 
   const acLines = acs.map((ac, i) => `- [${checked[i] ? 'x' : ' '}] #${i + 1} ${ac}`).join('\n');

--- a/pipeline-cli/src/deps/dependency-graph.test.ts
+++ b/pipeline-cli/src/deps/dependency-graph.test.ts
@@ -76,6 +76,21 @@ describe('buildDependencyGraph', () => {
     expect(g.nodes.get('aisdlc-1')?.dependencies).toEqual(['AISDLC-2', 'AISDLC-3']);
   });
 
+  it('parses parent_task_id frontmatter (AISDLC-175)', () => {
+    // Sub-tasks carry `parent_task_id: AISDLC-X` so the orphan-parent
+    // filter can detect parent tasks whose every child is in completed/.
+    writeTaskFile(tmp, { id: 'AISDLC-70', title: 'parent' });
+    writeTaskFile(tmp, {
+      id: 'AISDLC-70.1',
+      title: 'phase 1',
+      parentTaskId: 'AISDLC-70',
+      completed: true,
+    });
+    const g = buildDependencyGraph({ workDir: tmp });
+    expect(g.nodes.get('aisdlc-70')?.parentTaskId).toBe('');
+    expect(g.nodes.get('aisdlc-70.1')?.parentTaskId).toBe('AISDLC-70');
+  });
+
   it('skips non-md files', () => {
     writeTaskFile(tmp, { id: 'AISDLC-1', title: 'a' });
     writeFileSync(join(tmp, 'backlog', 'tasks', 'README.txt'), 'ignore me\n', 'utf8');

--- a/pipeline-cli/src/deps/dependency-graph.ts
+++ b/pipeline-cli/src/deps/dependency-graph.ts
@@ -88,6 +88,15 @@ export interface DependencyNode {
   lastModified: string;
   /** Path to the on-disk task file. */
   filePath: string;
+  /**
+   * RFC-0015 / AISDLC-175 — optional `parent_task_id:` from frontmatter
+   * (e.g. AISDLC-70.1 carries `parent_task_id: AISDLC-70`). Used by the
+   * orphan-parent filter to detect parent tasks whose every sub-task is
+   * already in `backlog/completed/` so the orchestrator stops dispatching
+   * developer subagents to do bookkeeping closures the framework should
+   * handle. Empty string when absent.
+   */
+  parentTaskId: string;
 }
 
 export interface DependencyGraph {
@@ -243,6 +252,12 @@ export function parseTaskFrontmatter(
   // array when the field is absent.
   const externalDependencies = parseExternalDependenciesBlock(fmRaw);
 
+  // RFC-0015 / AISDLC-175 — surface the `parent_task_id:` frontmatter value
+  // so the orphan-parent filter can detect parent tasks whose every sub-task
+  // landed in `backlog/completed/`. Empty string when absent (the common case
+  // for top-level tasks without a phased breakdown).
+  const parentTaskId = String(fm.parent_task_id ?? '').trim();
+
   // mtime — best-effort; if the stat fails (file vanished mid-walk per the
   // RFC-0014 Q6 "best-effort consistency" contract) we degrade to '' rather
   // than crashing the whole snapshot.
@@ -264,6 +279,7 @@ export function parseTaskFrontmatter(
     externalDependencies,
     lastModified,
     filePath,
+    parentTaskId,
   };
 }
 

--- a/pipeline-cli/src/orchestrator/events-schema.test.ts
+++ b/pipeline-cli/src/orchestrator/events-schema.test.ts
@@ -132,6 +132,17 @@ describe('orchestrator-events.v1.schema.json — accepts every emitted type', ()
     });
   });
 
+  it('accepts OrchestratorOrphanParent (AISDLC-175)', () => {
+    expectValid({
+      ts: baseTs,
+      type: 'OrchestratorOrphanParent',
+      taskId: 'AISDLC-70',
+      runId,
+      tick: 1,
+      completedChildren: ['aisdlc-70.1', 'aisdlc-70.2', 'aisdlc-70.3'],
+    });
+  });
+
   it('accepts WorkerStateTransition (Phase 2 forensic forward)', () => {
     expectValid({
       ts: baseTs,

--- a/pipeline-cli/src/orchestrator/events.ts
+++ b/pipeline-cli/src/orchestrator/events.ts
@@ -55,6 +55,7 @@ export type OrchestratorEventType =
   | 'OrchestratorBlockedByDor'
   | 'OrchestratorIdleNoWork'
   | 'OrchestratorIdleAllFiltered'
+  | 'OrchestratorOrphanParent'
   | 'OrchestratorStuckCandidate'
   | 'WorkerStateTransition';
 

--- a/pipeline-cli/src/orchestrator/filters/chain.test.ts
+++ b/pipeline-cli/src/orchestrator/filters/chain.test.ts
@@ -23,7 +23,12 @@ import type {
 
 function node(
   id: string,
-  opts: { deps?: string[]; ext?: ExternalDependency[]; status?: 'open' | 'completed' } = {},
+  opts: {
+    deps?: string[];
+    ext?: ExternalDependency[];
+    status?: 'open' | 'completed';
+    parent?: string;
+  } = {},
 ): DependencyNode {
   const status = opts.status ?? 'open';
   return {
@@ -37,6 +42,7 @@ function node(
     externalDependencies: opts.ext ?? [],
     lastModified: '2026-05-02T00:00:00Z',
     filePath: `/tmp/${id}.md`,
+    parentTaskId: opts.parent ?? '',
   };
 }
 
@@ -61,7 +67,7 @@ beforeEach(() => {
 });
 
 describe('runFilterChain — all-pass', () => {
-  it('admits a candidate that clears all three filters', () => {
+  it('admits a candidate that clears all four filters', () => {
     const g = graph([node('AISDLC-READY')]);
     const result = runFilterChain({
       graph: g,
@@ -70,8 +76,11 @@ describe('runFilterChain — all-pass', () => {
     });
     expect(result.passed).toBe(true);
     expect(result.failure).toBeNull();
-    expect(result.trace).toHaveLength(3);
+    expect(result.trace).toHaveLength(4);
+    // AISDLC-175 prepended `OrphanParent` to the chain — cheapest +
+    // most decisive filter runs first.
     expect(result.trace.map((r) => r.filter)).toEqual([
+      'OrphanParent',
       'DependencyReadiness',
       'DorReadiness',
       'ExternalDependencies',
@@ -81,7 +90,23 @@ describe('runFilterChain — all-pass', () => {
 });
 
 describe('runFilterChain — short-circuit ordering', () => {
-  it('rejects + stops at filter 1 when a dependency is open (no DoR/external in trace)', () => {
+  it('rejects + stops at OrphanParent when the candidate is a parent with all children done', () => {
+    const g = graph([
+      node('AISDLC-PARENT'),
+      node('AISDLC-PARENT.1', { status: 'completed', parent: 'AISDLC-PARENT' }),
+    ]);
+    const result = runFilterChain({
+      graph: g,
+      taskId: 'AISDLC-PARENT',
+      calibrationLogPath: logPath,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.failure?.filter).toBe('OrphanParent');
+    // Short-circuited at filter 0 → no downstream filters in trace.
+    expect(result.trace).toHaveLength(1);
+  });
+
+  it('rejects + stops at DependencyReadiness when a dependency is open (no DoR/external in trace)', () => {
     const g = graph([node('AISDLC-OPEN'), node('AISDLC-DEP', { deps: ['AISDLC-OPEN'] })]);
     const result = runFilterChain({
       graph: g,
@@ -90,10 +115,13 @@ describe('runFilterChain — short-circuit ordering', () => {
     });
     expect(result.passed).toBe(false);
     expect(result.failure?.filter).toBe('DependencyReadiness');
-    expect(result.trace).toHaveLength(1);
+    // OrphanParent passed (filter 0), DependencyReadiness failed (filter 1).
+    expect(result.trace).toHaveLength(2);
+    expect(result.trace[0].filter).toBe('OrphanParent');
+    expect(result.trace[0].passed).toBe(true);
   });
 
-  it('rejects + stops at filter 2 when the DoR verdict blocks (no external in trace)', () => {
+  it('rejects + stops at DorReadiness when the verdict blocks (no external in trace)', () => {
     writeFileSync(
       logPath,
       JSON.stringify({
@@ -122,13 +150,15 @@ describe('runFilterChain — short-circuit ordering', () => {
     });
     expect(result.passed).toBe(false);
     expect(result.failure?.filter).toBe('DorReadiness');
-    expect(result.trace).toHaveLength(2);
-    expect(result.trace[0].filter).toBe('DependencyReadiness');
+    expect(result.trace).toHaveLength(3);
+    expect(result.trace[0].filter).toBe('OrphanParent');
     expect(result.trace[0].passed).toBe(true);
-    expect(result.trace[1].passed).toBe(false);
+    expect(result.trace[1].filter).toBe('DependencyReadiness');
+    expect(result.trace[1].passed).toBe(true);
+    expect(result.trace[2].passed).toBe(false);
   });
 
-  it('rejects at filter 3 when an external manual dep is unresolved (full trace populated)', () => {
+  it('rejects at ExternalDependencies when an external manual dep is unresolved (full trace populated)', () => {
     const g = graph([
       node('AISDLC-X', {
         ext: [{ id: 'sec-review', description: 'wait', kind: 'manual' }],
@@ -141,10 +171,11 @@ describe('runFilterChain — short-circuit ordering', () => {
     });
     expect(result.passed).toBe(false);
     expect(result.failure?.filter).toBe('ExternalDependencies');
-    expect(result.trace).toHaveLength(3);
+    expect(result.trace).toHaveLength(4);
     expect(result.trace[0].passed).toBe(true);
     expect(result.trace[1].passed).toBe(true);
-    expect(result.trace[2].passed).toBe(false);
+    expect(result.trace[2].passed).toBe(true);
+    expect(result.trace[3].passed).toBe(false);
   });
 });
 
@@ -158,10 +189,26 @@ describe('formatFilterTrace', () => {
     });
     const text = formatFilterTrace('AISDLC-READY', result);
     expect(text).toContain('[orchestrator] filter trace for AISDLC-READY:');
+    expect(text).toContain('Orphan-parent check: passed');
     expect(text).toContain('Dependency check: passed');
     expect(text).toContain('DoR readiness: passed');
     expect(text).toContain('External deps: passed');
     expect(text).toContain('→ admitted');
+  });
+
+  it('renders the orphan-parent case with the → skipped, orphan parent needs closure footer', () => {
+    const g = graph([
+      node('AISDLC-PARENT'),
+      node('AISDLC-PARENT.1', { status: 'completed', parent: 'AISDLC-PARENT' }),
+    ]);
+    const result = runFilterChain({
+      graph: g,
+      taskId: 'AISDLC-PARENT',
+      calibrationLogPath: logPath,
+    });
+    const text = formatFilterTrace('AISDLC-PARENT', result);
+    expect(text).toContain('Orphan-parent check: failed');
+    expect(text).toContain('→ skipped, orphan parent needs closure');
   });
 
   it('renders the external-await case with the → skipped, awaiting external footer (matches the task-spec exemplar)', () => {

--- a/pipeline-cli/src/orchestrator/filters/chain.ts
+++ b/pipeline-cli/src/orchestrator/filters/chain.ts
@@ -26,6 +26,7 @@ import {
   checkExternalDependencies,
   type CheckExternalDependenciesOpts,
 } from './external-dependencies.js';
+import { checkOrphanParent, type CheckOrphanParentOpts } from './orphan-parent.js';
 import type { FilterChainResult, FilterResult } from './types.js';
 
 export interface RunFilterChainOpts {
@@ -50,12 +51,27 @@ export interface RunFilterChainOpts {
 }
 
 /**
- * Run the three filters in §4.3 order against a single candidate.
+ * Run the four filters in chain order against a single candidate.
  * Short-circuits on the first failure but ALWAYS returns the partial trace
  * so the loop's event emission carries the prefix of cleared filters.
+ *
+ * Order: OrphanParent (AISDLC-175) → DependencyReadiness → DorReadiness →
+ * ExternalDependencies. OrphanParent runs first because it's the cheapest
+ * check (constant-time graph lookup) AND the most decisive — an orphan
+ * parent isn't real work at all, so there's no point asking the other three
+ * filters about it. The other three preserve the RFC §4.3 ordering among
+ * themselves.
  */
 export function runFilterChain(opts: RunFilterChainOpts): FilterChainResult {
   const trace: FilterResult[] = [];
+
+  // Filter 0 — orphan-parent detection (AISDLC-175). Cheapest + most
+  // decisive: an orphan parent is bookkeeping work the framework should
+  // handle, not real dispatch.
+  const orphanOpts: CheckOrphanParentOpts = { graph: opts.graph, taskId: opts.taskId };
+  const orphan = checkOrphanParent(orphanOpts);
+  trace.push(orphan);
+  if (!orphan.passed) return { passed: false, trace, failure: orphan };
 
   // Filter 1 — dependency readiness.
   const depOpts: CheckDependencyReadinessOpts = { graph: opts.graph, taskId: opts.taskId };
@@ -113,6 +129,8 @@ export function formatFilterTrace(taskId: string, result: FilterChainResult): st
 
 function humanFilterName(filter: FilterResult['filter']): string {
   switch (filter) {
+    case 'OrphanParent':
+      return 'Orphan-parent check';
     case 'DependencyReadiness':
       return 'Dependency check';
     case 'DorReadiness':
@@ -130,6 +148,8 @@ function terminalNote(failure: FilterResult): string {
       return 'awaiting DoR clarification';
     case 'awaiting-external':
       return 'awaiting external';
+    case 'orphan-parent-needs-closure':
+      return 'orphan parent needs closure';
     default:
       return failure.reason ?? 'filter rejected';
   }

--- a/pipeline-cli/src/orchestrator/filters/dependency-readiness.test.ts
+++ b/pipeline-cli/src/orchestrator/filters/dependency-readiness.test.ts
@@ -28,6 +28,7 @@ function node(
     externalDependencies: [],
     lastModified: '2026-05-02T00:00:00Z',
     filePath: `/tmp/${id}.md`,
+    parentTaskId: '',
   };
 }
 

--- a/pipeline-cli/src/orchestrator/filters/external-dependencies.test.ts
+++ b/pipeline-cli/src/orchestrator/filters/external-dependencies.test.ts
@@ -36,6 +36,7 @@ function node(id: string, deps: ExternalDependency[]): DependencyNode {
     externalDependencies: deps,
     lastModified: '2026-05-02T00:00:00Z',
     filePath: `/tmp/${id}.md`,
+    parentTaskId: '',
   };
 }
 

--- a/pipeline-cli/src/orchestrator/filters/index.ts
+++ b/pipeline-cli/src/orchestrator/filters/index.ts
@@ -20,6 +20,7 @@ export {
   checkExternalDependencies,
   type CheckExternalDependenciesOpts,
 } from './external-dependencies.js';
+export { checkOrphanParent, type CheckOrphanParentOpts } from './orphan-parent.js';
 export { formatFilterTrace, runFilterChain, type RunFilterChainOpts } from './chain.js';
 export type {
   AwaitingExternalDetail,
@@ -29,4 +30,5 @@ export type {
   FilterDetail,
   FilterName,
   FilterResult,
+  OrphanParentDetail,
 } from './types.js';

--- a/pipeline-cli/src/orchestrator/filters/orphan-parent.test.ts
+++ b/pipeline-cli/src/orchestrator/filters/orphan-parent.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Filter — orphan-parent detection (AISDLC-175) tests.
+ *
+ * Covers the AC #4 cases from the task spec:
+ *   - Parent with all children done → REJECTS (orphan parent — bookkeeping
+ *     work the framework should handle, not real dispatch).
+ *   - Parent with mixed children (some done, some open) → ADMITS (still
+ *     real work pending).
+ *   - Parent with no children declared → ADMITS (not an orphan parent —
+ *     could be a leaf or a top-level task without a phased breakdown).
+ *   - Task that is itself a child (carries `parent_task_id`) → ADMITS
+ *     (closing a sub-task is real dispatch work, even when the sub-task
+ *     itself has its own grandchildren).
+ *
+ * Plus defensive cases:
+ *   - Missing graph node → ADMITS (matches the dependency-readiness
+ *     filter's "missing node = pass" defense).
+ *   - Case-insensitive parent reference (children using `aisdlc-70` vs
+ *     `AISDLC-70`).
+ *   - Pathological self-reference (a task naming itself as parent) is
+ *     ignored when counting children.
+ *   - The `completedChildren` payload is sorted + lowercased.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { checkOrphanParent } from './orphan-parent.js';
+import type { DependencyGraph, DependencyNode } from '../../deps/dependency-graph.js';
+
+// ── Fixture helpers ───────────────────────────────────────────────────
+
+function node(
+  id: string,
+  opts: { status?: 'open' | 'completed'; parent?: string } = {},
+): DependencyNode {
+  const status = opts.status ?? 'open';
+  return {
+    id,
+    status,
+    fileLocation: status,
+    frontmatterStatus: status === 'completed' ? 'Done' : 'To Do',
+    priority: '',
+    title: id,
+    dependencies: [],
+    externalDependencies: [],
+    lastModified: '2026-05-02T00:00:00Z',
+    filePath: `/tmp/${id}.md`,
+    parentTaskId: opts.parent ?? '',
+  };
+}
+
+function graph(nodes: DependencyNode[]): DependencyGraph {
+  const map = new Map<string, DependencyNode>();
+  const openIds: string[] = [];
+  const completedIds: string[] = [];
+  for (const n of nodes) {
+    map.set(n.id.toLowerCase(), n);
+    if (n.status === 'open') openIds.push(n.id.toLowerCase());
+    else completedIds.push(n.id.toLowerCase());
+  }
+  return { nodes: map, openIds, completedIds };
+}
+
+// ── Acceptance criteria (AC #4) ───────────────────────────────────────
+
+describe('checkOrphanParent — AC #4 cases', () => {
+  it('REJECTS a parent whose every declared child is already in completed/', () => {
+    // Replays the witness: AISDLC-70 with all 9 sub-tasks already shipped.
+    const g = graph([
+      node('AISDLC-70'),
+      node('AISDLC-70.1', { status: 'completed', parent: 'AISDLC-70' }),
+      node('AISDLC-70.2', { status: 'completed', parent: 'AISDLC-70' }),
+      node('AISDLC-70.3', { status: 'completed', parent: 'AISDLC-70' }),
+    ]);
+    const result = checkOrphanParent({ graph: g, taskId: 'AISDLC-70' });
+    expect(result.passed).toBe(false);
+    expect(result.filter).toBe('OrphanParent');
+    expect(result.detail?.kind).toBe('orphan-parent-needs-closure');
+    if (result.detail?.kind === 'orphan-parent-needs-closure') {
+      // Sorted + lowercased per the documented event-payload contract.
+      expect(result.detail.completedChildren).toEqual([
+        'aisdlc-70.1',
+        'aisdlc-70.2',
+        'aisdlc-70.3',
+      ]);
+    }
+    // Reason string surfaces the count + first few IDs for the trace log.
+    expect(result.reason).toContain('orphan-parent-needs-closure');
+    expect(result.reason).toContain('3 completed');
+  });
+
+  it('ADMITS a parent with mixed children (≥1 still open)', () => {
+    const g = graph([
+      node('AISDLC-100'),
+      node('AISDLC-100.1', { status: 'completed', parent: 'AISDLC-100' }),
+      // 100.2 is still open — there's real downstream work, the parent
+      // shouldn't be skipped as an orphan.
+      node('AISDLC-100.2', { status: 'open', parent: 'AISDLC-100' }),
+      node('AISDLC-100.3', { status: 'completed', parent: 'AISDLC-100' }),
+    ]);
+    const result = checkOrphanParent({ graph: g, taskId: 'AISDLC-100' });
+    expect(result.passed).toBe(true);
+    expect(result.detail).toBeUndefined();
+  });
+
+  it('ADMITS a parent with no children declared (not an orphan parent)', () => {
+    // A leaf or top-level task without a phased breakdown — could be real
+    // work; the chain should let downstream filters decide.
+    const g = graph([node('AISDLC-200'), node('AISDLC-201'), node('AISDLC-202')]);
+    const result = checkOrphanParent({ graph: g, taskId: 'AISDLC-200' });
+    expect(result.passed).toBe(true);
+    expect(result.detail).toBeUndefined();
+  });
+
+  it('ADMITS a candidate that is itself a child (carries parent_task_id)', () => {
+    // AISDLC-100.7 is AISDLC-100's child. Even if 100.7 had grandchildren
+    // that were all completed, closing 100.7 itself is real dispatch work
+    // — the orchestrator should keep working on it.
+    const g = graph([
+      node('AISDLC-100'),
+      node('AISDLC-100.7', { parent: 'AISDLC-100' }),
+      node('AISDLC-100.7.1', { status: 'completed', parent: 'AISDLC-100.7' }),
+    ]);
+    const result = checkOrphanParent({ graph: g, taskId: 'AISDLC-100.7' });
+    expect(result.passed).toBe(true);
+  });
+});
+
+// ── Defensive cases ───────────────────────────────────────────────────
+
+describe('checkOrphanParent — defensive cases', () => {
+  it('ADMITS when the candidate is missing from the graph', () => {
+    // Matches the dependency-readiness filter's "missing node = pass"
+    // defense — the chain should not silently REJECT on data gaps.
+    const g = graph([]);
+    const result = checkOrphanParent({ graph: g, taskId: 'AISDLC-MISSING' });
+    expect(result.passed).toBe(true);
+  });
+
+  it('matches parent_task_id case-insensitively', () => {
+    // On-disk frontmatter sometimes uses `AISDLC-70`, sometimes
+    // `aisdlc-70` — both refer to the same parent.
+    const g = graph([
+      node('AISDLC-Mixed'),
+      node('AISDLC-Mixed.1', { status: 'completed', parent: 'aisdlc-mixed' }),
+      node('AISDLC-Mixed.2', { status: 'completed', parent: 'AISDLC-MIXED' }),
+    ]);
+    const result = checkOrphanParent({ graph: g, taskId: 'AISDLC-Mixed' });
+    expect(result.passed).toBe(false);
+    if (result.detail?.kind === 'orphan-parent-needs-closure') {
+      expect(result.detail.completedChildren).toEqual(['aisdlc-mixed.1', 'aisdlc-mixed.2']);
+    }
+  });
+
+  it('ignores self-reference (a task naming itself as parent does not count)', () => {
+    // Pathological data — shouldn't produce a false-positive orphan
+    // detection. With only the self-ref "child", the candidate has no
+    // real children and should ADMIT.
+    const g = graph([node('AISDLC-SELF', { parent: 'AISDLC-SELF' })]);
+    const result = checkOrphanParent({ graph: g, taskId: 'AISDLC-SELF' });
+    // The candidate has parent_task_id set → treated as a child; the
+    // earlier "candidate is itself a child" guard fires first.
+    expect(result.passed).toBe(true);
+  });
+
+  it('ignores self-reference by id even when the candidate has no parent_task_id', () => {
+    // Build a graph where AISDLC-X has no parent_task_id BUT one of its
+    // "children" is itself (id collision). The self-ref should be
+    // skipped, leaving zero real children → ADMIT.
+    const candidate = node('AISDLC-X');
+    const fakeChild = node('AISDLC-X', { status: 'completed', parent: 'AISDLC-X' });
+    // We can't put two nodes with the same id in the graph map, but we
+    // can assert that even when the candidate's own id matches its
+    // parent_task_id (synthetic data), the self-ref guard doesn't
+    // create a false positive. Use the second node directly.
+    const g: DependencyGraph = {
+      nodes: new Map([['aisdlc-x', fakeChild]]),
+      openIds: [],
+      completedIds: ['aisdlc-x'],
+    };
+    void candidate; // documentary
+    const result = checkOrphanParent({ graph: g, taskId: 'AISDLC-X' });
+    // candidate carries parent_task_id (=== its own id) → "is itself a
+    // child" guard fires, ADMIT.
+    expect(result.passed).toBe(true);
+  });
+
+  it('REJECTS a single-child parent when that child is completed', () => {
+    // Edge case: minimum quorum for orphan-parent classification is 1
+    // completed child + 0 open children. Verifies the spec's "≥1" lower
+    // bound.
+    const g = graph([
+      node('AISDLC-SINGLE'),
+      node('AISDLC-SINGLE.1', { status: 'completed', parent: 'AISDLC-SINGLE' }),
+    ]);
+    const result = checkOrphanParent({ graph: g, taskId: 'AISDLC-SINGLE' });
+    expect(result.passed).toBe(false);
+    if (result.detail?.kind === 'orphan-parent-needs-closure') {
+      expect(result.detail.completedChildren).toEqual(['aisdlc-single.1']);
+    }
+  });
+
+  it('case-insensitive candidate task ID lookup', () => {
+    // Same case-folding contract as dependency-readiness — callers may
+    // pass the candidate ID in any case.
+    const g = graph([
+      node('AISDLC-LowerLookup'),
+      node('AISDLC-LowerLookup.1', {
+        status: 'completed',
+        parent: 'AISDLC-LowerLookup',
+      }),
+    ]);
+    const result = checkOrphanParent({ graph: g, taskId: 'aisdlc-lowerlookup' });
+    expect(result.passed).toBe(false);
+  });
+
+  it('ignores children with empty parent_task_id', () => {
+    // Empty-string `parentTaskId` (the absent case) must not match any
+    // candidate — defending against the "every node has empty parent"
+    // false positive.
+    const g = graph([node('AISDLC-A'), node('AISDLC-B'), node('AISDLC-C')]);
+    expect(checkOrphanParent({ graph: g, taskId: 'AISDLC-A' }).passed).toBe(true);
+  });
+});

--- a/pipeline-cli/src/orchestrator/filters/orphan-parent.ts
+++ b/pipeline-cli/src/orchestrator/filters/orphan-parent.ts
@@ -1,0 +1,135 @@
+/**
+ * Filter — Orphan-parent detection (AISDLC-175).
+ *
+ * Catches parent tasks whose every declared child landed in
+ * `backlog/completed/`. The witness was a 2026-05-04 dogfood run of
+ * `cli-orchestrator tick` that picked up AISDLC-70 (RFC-0010 parent task with
+ * all 9 sub-tasks already in `backlog/completed/`). The dev subagent did the
+ * right semantic thing — drafted a closure commit moving the parent file —
+ * but this is bookkeeping work, not real dispatch. Worse, the closure had
+ * already shipped via PR #231, so the dispatch was a complete duplicate.
+ *
+ * Detection
+ * =========
+ * A candidate X is an "orphan parent" iff:
+ *   1. ≥1 OTHER task Y in the graph carries `parent_task_id: X` (any case),
+ *      AND
+ *   2. EVERY such child Y has `status === 'completed'` (file is in
+ *      `backlog/completed/`, OR file is in `backlog/tasks/` but frontmatter
+ *      already says `Done` — the same reclassification rule the rest of the
+ *      graph uses per AISDLC-153).
+ *
+ * Not-an-orphan-parent cases (admitted):
+ *   - Candidate has no declared children at all (it's a leaf or a top-level
+ *     task without a phased breakdown — could be real work).
+ *   - Candidate has children, but ≥1 is still open.
+ *   - Candidate itself carries a non-empty `parent_task_id` (it's a child,
+ *     not a parent — even if it has its own grandchildren, the orchestrator
+ *     should still admit it because the candidate IS real work).
+ *
+ * The "candidate is itself a child" exclusion is important for nested
+ * decompositions (AISDLC-100.7 has children of its own conceptually, but
+ * it's also AISDLC-100's child — the orchestrator should keep working on
+ * it, not refuse to dispatch).
+ *
+ * Pure: reads ONLY the pre-built graph. No I/O, no side effects.
+ *
+ * Cost: O(N) where N = total nodes in the graph. We could pre-build a
+ * `parentId → childIds[]` reverse-index in `buildDependencyGraph` and turn
+ * this into O(K) where K = candidate's child count, but graphs of even very
+ * large backlogs (1000+ tasks) walk in microseconds and the simpler
+ * implementation reads better. Phase 4 / future RFCs can add the index if
+ * the corpus shows the linear walk dominates orchestrator hot-loop time.
+ *
+ * @module orchestrator/filters/orphan-parent
+ */
+
+import type { DependencyGraph, DependencyNode } from '../../deps/dependency-graph.js';
+import type { FilterResult } from './types.js';
+
+export interface CheckOrphanParentOpts {
+  /** Pre-built graph — shared across all filters in this tick. */
+  graph: DependencyGraph;
+  /** Candidate task ID (case-insensitive lookup). */
+  taskId: string;
+}
+
+/**
+ * Walk the graph to find children of the candidate; reject the candidate
+ * when it has children AND every child is already completed.
+ *
+ * Two short-circuit rejections of "this candidate is not an orphan parent":
+ *   - If the candidate itself carries `parent_task_id`, it's a child (could
+ *     be a leaf grandchild, could be a mid-tree node — either way the
+ *     orchestrator should still consider it real work).
+ *   - If no other task in the graph names the candidate as `parent_task_id`,
+ *     it's not a parent at all.
+ *
+ * Pure — no I/O. The graph + task ID come from the caller.
+ */
+export function checkOrphanParent(opts: CheckOrphanParentOpts): FilterResult {
+  const candidateKey = opts.taskId.toLowerCase();
+  const candidate: DependencyNode | undefined = opts.graph.nodes.get(candidateKey);
+
+  // Defensive: missing-from-graph candidate cannot be classified as an
+  // orphan parent (no children to check). The dependency-readiness filter
+  // applies the same "missing node = pass" defense; matching here keeps
+  // the chain consistent.
+  if (!candidate) {
+    return { filter: 'OrphanParent', passed: true };
+  }
+
+  // The candidate is itself someone's child — not an orphan-parent
+  // candidate, even if it has its own grandchildren. Closing a sub-task
+  // is real dispatch work.
+  if (candidate.parentTaskId.trim() !== '') {
+    return { filter: 'OrphanParent', passed: true };
+  }
+
+  // Walk the full node map looking for children that name this candidate
+  // as their `parent_task_id`. Case-insensitive comparison: the on-disk
+  // frontmatter sometimes uses `AISDLC-70`, sometimes `aisdlc-70` — both
+  // refer to the same parent.
+  const completedChildren: string[] = [];
+  let hasOpenChild = false;
+  for (const child of opts.graph.nodes.values()) {
+    if (child.parentTaskId.trim() === '') continue;
+    if (child.parentTaskId.trim().toLowerCase() !== candidateKey) continue;
+    // Don't count the candidate as its own child even in pathological
+    // self-reference cases.
+    if (child.id.toLowerCase() === candidateKey) continue;
+    if (child.status === 'completed') {
+      completedChildren.push(child.id.toLowerCase());
+    } else {
+      // First open child seen → no longer a closure candidate. We can
+      // bail early because the rejection condition requires ALL children
+      // to be completed.
+      hasOpenChild = true;
+      break;
+    }
+  }
+
+  // No declared children → this candidate is not a parent at all (could be
+  // a top-level task without a phased breakdown; the chain admits it and
+  // lets downstream filters decide).
+  if (!hasOpenChild && completedChildren.length === 0) {
+    return { filter: 'OrphanParent', passed: true };
+  }
+
+  // Mixed children (≥1 open) → still real work. Admit and let the regular
+  // chain run.
+  if (hasOpenChild) {
+    return { filter: 'OrphanParent', passed: true };
+  }
+
+  // All declared children are completed → orphan parent. Reject so the
+  // orchestrator skips it; operators close the parent manually (or via a
+  // future automatic-close affordance) per the AISDLC-175 design.
+  completedChildren.sort();
+  return {
+    filter: 'OrphanParent',
+    passed: false,
+    reason: `orphan-parent-needs-closure (${completedChildren.length} completed child(ren), no open: ${completedChildren.slice(0, 5).join(', ')})`,
+    detail: { kind: 'orphan-parent-needs-closure', completedChildren },
+  };
+}

--- a/pipeline-cli/src/orchestrator/filters/types.ts
+++ b/pipeline-cli/src/orchestrator/filters/types.ts
@@ -20,11 +20,20 @@
 import type { ExternalDependency } from '../../deps/dependency-graph.js';
 
 /**
- * Names of the three filters in the order RFC §4.3 specifies. Used in trace
+ * Names of the filters in the order the chain runs them. Used in trace
  * lines + event payloads so operators can grep for a specific filter without
  * decoding the human-readable reason string.
+ *
+ * `OrphanParent` (AISDLC-175) is the cheapest filter — a constant-time graph
+ * lookup against the candidate's own node + the already-loaded parent map —
+ * so it runs FIRST and short-circuits before the costlier dependency walk.
+ * The other three filters preserve the RFC §4.3 ordering among themselves.
  */
-export type FilterName = 'DependencyReadiness' | 'DorReadiness' | 'ExternalDependencies';
+export type FilterName =
+  | 'OrphanParent'
+  | 'DependencyReadiness'
+  | 'DorReadiness'
+  | 'ExternalDependencies';
 
 /**
  * Single-filter outcome. `passed: true` clears the candidate; `passed: false`
@@ -51,7 +60,30 @@ export interface FilterResult {
  * narrow safely. Each shape carries only the fields the matching event
  * actually needs (RFC §7.1 event surface).
  */
-export type FilterDetail = DependencyBlockedDetail | DorBlockedDetail | AwaitingExternalDetail;
+export type FilterDetail =
+  | DependencyBlockedDetail
+  | DorBlockedDetail
+  | AwaitingExternalDetail
+  | OrphanParentDetail;
+
+/**
+ * AISDLC-175 — the candidate is a parent task whose every declared child is
+ * already in `backlog/completed/`. The filter rejects so the orchestrator
+ * stops dispatching developer subagents to do bookkeeping closures the
+ * framework should handle (the witness was AISDLC-70 — RFC-0010 parent with
+ * 9 completed children — getting picked up after PR #231 had already shipped
+ * its closure).
+ */
+export interface OrphanParentDetail {
+  kind: 'orphan-parent-needs-closure';
+  /**
+   * IDs of the candidate's children that are all already in
+   * `backlog/completed/` (lowercased, sorted). At least one entry by
+   * construction — a parent with zero children is not an orphan-parent and
+   * the filter admits it.
+   */
+  completedChildren: string[];
+}
 
 export interface DependencyBlockedDetail {
   kind: 'dependency-blocked';

--- a/pipeline-cli/src/orchestrator/index.ts
+++ b/pipeline-cli/src/orchestrator/index.ts
@@ -66,6 +66,7 @@ export type {
   OrchestratorConfig,
   OrchestratorFilterEvent,
   OrchestratorIdleEvent,
+  OrchestratorOrphanParentEvent,
   OrchestratorStatus,
   OrchestratorStuckCandidateEvent,
   OrchestratorTickResult,
@@ -122,10 +123,12 @@ export {
 } from './playbook/index.js';
 
 // RFC-0015 Phase 3 — pre-dispatch admission filters (AISDLC-169.3).
+// AISDLC-175 — orphan-parent filter (parent task whose every child is done).
 export {
   checkDependencyReadiness,
   checkDorReadiness,
   checkExternalDependencies,
+  checkOrphanParent,
   DOR_BYPASS_LABEL,
   formatFilterTrace,
   runFilterChain,
@@ -133,11 +136,13 @@ export {
   type CheckDependencyReadinessOpts,
   type CheckDorReadinessOpts,
   type CheckExternalDependenciesOpts,
+  type CheckOrphanParentOpts,
   type DependencyBlockedDetail,
   type DorBlockedDetail,
   type FilterChainResult,
   type FilterDetail,
   type FilterName,
   type FilterResult,
+  type OrphanParentDetail,
   type RunFilterChainOpts,
 } from './filters/index.js';

--- a/pipeline-cli/src/orchestrator/loop.filters.test.ts
+++ b/pipeline-cli/src/orchestrator/loop.filters.test.ts
@@ -37,6 +37,7 @@ import {
   type OrchestratorAwaitingExternalEvent,
   type OrchestratorBlockedByDependencyEvent,
   type OrchestratorBlockedByDorEvent,
+  type OrchestratorOrphanParentEvent,
   type StuckCounterEntry,
 } from './index.js';
 import type {
@@ -67,7 +68,12 @@ function captureLogger(): { logger: PipelineLogger; lines: string[] } {
 
 function node(
   id: string,
-  opts: { deps?: string[]; ext?: ExternalDependency[]; status?: 'open' | 'completed' } = {},
+  opts: {
+    deps?: string[];
+    ext?: ExternalDependency[];
+    status?: 'open' | 'completed';
+    parent?: string;
+  } = {},
 ): DependencyNode {
   const status = opts.status ?? 'open';
   return {
@@ -81,6 +87,7 @@ function node(
     externalDependencies: opts.ext ?? [],
     lastModified: '2026-05-02T00:00:00Z',
     filePath: `/tmp/${id}.md`,
+    parentTaskId: opts.parent ?? '',
   };
 }
 
@@ -525,5 +532,112 @@ describe('runOrchestratorLoop — uses tick.nextSleepSec for inter-tick sleep', 
     expect(sleepCalls).toHaveLength(2);
     expect(sleepCalls[0]).toBe(60_000);
     expect(sleepCalls[1]).toBe(120_000);
+  });
+});
+
+// ── AISDLC-175 witness regression ─────────────────────────────────────
+
+describe('runOrchestratorTick — AISDLC-175 orphan-parent witness regression', () => {
+  it('skips the orphan parent + dispatches the real bug task instead', async () => {
+    // Witness reproduction: 2026-05-04 dogfood run picked up AISDLC-70
+    // (RFC-0010 parent task with all 9 sub-tasks already in
+    // backlog/completed/) ahead of real work. The fix should make the
+    // orchestrator skip the orphan parent and pick the real bug task.
+    //
+    // Fixture:
+    //   AISDLC-PARENT — parent of two completed children → ORPHAN, skip.
+    //   AISDLC-PARENT.1, .2 — completed children of AISDLC-PARENT.
+    //   AISDLC-BUG    — real open bug task → ADMIT + dispatch.
+    const graph = buildGraph([
+      node('AISDLC-PARENT'),
+      node('AISDLC-PARENT.1', { status: 'completed', parent: 'AISDLC-PARENT' }),
+      node('AISDLC-PARENT.2', { status: 'completed', parent: 'AISDLC-PARENT' }),
+      node('AISDLC-BUG'),
+    ]);
+
+    const dispatched: string[] = [];
+    const config = defaultOrchestratorConfig({
+      workDir: tmp,
+      // maxConcurrent = 2 so the chain considers BOTH the orphan parent
+      // and the real bug task — verifying the orphan is filtered out
+      // (not just deprioritised) and the bug still gets through.
+      maxConcurrent: 2,
+      maxTicks: 1,
+      tickIntervalSec: 0,
+    });
+    const adapters: OrchestratorAdapters = {
+      logger: silentLogger(),
+      sleep: () => Promise.resolve(),
+      // Orphan parent ranked FIRST in the frontier (matches the witness
+      // — AISDLC-70 was picked because it sorts before later IDs). The
+      // filter must reject it even though it tops the queue.
+      frontier: () => [
+        { id: 'AISDLC-PARENT', title: 'PARENT' },
+        { id: 'AISDLC-BUG', title: 'BUG' },
+      ],
+      graphLoader: () => graph,
+      taskLabelsLoader: () => [],
+      dispatch: async (taskId) => {
+        dispatched.push(taskId);
+        return approvedResult(taskId);
+      },
+      escalate: async () => {},
+    };
+    const tick = await runOrchestratorTick(config, adapters, 1);
+
+    // Bug task dispatched, orphan parent skipped.
+    expect(dispatched).toEqual(['AISDLC-BUG']);
+    expect(tick.dispatched).toEqual(['AISDLC-BUG']);
+
+    // Orphan parent surfaces as a structured filter rejection so
+    // operators see it in the events.jsonl bus + cli-status view.
+    const orphanEvt = tick.filterEvents.find((e) => e.taskId === 'AISDLC-PARENT');
+    expect(orphanEvt?.trace.passed).toBe(false);
+    expect(orphanEvt?.trace.failure?.filter).toBe('OrphanParent');
+    const orphanBlocked = orphanEvt?.blockedEvent as OrchestratorOrphanParentEvent;
+    expect(orphanBlocked.type).toBe('OrchestratorOrphanParent');
+    expect(orphanBlocked.completedChildren).toEqual(['aisdlc-parent.1', 'aisdlc-parent.2']);
+
+    // Bug task admitted (no blockedEvent + chain.passed === true).
+    const bugEvt = tick.filterEvents.find((e) => e.taskId === 'AISDLC-BUG');
+    expect(bugEvt?.trace.passed).toBe(true);
+    expect(bugEvt?.blockedEvent).toBeNull();
+  });
+
+  it('emits OrchestratorOrphanParent on the events.jsonl bus when the filter rejects', async () => {
+    // Verify the loop forwards the orphan-parent rejection to the events
+    // sink (the same path the date-rotated events.jsonl writer uses). A
+    // capturing sink keeps the test hermetic.
+    const graph = buildGraph([
+      node('AISDLC-ORPHAN'),
+      node('AISDLC-ORPHAN.1', { status: 'completed', parent: 'AISDLC-ORPHAN' }),
+    ]);
+    const captured: Array<{ type: string; taskId?: string; completedChildren?: string[] }> = [];
+    const config = defaultOrchestratorConfig({
+      workDir: tmp,
+      maxConcurrent: 1,
+      maxTicks: 1,
+      tickIntervalSec: 0,
+    });
+    await runOrchestratorTick(
+      config,
+      {
+        logger: silentLogger(),
+        sleep: () => Promise.resolve(),
+        frontier: () => [{ id: 'AISDLC-ORPHAN', title: 'ORPHAN' }],
+        graphLoader: () => graph,
+        taskLabelsLoader: () => [],
+        dispatch: async (id) => approvedResult(id),
+        escalate: async () => {},
+        emitEvent: (event) => {
+          captured.push(event as { type: string; taskId?: string; completedChildren?: string[] });
+        },
+      },
+      1,
+    );
+    const orphanEvent = captured.find((e) => e.type === 'OrchestratorOrphanParent');
+    expect(orphanEvent).toBeDefined();
+    expect(orphanEvent?.taskId).toBe('AISDLC-ORPHAN');
+    expect(orphanEvent?.completedChildren).toEqual(['aisdlc-orphan.1']);
   });
 });

--- a/pipeline-cli/src/orchestrator/loop.ts
+++ b/pipeline-cli/src/orchestrator/loop.ts
@@ -892,6 +892,13 @@ function toBlockedEvent(
         externalDeps: detail.blocking.map((d) => ({ id: d.id, kind: d.kind })),
         allExternalDeps: detail.all.map((d) => ({ id: d.id, kind: d.kind })),
       };
+    case 'orphan-parent-needs-closure':
+      return {
+        type: 'OrchestratorOrphanParent',
+        ts,
+        taskId,
+        completedChildren: detail.completedChildren,
+      };
   }
 }
 
@@ -923,6 +930,12 @@ function toEmittableBlockedEvent(blocked: OrchestratorBlockedEvent): Omit<Orches
         taskId: blocked.taskId,
         externalDeps: blocked.externalDeps.map((d) => ({ id: d.id, kind: d.kind })),
         allExternalDeps: blocked.allExternalDeps.map((d) => ({ id: d.id, kind: d.kind })),
+      };
+    case 'OrchestratorOrphanParent':
+      return {
+        type: 'OrchestratorOrphanParent',
+        taskId: blocked.taskId,
+        completedChildren: [...blocked.completedChildren],
       };
   }
 }

--- a/pipeline-cli/src/orchestrator/types.ts
+++ b/pipeline-cli/src/orchestrator/types.ts
@@ -102,14 +102,16 @@ export interface OrchestratorFilterEvent {
 }
 
 /**
- * Discriminated union for the three RFC §4.3 admission-block events.
- * Phase 4 (AISDLC-169.4) plumbs these into `events.jsonl`; Phase 3
- * surfaces them in the tick result + via the logger.
+ * Discriminated union for the admission-block events. Phase 4
+ * (AISDLC-169.4) plumbs these into `events.jsonl`; Phase 3 surfaces them
+ * in the tick result + via the logger. AISDLC-175 added the
+ * `OrchestratorOrphanParent` arm for parent-task closure detection.
  */
 export type OrchestratorBlockedEvent =
   | OrchestratorBlockedByDependencyEvent
   | OrchestratorBlockedByDorEvent
-  | OrchestratorAwaitingExternalEvent;
+  | OrchestratorAwaitingExternalEvent
+  | OrchestratorOrphanParentEvent;
 
 export interface OrchestratorBlockedByDependencyEvent {
   type: 'OrchestratorBlockedByDependency';
@@ -143,6 +145,28 @@ export interface OrchestratorAwaitingExternalEvent {
    * surfaced here so operators see the complete picture).
    */
   allExternalDeps: Array<{ id: string; kind: string }>;
+}
+
+/**
+ * AISDLC-175 — emitted when the orphan-parent filter rejects a candidate.
+ * The candidate is a parent task whose every declared child is already in
+ * `backlog/completed/`; the orchestrator skips it instead of dispatching a
+ * developer subagent for what is bookkeeping (parent file `git mv` to
+ * `completed/`) the framework should handle. Witness: AISDLC-70 (RFC-0010
+ * parent with all 9 sub-tasks already in `completed/`) was incorrectly
+ * dispatched on 2026-05-04 even though PR #231 had already shipped its
+ * closure.
+ */
+export interface OrchestratorOrphanParentEvent {
+  type: 'OrchestratorOrphanParent';
+  ts: string;
+  taskId: string;
+  /**
+   * IDs of the candidate's children that are all already in
+   * `backlog/completed/` (lowercased, sorted). At least one entry by
+   * construction — a parent with zero children is not an orphan parent.
+   */
+  completedChildren: string[];
 }
 
 export interface OrchestratorStuckCandidateEvent {

--- a/reference/src/core/generated-schemas.ts
+++ b/reference/src/core/generated-schemas.ts
@@ -2506,13 +2506,19 @@ export const orchestratorEventsV1Schema = {
       description:
         'Consecutive-skip count for the candidate at the moment the stuck event fires — present on `OrchestratorStuckCandidate`.',
     },
+    completedChildren: {
+      type: 'array',
+      items: { type: 'string', minLength: 1 },
+      description:
+        "IDs of the candidate's children that are all already in `backlog/completed/` (lowercased, sorted). At least one entry by construction. Present on `OrchestratorOrphanParent` (AISDLC-175) — emitted when the orphan-parent filter rejects a parent task whose every declared child has already shipped, so the orchestrator stops dispatching developer subagents for what is bookkeeping (parent file `git mv` to `completed/`) the framework should handle.",
+    },
   },
   additionalProperties: false,
   $defs: {
     OrchestratorEventType: {
       type: 'string',
       description:
-        "Discriminator. Phase 4 (AISDLC-169.4) shipped the seven core types covering tick lifecycle + dispatch outcomes + worker-state transitions + the external-deps filter rejection. Phase 3 (AISDLC-169.3) extends the enum with the remaining five filter-rejection / idle / stuck event types so the events.jsonl stream is the single observability path. Future phases / RFCs extend this enum without a schema bump (consumers that don't enforce the enum strictly will tolerate unknown types, those that do will reject + log).",
+        "Discriminator. Phase 4 (AISDLC-169.4) shipped the seven core types covering tick lifecycle + dispatch outcomes + worker-state transitions + the external-deps filter rejection. Phase 3 (AISDLC-169.3) extends the enum with the remaining five filter-rejection / idle / stuck event types so the events.jsonl stream is the single observability path. AISDLC-175 adds `OrchestratorOrphanParent` for parent-task closure detection. Future phases / RFCs extend this enum without a schema bump (consumers that don't enforce the enum strictly will tolerate unknown types, those that do will reject + log).",
       enum: [
         'OrchestratorTick',
         'OrchestratorDispatched',
@@ -2524,6 +2530,7 @@ export const orchestratorEventsV1Schema = {
         'OrchestratorBlockedByDor',
         'OrchestratorIdleNoWork',
         'OrchestratorIdleAllFiltered',
+        'OrchestratorOrphanParent',
         'OrchestratorStuckCandidate',
         'WorkerStateTransition',
       ],

--- a/spec/schemas/orchestrator-events.v1.schema.json
+++ b/spec/schemas/orchestrator-events.v1.schema.json
@@ -136,13 +136,18 @@
       "type": "integer",
       "minimum": 0,
       "description": "Consecutive-skip count for the candidate at the moment the stuck event fires — present on `OrchestratorStuckCandidate`."
+    },
+    "completedChildren": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "IDs of the candidate's children that are all already in `backlog/completed/` (lowercased, sorted). At least one entry by construction. Present on `OrchestratorOrphanParent` (AISDLC-175) — emitted when the orphan-parent filter rejects a parent task whose every declared child has already shipped, so the orchestrator stops dispatching developer subagents for what is bookkeeping (parent file `git mv` to `completed/`) the framework should handle."
     }
   },
   "additionalProperties": false,
   "$defs": {
     "OrchestratorEventType": {
       "type": "string",
-      "description": "Discriminator. Phase 4 (AISDLC-169.4) shipped the seven core types covering tick lifecycle + dispatch outcomes + worker-state transitions + the external-deps filter rejection. Phase 3 (AISDLC-169.3) extends the enum with the remaining five filter-rejection / idle / stuck event types so the events.jsonl stream is the single observability path. Future phases / RFCs extend this enum without a schema bump (consumers that don't enforce the enum strictly will tolerate unknown types, those that do will reject + log).",
+      "description": "Discriminator. Phase 4 (AISDLC-169.4) shipped the seven core types covering tick lifecycle + dispatch outcomes + worker-state transitions + the external-deps filter rejection. Phase 3 (AISDLC-169.3) extends the enum with the remaining five filter-rejection / idle / stuck event types so the events.jsonl stream is the single observability path. AISDLC-175 adds `OrchestratorOrphanParent` for parent-task closure detection. Future phases / RFCs extend this enum without a schema bump (consumers that don't enforce the enum strictly will tolerate unknown types, those that do will reject + log).",
       "enum": [
         "OrchestratorTick",
         "OrchestratorDispatched",
@@ -154,6 +159,7 @@
         "OrchestratorBlockedByDor",
         "OrchestratorIdleNoWork",
         "OrchestratorIdleAllFiltered",
+        "OrchestratorOrphanParent",
         "OrchestratorStuckCandidate",
         "WorkerStateTransition"
       ]


### PR DESCRIPTION
Closes AISDLC-175.

Witnessed 2026-05-04: orchestrator dispatched AISDLC-70 (orphan parent — all 9 sub-tasks already in `backlog/completed/`). The dev did the right thing semantically (drafted parent closure) but it's bookkeeping work, not real dispatch. Same closure had already shipped via PR #231.

## Implementation

- New filter at `pipeline-cli/src/orchestrator/filters/orphan-parent.ts` — pure graph walk; refuses dispatch when ALL declared children are in `backlog/completed/`. Wired as filter-0 (cheapest + most decisive).
- New `OrchestratorOrphanParent` event type with `completedChildren: string[]` payload (added to types, schema, regenerated reference).
- Extended `DependencyNode` with `parentTaskId` field parsed from frontmatter; updated 4 fixtures + writeTaskFile helper.
- Guard for nested decompositions: a task that's itself a child still admits even if it has further children.

## Tests
- 11 unit tests on the filter (4 AC cases + 7 defensive: nested decomposition, empty children, mixed-state children, etc.)
- 2 integration tests in `loop.filters.test.ts` (witness regression: parent skipped, bug task dispatched)
- 1553 pipeline-cli tests pass; build/lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)