### PR TITLE
docs(spec): RFC-0017 + RFC-0018 v0.2 — engineering pass on Mo's stubs

### DIFF
--- a/spec/rfcs/RFC-0017-in-soul-variant-pattern.md
+++ b/spec/rfcs/RFC-0017-in-soul-variant-pattern.md
@@ -15,9 +15,10 @@ requiresDocs: []
 # RFC-0017: In-Soul Variant Pattern
 
 **Document type:** Normative (draft)
-**Status:** Draft v0.1 — Initial stub. Full spec pending practitioner validation pass against SpryPoint four-soul platform (SpryEngage / SpryMobile / SpryCIS / SpryBackflow).
+**Status:** Draft v0.2 — Initial spec expansion (Engineering pass on Mo's v0.1 stub). Practitioner-validation gates in §11 unresolved; full normative status awaits SpryPoint four-soul implementation pass + Mo's design-authority editorial review of §3-§13.
 **Created:** 2026-05-04
 **Authors:** Morgan Hirtle (Design Authority, SpryPoint)
+**Engineering pass:** Dominique Legault, Claude Opus 4.7 (orchestrator), 2026-05-04 — fleshed §3-§13 from Mo's v0.1 stub. Design-vertex semantics (specifically §5.3 inheritance table + §10 OQs) deferred to Mo for editorial pass.
 **Requires:** RFC-0009 (Tessellated Design Intent Documents)
 
 > The bold-style status block above is preserved for human readability. The
@@ -30,105 +31,322 @@ requiresDocs: []
 
 | Person | Role | Status | Date |
 |--------|------|--------|------|
-| Morgan Hirtle | Chief of Design / Design Authority | ✍️ Authored v0.1 | 2026-05-04 |
-| Dominique Legault | CTO / Engineering Authority | ⏸ Pending | — |
+| Morgan Hirtle | Chief of Design / Design Authority | ✍️ Authored v0.1 stub | 2026-05-04 |
+| Dominique Legault | CTO / Engineering Authority | ✏️ Engineering pass on v0.2 (pending Design editorial) | 2026-05-04 |
 | Alexander Kline | Head of Product Strategy / Product Authority | ⏸ Pending | — |
 
 ---
 
 ## 1. Summary
 
-A Variant is a soul-scoped sub-theme within a Soul DID: a named configuration that carries distinct visual identity specializations and audience targeting while inheriting the parent Soul DID's foundational triad and compliance regime.
+A **Variant** is a soul-scoped sub-theme within a Soul DID (RFC-0009 §2): a named configuration that carries distinct visual identity specializations and audience targeting while inheriting the parent Soul DID's foundational triad (E × P × D) and compliance regime.
 
-This RFC defines the In-Soul Variant Pattern — how variants are declared, how they inherit from their parent Soul DID, and how the admission composite scores work items that target a specific variant rather than the full soul.
+This RFC defines the **In-Soul Variant Pattern** — how variants are declared on a Soul DID, how they inherit from their parent, how the admission composite (RFC-0008 / RFC-0005) scores work items that target a specific variant rather than the full soul, and where the boundary lies between "this is a variant" and "this is a separate soul."
 
-**Practitioner validation source:** SpryPoint's four-product suite (SpryEngage, SpryMobile, SpryCIS, SpryBackflow) provides the reference implementation. Each product is a distinct soul on shared substrate; each soul contains audience-specific variants requiring independent design intent declaration while sharing the soul's compliance floor and design system tokens.
+The pattern is **configuration-based, not flow-based**. Flow-based sub-divisions (sequences of states + transitions) are RFC-0018's concern; this RFC handles the static configuration overlay.
 
-Full normative spec to follow after practitioner validation pass.
+**Practitioner validation source:** SpryPoint's four-product suite (SpryEngage, SpryMobile, SpryCIS, SpryBackflow). Each product is a distinct soul on shared substrate. Within each product, audience-specific variants emerge — e.g., SpryEngage has variants for small-utility-municipality vs. large-municipality vs. county-level deployments — each with distinct visual specializations and audience profiles, but all sharing the soul's WCAG 2.1 AA compliance floor and shared design system tokens.
 
-## Motivation
+## 2. Motivation
 
-Why is this change needed? What problem does it solve? Include specific pain points, use cases, or data that motivate the proposal.
+Today, the Soul DID model (RFC-0009) gives a single design intent surface per product face. This is correct for cases where a product has one cohesive identity. But practitioners report:
 
-## Goals
+- A product targets multiple audience segments with distinct visual specializations (e.g., small-utility vs. enterprise) that share the same compliance regime + design system foundation
+- Forcing each audience-segment to be its own Soul DID creates platform-level fragmentation: the substrate doesn't actually differ; only the visual + audience specialization does
+- Forcing them to share one Soul DID collapses the per-segment design intent into platform-aggregate scoring (the same observed failure mode as multi-product platforms in RFC-0009 §3, applied one scope down)
 
-- Goal 1
-- Goal 2
+Specifically observed: **a Soul DID's `design.imperatives` field feeds Sα₂ Vibe Coherence scoring at soul scope. When a soul has multiple audience-specific variants, soul-aggregate Sα₂ scoring produces the same misallocation pattern RFC-0009 documented at the platform↔soul boundary** — work that's variant-bounded (e.g., a small-utility-only feature) gets scored against the soul-aggregate design intent, which underweights the variant's specific design imperatives.
 
-## Non-Goals
+The framework needs an in-soul partition for this case that:
 
-- Non-goal 1 (explicitly out of scope)
-- Non-goal 2
+1. Inherits the soul's compliance + substrate (no escape hatch)
+2. Allows a bounded specialization of design intent
+3. Composes cleanly with admission scoring (variant-targeted work scores against variant intent, not soul-aggregate)
 
-## Proposal
+## 3. Goals
 
-Detailed description of the proposed change. Include:
+1. **First-class variant declaration on Soul DID** — `soul.spec.variants[]` with id, audience, design overrides
+2. **Bounded inheritance** — variants inherit substrate + compliance from parent Soul; cannot escape either
+3. **Admission scoring composes** — `targetedVariants` field on work items routes scoring through variant-level design intent (analogous to RFC-0009's `targetedSouls`)
+4. **Boundary clarity** — explicit guidance for when to use a variant vs. spawn a separate Soul DID
+5. **Backward compatibility** — Soul DIDs without variants behave identically to today
+6. **Practitioner validation** — SpryPoint's four-product suite proves out the pattern before normative status
 
-- New or modified resource fields with types and validation rules
-- Updated schema definitions (JSON Schema fragments)
-- Modified normative requirements (with RFC 2119 language)
-- YAML examples showing the proposed configuration
+## 4. Non-Goals
 
-## Design Details
+1. **Flow-based sub-divisions** — that's RFC-0018 (Journey). Variant is static configuration; Journey is temporal sequence.
+2. **Cross-soul variants** — a variant lives within a single Soul DID. Cross-soul work uses RFC-0009's `targetedSouls`.
+3. **Independent compliance regimes per variant** — variants inherit the soul's compliance floor with no escape hatch. If two configurations require different compliance regimes, they're separate Souls.
+4. **Variant marketplaces** — third-party / customer-defined variants are explicitly out of scope; v1 limits variant declaration to the Soul DID author (Design Authority).
+5. **Substrate divergence** — variants share the soul's `substrateInvariants` exactly. Substrate-level differences require a separate Soul.
 
-### Schema Changes
+## 5. Proposal
 
-Show the relevant JSON Schema additions or modifications.
+### 5.1 Variant declaration on Soul DID
+
+Add `variants[]` to Soul DID `spec`:
+
+```yaml
+apiVersion: ai-sdlc.io/v1alpha1
+kind: SoulDID
+metadata:
+  name: spry-engage
+spec:
+  # ... existing Soul DID fields ...
+  variants:
+    - id: small-utility
+      targetAudience:
+        segments: [municipal-small, water-district-small]
+        sizeRange: { minStaff: 1, maxStaff: 50 }
+      designOverrides:
+        voiceRegister: "approachable-municipal"
+        colorPaletteOverlay: "small-utility-warm"
+        densityProfile: "comfortable"
+      complianceFloor: inherit  # MUST inherit; explicit for clarity
+      designImperatives:
+        - "low-tech-fluency-tolerance"
+        - "single-task-focus-per-screen"
+    - id: enterprise
+      targetAudience:
+        segments: [municipal-large, regional-utility]
+        sizeRange: { minStaff: 51, maxStaff: 5000 }
+      designOverrides:
+        voiceRegister: "professional-administrative"
+        colorPaletteOverlay: "enterprise-cool"
+        densityProfile: "compact"
+      complianceFloor: inherit
+      designImperatives:
+        - "bulk-operation-efficiency"
+        - "multi-tab-workflow-tolerance"
+```
+
+### 5.2 Variant fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string (kebab-case, unique within soul) | yes | Variant identifier |
+| `targetAudience` | object | yes | Audience characteristics; structure mirrors Soul DID `targetAudience` schema (Sα₁ input) |
+| `designOverrides` | object | no | Subset of design fields the variant specializes (voice, color overlay, density). MUST be a subset of fields the parent Soul declares as variant-overridable. |
+| `complianceFloor` | enum (`inherit`) | yes | MUST be `inherit`. Variants cannot diverge from soul compliance. The field is required-and-fixed for clarity at the YAML surface — schema validation rejects any other value. |
+| `designImperatives` | string[] | no | Variant-scoped Sα₂ inputs. Layered on top of soul-level `designImperatives`; variant imperatives take precedence in conflict (most-specific-wins). |
+| `cardinality` (RESERVED) | enum (`primary`, `secondary`, `experimental`) | no | Future-use lifecycle hint. v1 ignores; documents the `experimental` exit ramp for OQ-3. |
+
+### 5.3 Bounded inheritance
+
+A Variant inherits from its parent Soul DID:
+
+| Inherited (variant cannot override) | Specializable (variant overrides allowed) |
+|---|---|
+| `complianceRegimes` (per-soul) | `voiceRegister` (variant-scoped) |
+| `substrateInvariants` | `colorPaletteOverlay` (additive layer over soul palette) |
+| `tenantQuotaShare` (RFC-0010) | `densityProfile` |
+| `engineering.performanceBudgets` | `designImperatives` (additive, most-specific-wins) |
+| `engineering.observabilityRequirements` | `targetAudience` (variant-specific segments) |
+
+If a variant attempts to override an inherited field, schema validation MUST emit `VariantInheritanceViolation` (Engineering vertex error per RFC-0008 §C5).
+
+### 5.4 Admission scoring composition
+
+Work items target a variant via `targetedVariants` (parallel to RFC-0009 `targetedSouls`):
+
+```yaml
+apiVersion: ai-sdlc.io/v1alpha1
+kind: WorkItem
+metadata:
+  name: small-utility-onboarding-improvement
+spec:
+  targetedSouls: [spry-engage]
+  targetedVariants: [spry-engage/small-utility]   # Soul-id/Variant-id
+```
+
+Scoring composes per-variant:
+
+- **Sα₁ Audience Resonance** — variant's `targetAudience` overrides soul's
+- **Sα₂ Vibe Coherence** — variant's `designImperatives` UNION soul's; conflict resolution: variant wins (most-specific)
+- **Cκ Capability Coverage** — soul-level (variants don't override capability)
+- **Eρ_n** — soul-level (variants inherit compliance/substrate; no override)
+- **Dπ_n** — soul-level (Demand Pressure / Market Force / Entropy Tax are platform-aggregate channels)
+
+Cross-variant scoring rule (work touches multiple variants of same soul) — same `min` aggregation as RFC-0009 §7.2 for cross-soul, applied at the variant scope. Per RFC-0009 OQ-2: `min` is the default; opt-in alternatives (`max`, `weighted`) require explicit declaration.
+
+### 5.5 Boundary: variant vs. separate Soul
+
+**Use a Variant when:**
+- Same compliance regime (WCAG level, regulatory posture, retention rules)
+- Same substrate (event bus, schema, tenant model)
+- Different audience + visual specialization within the same product face
+
+**Use a separate Soul when:**
+- Different compliance regime (e.g., HIPAA vs. SOC2, different WCAG level)
+- Different substrate (different event bus, different schema, different tenant model)
+- Different "product face" (operator + adopter both perceive these as distinct products)
+
+The Design Authority owns the boundary call. When uncertain, default to **separate Soul** — variants are an optimization for the homogeneous-substrate case; separate Souls are the safe default that preserves flexibility.
+
+## 6. Design Details
+
+### 6.1 Schema additions
+
+Add to the Soul DID schema (file path: RFC-0009 implementation phase concern):
 
 ```json
 {
   "properties": {
-    "newField": {
-      "type": "string",
-      "description": "Description of the new field."
+    "variants": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "targetAudience", "complianceFloor"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*$",
+            "description": "Kebab-case variant identifier; unique within the soul."
+          },
+          "targetAudience": { "$ref": "#/$defs/AudienceProfile" },
+          "designOverrides": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "voiceRegister": { "type": "string" },
+              "colorPaletteOverlay": { "type": "string" },
+              "densityProfile": { "type": "string", "enum": ["compact", "comfortable", "spacious"] }
+            }
+          },
+          "complianceFloor": {
+            "type": "string",
+            "const": "inherit",
+            "description": "MUST be 'inherit'. Variants cannot diverge from soul compliance."
+          },
+          "designImperatives": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "cardinality": {
+            "type": "string",
+            "enum": ["primary", "secondary", "experimental"]
+          }
+        }
+      }
     }
   }
 }
 ```
 
-### Behavioral Changes
+Add to the Work Item schema:
 
-Describe any changes to reconciliation behavior, evaluation semantics, or enforcement logic.
+```json
+{
+  "properties": {
+    "targetedVariants": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]*\\/[a-z][a-z0-9-]*$",
+        "description": "Soul-id/variant-id format."
+      }
+    }
+  }
+}
+```
 
-### Migration Path
+### 6.2 Behavioral changes
 
-If this is a breaking change, describe the migration path from the current behavior to the proposed behavior.
+- **Reconciliation** — when a variant is added/removed/modified, the `Eτ_tessellation_drift` detector (RFC-0009 §13) MUST scan substrate code for variant-specific identifiers (parallel to per-soul scan). Substrate code referring to specific variant IDs is a drift signal.
+- **Admission scoring** — when `targetedVariants` is non-empty, the admission scorer routes Sα₁ + Sα₂ inputs through variant-level fields. When empty, scoring proceeds at soul scope (unchanged from RFC-0009 baseline).
+- **Cross-soul work** — when a work item targets variants in MULTIPLE souls, the cross-soul aggregation rule (RFC-0009 §7.2) applies at the soul level FIRST, then the cross-variant rule applies within each soul.
 
-## Backward Compatibility
+### 6.3 Migration path
 
-Describe the backward compatibility implications:
+Soul DIDs without `variants[]` declared are unchanged. Adding variants is purely additive. Removing a variant requires:
 
-- Is this a breaking change?
-- Can existing resources be validated against the updated schema without modification?
-- What is the migration path for existing implementations?
+1. Sweep `targetedVariants` across all open work items; reject removal if any work item references the variant
+2. Provide deprecation window (default 30 days) before hard-removal
+3. Emit `VariantRemoved` event per RFC-0008 event taxonomy
 
-## Alternatives Considered
+## 7. Backward Compatibility
 
-Describe alternative approaches that were considered and why they were rejected.
+**Not a breaking change.** Soul DIDs that don't declare `variants[]` continue to behave identically. Work items that don't declare `targetedVariants` are scored at soul scope as before.
 
-### Alternative 1: [Name]
+The only soft regression: if a Soul DID's Sα₂ scoring previously relied on operator-implicit knowledge of audience-specific design intent, surfacing variants makes that intent explicit AND scorable. Some operators may discover their existing `designImperatives` are over-aggregated; the migration is to factor them into variant-specific lists.
 
-Description and rationale for rejection.
+## 8. Alternatives Considered
 
-### Alternative 2: [Name]
+### 8.1 Subclasses (variant inherits Soul via `extends:`)
 
-Description and rationale for rejection.
+OO-style inheritance with method-override semantics. **Rejected** — too sharp an edge; operators end up reasoning about what's overridable. The bounded-inheritance table (§5.3) is more constrained and less surprising.
 
-## Implementation Plan
+### 8.2 Composition (variant composes a Soul + an overlay resource)
 
-- [ ] Update normative spec document(s)
-- [ ] Update JSON Schema(s)
-- [ ] Update glossary (if new terms introduced)
-- [ ] Update primer (if architectural changes)
-- [ ] Reference implementation proof-of-concept
-- [ ] Conformance test updates
-- [ ] Author/update each user-facing doc surface declared in `requiresDocs`
+Variants as separate `kind: SoulVariant` resources composed at admission time. **Rejected** — adds a resource kind for a sub-concern that's tightly bound to a parent. Composition makes sense across loosely-coupled concerns; variant ↔ soul is a tight binding.
 
-## Open Questions
+### 8.3 Tags / labels (variant as a label dimension on work items)
 
-1. Question 1?
-2. Question 2?
+Skip the schema change; route through label-based filtering. **Rejected** — doesn't compose with admission scoring; loses the inheritance contract; doesn't surface in the Tessellated Design Intent Document hierarchy.
 
-## References
+### 8.4 Just spawn a separate Soul per variant
 
-- [RFC-0009 Tessellated Design Intent Documents](RFC-0009-tessellated-design-intent-documents.md)
+The "use the existing Soul DID model" answer. **Rejected for the homogeneous-substrate case** (per §5.5) — creates platform-level fragmentation when the substrate genuinely doesn't differ. **Recommended for the heterogeneous-substrate case** — RFC keeps the boundary explicit.
+
+## 9. Implementation Plan
+
+- [ ] Soul DID schema addition (`variants[]`)
+- [ ] Work Item schema addition (`targetedVariants`)
+- [ ] Admission scorer composition (Sα₁ + Sα₂ variant routing)
+- [ ] Variant inheritance validator (`VariantInheritanceViolation` event)
+- [ ] `Eτ_tessellation_drift` detector extension for variant-scoped scans
+- [ ] SpryPoint four-product suite as reference implementation (one variant per product, minimum)
+- [ ] Glossary additions (`Variant`, `targetedVariants`, `complianceFloor: inherit`)
+- [ ] Conformance test suite — variant declaration round-trip; admission-scoring composition; inheritance enforcement
+- [ ] Author/update each user-facing doc surface declared in `requiresDocs` (currently `[]` — pending tutorial/runbook decision)
+
+## 10. Open Questions
+
+These need design + operator walkthrough before Lifecycle: Draft → Ready for Review.
+
+**OQ-1 — Maximum variants per Soul:** Should the schema cap variant count (e.g., max 5) to discourage over-fragmentation, or trust operators? Recommendation: soft warning at 5+, hard limit at 20 (sanity check, not design constraint).
+
+**OQ-2 — Nested variants:** Can a variant declare its own sub-variants? Recommendation: NO for v1 — adds complexity for a use case (variant-of-variant) we have no practitioner evidence for. Revisit if SpryPoint or another adopter surfaces a real need.
+
+**OQ-3 — Variant lifecycle (deprecation, removal):** §6.3 sketches the removal flow. What's the right deprecation-window default — 30 days, 90 days, or operator-configured per Soul? Recommendation: configurable per Soul with 30-day default.
+
+**OQ-4 — Cross-variant scoring rule precedence:** RFC-0009 §7.2 sets `min` as cross-soul default. Same default for cross-variant within a soul, OR should variants default to `max` (since they're more loosely coupled than souls within a tessellation)? Recommendation: same `min` default for consistency.
+
+**OQ-5 — designOverrides extensibility:** §6.1 lists `voiceRegister`, `colorPaletteOverlay`, `densityProfile`. Should this be open-ended (any field name) or closed-enum? Recommendation: closed-enum for v1 to force design-authority discipline; expand as new override needs surface.
+
+**OQ-6 — Variant ID URI representation in DID:** RFC-0009 uses `did:platform-x:soul:engage`. What's the variant URI? Options: (a) `did:platform-x:soul:engage/variant:small-utility`, (b) `did:platform-x:soul:engage:small-utility` (slug-concat), (c) `did:platform-x:variant:engage/small-utility`. Recommendation: (a) — preserves explicit hierarchy.
+
+**OQ-7 — Engineering authority on variant declarations:** RFC-0009 makes Design Authority the owner of `design.*` fields with Engineering as reviewer. Same model for variant declarations? Or does Engineering own `targetAudience` (since audience determines load characteristics)? Recommendation: Design owns variant declaration; Engineering reviews + may block on substrate-cost grounds.
+
+**OQ-8 — `cardinality` field activation:** §5.2 reserves `cardinality: primary | secondary | experimental` for v2. What's the v1 → v2 trigger to activate this — practitioner demand, or a specific lifecycle event? Recommendation: defer activation to a follow-on RFC when at least 2 adopters request lifecycle distinctions.
+
+## 11. Practitioner Validation Plan
+
+SpryPoint's four-product suite drives the validation pass:
+
+| Soul | Variants (proposed) | Validates |
+|---|---|---|
+| SpryEngage | small-utility, enterprise, county-regional | Audience-segment specialization; voice register variation |
+| SpryMobile | field-tech-on-truck, field-tech-handheld, supervisor-tablet | Density profile + form-factor specialization |
+| SpryCIS | billing-clerk, customer-portal, csr-dashboard | Role-based audience + workflow-density specialization |
+| SpryBackflow | annual-test, repair-event, regulatory-audit-mode | Temporal-context-bound design intent (validates the §11 carries through to RFC-0018 Journey too) |
+
+Validation criteria (Mo's edits welcome):
+1. Each variant's design intent is articulable in ≤ 5 `designImperatives` strings
+2. No variant requires a field NOT in the §6.1 schema (closed-enum holds)
+3. Admission scoring on a real work item (e.g., "small-utility onboarding improvement") produces a different + better-justified score than soul-aggregate scoring
+4. Engineering vertex confirms substrate is genuinely shared across all variants of each soul (no hidden divergence)
+
+## 12. References
+
+- [RFC-0009 Tessellated Design Intent Documents](RFC-0009-tessellated-design-intent-documents.md) — parent Soul DID model
+- [RFC-0008 PPA Triad Integration](RFC-0008-ppa-triad-integration-final-combined.md) — admission scoring foundation; variant scoring extends `targetedSouls` pattern
+- [RFC-0018 In-Soul Journey Pattern](RFC-0018-in-soul-journey-pattern.md) — companion: temporal flow patterns within a Soul or Variant
+
+## 13. Revision History
+
+| Version | Date | Author | Notes |
+|---|---|---|---|
+| v0.1 | 2026-05-04 | Morgan Hirtle | Initial stub (carve-out from RFC-0009 OQ-3). Established summary + practitioner-validation source. |
+| v0.2 | 2026-05-04 | Engineering pass (Dominique + Claude Opus 4.7) | Filled §3-§13 from boilerplate. Schema sketch, inheritance table, admission-scoring composition, boundary-vs-separate-soul, alternatives, 8 open questions, SpryPoint validation plan. Awaiting Mo's design-authority editorial pass on §5.3 + §10. |

--- a/spec/rfcs/RFC-0018-in-soul-journey-pattern.md
+++ b/spec/rfcs/RFC-0018-in-soul-journey-pattern.md
@@ -16,9 +16,10 @@ requiresDocs: []
 # RFC-0018: In-Soul Journey Pattern
 
 **Document type:** Normative (draft)
-**Status:** Draft v0.1 — Initial stub. Full spec pending practitioner validation pass against SpryPoint accessibility audit pipeline.
+**Status:** Draft v0.2 — Initial spec expansion (Engineering pass on Mo's v0.1 stub). Practitioner-validation gates in §11 unresolved; full normative status awaits SpryPoint accessibility-audit-pipeline implementation pass + Mo's design-authority editorial review of §3-§13.
 **Created:** 2026-05-04
 **Authors:** Morgan Hirtle (Design Authority, SpryPoint)
+**Engineering pass:** Dominique Legault, Claude Opus 4.7 (orchestrator), 2026-05-04 — fleshed §3-§13 from Mo's v0.1 stub. Design + accessibility-vertex semantics (specifically §5.4 success metrics + §10 OQs) deferred to Mo for editorial pass.
 **Requires:** RFC-0009 (Tessellated Design Intent Documents), RFC-0017 (In-Soul Variant Pattern)
 
 > The bold-style status block above is preserved for human readability. The
@@ -31,106 +32,415 @@ requiresDocs: []
 
 | Person | Role | Status | Date |
 |--------|------|--------|------|
-| Morgan Hirtle | Chief of Design / Design Authority | ✍️ Authored v0.1 | 2026-05-04 |
-| Dominique Legault | CTO / Engineering Authority | ⏸ Pending | — |
+| Morgan Hirtle | Chief of Design / Design Authority | ✍️ Authored v0.1 stub | 2026-05-04 |
+| Dominique Legault | CTO / Engineering Authority | ✏️ Engineering pass on v0.2 (pending Design editorial) | 2026-05-04 |
 | Alexander Kline | Head of Product Strategy / Product Authority | ⏸ Pending | — |
 
 ---
 
 ## 1. Summary
 
-A Journey is a temporally-ordered user flow within a Soul DID (or within a Variant per RFC-0017): a named sequence of states and transitions that carries distinct design intent, completion criteria, and success metrics at the soul level.
+A **Journey** is a temporally-ordered user flow within a Soul DID (RFC-0009 §2) or Variant (RFC-0017): a named sequence of states and transitions that carries distinct design intent, completion criteria, accessibility requirements, and success metrics at the journey scope.
 
-This RFC defines the In-Soul Journey Pattern — how journeys are declared on a Soul DID, how they relate to Variants (RFC-0017), and how the admission composite prioritizes work items that advance, repair, or complete a specific journey.
+This RFC defines the **In-Soul Journey Pattern** — how journeys are declared on a Soul DID (or Variant), how they relate to the parent's design intent surface, how the admission composite (RFC-0008 / RFC-0005) prioritizes work items that advance, repair, or complete a specific journey, and where the boundary lies between "this is a journey" and "this is just a feature."
 
-**Practitioner validation source:** SpryPoint's accessibility audit pipeline provides the reference implementation. The WCAG 2.1 AA audit surface maps naturally to journey-level design intent: each product flow (onboarding, payment, backflow reporting) is a journey with distinct completion criteria and accessibility requirements that cannot be collapsed to soul-level aggregate scoring without losing precision.
+The pattern is **flow-based, not configuration-based**. Static configuration overlays are RFC-0017's concern; this RFC handles temporal sequences that have entry, intermediate, terminal, and (sometimes) failure states.
 
-Full normative spec to follow after practitioner validation pass.
+**Practitioner validation source:** SpryPoint's accessibility audit pipeline. The WCAG 2.1 AA audit surface maps naturally to journey-level design intent: each product flow (onboarding, payment, backflow reporting, regulatory submission) is a journey with distinct completion criteria and accessibility requirements that cannot be collapsed to soul-level aggregate scoring without losing precision. A WCAG failure on the SpryEngage onboarding journey doesn't tell you anything useful about SpryEngage's billing journey — they have different states, different transitions, different audiences, different success criteria.
 
-## Motivation
+## 2. Motivation
 
-Why is this change needed? What problem does it solve? Include specific pain points, use cases, or data that motivate the proposal.
+Today, the Soul DID model (RFC-0009) gives a single design intent surface per product face, and RFC-0017 adds variant-level configuration overlays. Both are static — they describe a configuration in time, not a sequence through time. But practitioners report:
 
-## Goals
+- A product face contains multiple distinct user flows (onboarding, daily-task, occasional-event, regulatory) each with different completion semantics
+- Soul-level success metrics aggregate across all flows, masking per-flow regressions (an onboarding-completion regression averages-out against a healthy daily-task flow)
+- WCAG conformance audits MUST be per-flow — auditors evaluate the user's path through the system, not the system's overall configuration
+- Work items that target "improve the onboarding flow" need to score against onboarding-specific design intent + accessibility requirements, not soul-aggregate
 
-- Goal 1
-- Goal 2
+Specifically observed at SpryPoint: **the WCAG 2.1 AA audit pipeline produces per-flow conformance reports. Today these reports have nowhere to land in the framework's scoring surface — they're operator-implicit context.** The framework treats accessibility as a soul-level compliance regime, but the actual conformance evidence is journey-level.
 
-## Non-Goals
+The framework needs a temporal partition for this case that:
 
-- Non-goal 1 (explicitly out of scope)
-- Non-goal 2
+1. Names the user flow at a scope the framework can score against
+2. Captures completion criteria the framework can verify (work item that "improves onboarding" scores higher when onboarding completion-rate has regressed)
+3. Routes accessibility + design imperatives at journey scope (not collapsed to soul)
+4. Composes with RFC-0017 (a journey can live within a Variant — e.g., the small-utility variant has a different onboarding flow than the enterprise variant)
 
-## Proposal
+## 3. Goals
 
-Detailed description of the proposed change. Include:
+1. **First-class journey declaration on Soul DID (or Variant)** — `soul.spec.journeys[]` (or `variant.spec.journeys[]`) with id, states, transitions, completion criteria, success metrics
+2. **Journey-scoped design intent** — `journey.designImperatives` layered on top of soul/variant level (most-specific-wins, same as RFC-0017 §5.4)
+3. **Journey-scoped accessibility requirements** — explicit WCAG level / conformance target per journey; lifts compliance gating from soul-aggregate to per-flow
+4. **Admission scoring composes** — `targetedJourneys` field on work items routes scoring through journey-level design intent + success metrics
+5. **Composes with Variants (RFC-0017)** — a journey can be soul-scoped OR variant-scoped; admission scorer handles both
+6. **Backward compatibility** — Soul DIDs without journeys behave identically
+7. **Practitioner validation** — SpryPoint's accessibility audit pipeline proves out journey-scoped scoring + WCAG mapping before normative status
 
-- New or modified resource fields with types and validation rules
-- Updated schema definitions (JSON Schema fragments)
-- Modified normative requirements (with RFC 2119 language)
-- YAML examples showing the proposed configuration
+## 4. Non-Goals
 
-## Design Details
+1. **Workflow engine** — this RFC defines journey AS A SCORING SCOPE. Runtime state-machine execution (does a user actually move from state A → B?) is the application's concern, not the framework's. The framework reads completion-rate metrics; it doesn't compute them.
+2. **Cross-journey navigation** — a journey is a flow within ONE soul/variant. Multi-soul user paths (user spans multiple products) are operator-application concerns.
+3. **State-explosion guards** — the framework does not enforce a maximum number of states or transitions per journey. Journey complexity is the design authority's call.
+4. **A/B testing framework** — running parallel journey variants in production is out of scope. RFC-0017's `cardinality: experimental` is the closest hook for "this journey is experimental"; treatment-vs-control tracking is application-side.
+5. **Cross-soul journeys** — a journey lives within a single Soul DID (or one of its Variants). Multi-soul flows require the operator to model them as separate journeys per soul + a coordination layer outside the framework.
 
-### Schema Changes
+## 5. Proposal
 
-Show the relevant JSON Schema additions or modifications.
+### 5.1 Journey declaration
+
+Add `journeys[]` to Soul DID `spec` AND to Variant (RFC-0017 §5.1):
+
+```yaml
+apiVersion: ai-sdlc.io/v1alpha1
+kind: SoulDID
+metadata:
+  name: spry-engage
+spec:
+  # ... existing Soul DID fields including variants[] from RFC-0017 ...
+  journeys:
+    - id: onboarding
+      scope: soul                 # journey applies to ALL variants
+      states:
+        - id: arrived
+          terminal: false
+        - id: account-created
+          terminal: false
+        - id: profile-complete
+          terminal: false
+        - id: first-task-done
+          terminal: true
+          successState: true       # reaching this state = journey-success
+        - id: abandoned
+          terminal: true
+          successState: false      # explicit failure-state (analytics signal)
+      transitions:
+        - from: arrived
+          to: account-created
+          trigger: "user-signup"
+        - from: account-created
+          to: profile-complete
+          trigger: "profile-form-submitted"
+        - from: profile-complete
+          to: first-task-done
+          trigger: "first-task-completed"
+        - from: ["arrived", "account-created", "profile-complete"]
+          to: abandoned
+          trigger: "session-timeout-30d"
+      completionCriteria:
+        kind: terminal-success-state
+        target: first-task-done
+      accessibility:
+        wcagLevel: "AA"
+        wcagVersion: "2.1"
+        conformanceTarget: 100   # percent
+        auditCadence: quarterly
+      successMetrics:
+        - id: completion-rate
+          target: 0.65            # 65%
+          alertBelow: 0.50
+        - id: median-time-to-first-task-done
+          targetSeconds: 1800     # 30 min
+          alertAbove: 3600        # 1 hour
+      designImperatives:
+        - "first-task-done within 30 min of account creation"
+        - "profile-form is single-screen (no pagination)"
+    - id: backflow-annual-test
+      scope: variant:annual-test  # journey applies only to a specific variant
+      # ... fields as above ...
+```
+
+### 5.2 Journey fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string (kebab-case, unique within parent scope) | yes | Journey identifier |
+| `scope` | enum (`soul`, `variant:<id>`) | yes | Whether this journey applies to the whole Soul or a specific Variant |
+| `states` | array of state objects | yes | Named states; at least 1 MUST have `terminal: true` AND `successState: true` |
+| `transitions` | array of transition objects | yes | State-to-state transitions; `from` MAY be a string OR array (any-of); `to` is a single state id |
+| `completionCriteria` | object | yes | How "done" is defined (terminal-success-state, all-states-reached, custom-predicate) |
+| `accessibility` | object | yes | WCAG level + version + conformance target + audit cadence (per RFC-0009 compliance regime) |
+| `successMetrics` | array of metric objects | no | Quantified success signals; feeds Sα₂ + Cκ scoring at journey scope |
+| `designImperatives` | string[] | no | Journey-scoped design intent; layered on soul + variant per most-specific-wins |
+| `complianceFloor` | enum (`inherit`) | yes (when scope=variant) | MUST be `inherit` — journeys cannot diverge from parent compliance |
+
+### 5.3 Bounded inheritance + composition with Variants
+
+Inheritance flows: **Soul DID → Variant → Journey** (when scoped to a variant) OR **Soul DID → Journey** (when scoped to soul).
+
+| Inherited (journey cannot override) | Specializable (journey overrides allowed) |
+|---|---|
+| `complianceRegimes` (per-soul) | `accessibility.wcagLevel` (journey may set HIGHER than soul) |
+| `substrateInvariants` | `designImperatives` (additive, most-specific-wins) |
+| `targetAudience` (from soul or variant) | `successMetrics` (journey-scoped only — no parent equivalent) |
+| `tenantQuotaShare` (RFC-0010) | `completionCriteria` (journey-scoped only) |
+
+Journeys MAY raise the WCAG level above the parent (e.g., a soul defaults to WCAG 2.1 AA but the regulatory-submission journey requires 2.2 AAA). Journeys MAY NOT lower the WCAG level below the parent.
+
+### 5.4 Admission scoring composition
+
+Work items target a journey via `targetedJourneys` (parallel to RFC-0017 `targetedVariants`):
+
+```yaml
+apiVersion: ai-sdlc.io/v1alpha1
+kind: WorkItem
+metadata:
+  name: onboarding-profile-form-pagination-removal
+spec:
+  targetedSouls: [spry-engage]
+  targetedVariants: [spry-engage/small-utility]
+  targetedJourneys: [spry-engage/onboarding]   # Soul-id/Journey-id
+                                                # OR Soul-id/Variant-id/Journey-id
+```
+
+Scoring composes per-journey:
+
+- **Sα₁ Audience Resonance** — soul/variant level (journeys don't redefine audience)
+- **Sα₂ Vibe Coherence** — journey's `designImperatives` UNION variant's UNION soul's; conflict resolution: most-specific wins (journey > variant > soul)
+- **Cκ Capability Coverage** — journey's `successMetrics` weighted at journey scope; if journey's `completion-rate` is BELOW its `alertBelow` threshold, work that addresses this journey gets a Cκ boost (the framework knows this journey is hurting)
+- **Eρ₅ Compliance Clearance** — elevated when journey has explicit accessibility requirements above the soul floor (regulatory work on a journey with `wcagLevel: AAA` gates more strictly than soul-default work)
+- **Dπ_n** — soul/variant level (Demand Pressure / Market Force / Entropy Tax are aggregate channels)
+
+Cross-journey scoring rule (work touches multiple journeys) — same `min` aggregation as RFC-0009 §7.2 / RFC-0017 §5.4 by default.
+
+### 5.5 Boundary: journey vs. just a feature
+
+**Use a Journey when:**
+- The flow has a discoverable sequence of states (entry → intermediate → terminal)
+- Completion has a meaningful definition (not "user did something" but "user reached a specific terminal state")
+- Distinct accessibility requirements exist (WCAG audit produces per-flow reports)
+- Distinct success metrics exist (completion rate, time-to-completion are measurable + meaningful)
+
+**Don't use a Journey for:**
+- Single-screen interactions ("the settings page" — that's a feature, not a journey)
+- Stateless API calls
+- Background jobs
+- Static content surfaces
+
+The Design Authority owns the boundary call. When uncertain, default to **don't add a journey** — journeys carry overhead (declaration, accessibility audit, success metrics maintenance) that should pay for itself in scoring precision. Underuse is safer than overuse.
+
+## 6. Design Details
+
+### 6.1 Schema additions
+
+Add to Soul DID schema AND Variant schema (per RFC-0017 §5.1):
 
 ```json
 {
   "properties": {
-    "newField": {
-      "type": "string",
-      "description": "Description of the new field."
+    "journeys": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Journey" }
+    }
+  },
+  "$defs": {
+    "Journey": {
+      "type": "object",
+      "required": ["id", "scope", "states", "transitions", "completionCriteria", "accessibility"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+        "scope": {
+          "type": "string",
+          "pattern": "^(soul|variant:[a-z][a-z0-9-]*)$"
+        },
+        "states": {
+          "type": "array",
+          "minItems": 2,
+          "items": {
+            "type": "object",
+            "required": ["id", "terminal"],
+            "properties": {
+              "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+              "terminal": { "type": "boolean" },
+              "successState": { "type": "boolean", "description": "Required when terminal=true" }
+            }
+          }
+        },
+        "transitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["from", "to", "trigger"],
+            "properties": {
+              "from": {
+                "oneOf": [
+                  { "type": "string" },
+                  { "type": "array", "items": { "type": "string" } }
+                ]
+              },
+              "to": { "type": "string" },
+              "trigger": { "type": "string" }
+            }
+          }
+        },
+        "completionCriteria": {
+          "type": "object",
+          "required": ["kind"],
+          "properties": {
+            "kind": { "type": "string", "enum": ["terminal-success-state", "all-states-reached", "custom-predicate"] },
+            "target": { "type": "string" },
+            "predicate": { "type": "string", "description": "Required when kind=custom-predicate" }
+          }
+        },
+        "accessibility": {
+          "type": "object",
+          "required": ["wcagLevel", "wcagVersion", "conformanceTarget"],
+          "properties": {
+            "wcagLevel": { "type": "string", "enum": ["A", "AA", "AAA"] },
+            "wcagVersion": { "type": "string", "enum": ["2.0", "2.1", "2.2", "3.0"] },
+            "conformanceTarget": { "type": "number", "minimum": 0, "maximum": 100 },
+            "auditCadence": { "type": "string", "enum": ["quarterly", "annually", "release-gated", "continuous"] }
+          }
+        },
+        "successMetrics": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id"],
+            "properties": {
+              "id": { "type": "string" },
+              "target": { "type": "number" },
+              "alertBelow": { "type": "number" },
+              "alertAbove": { "type": "number" },
+              "targetSeconds": { "type": "number" }
+            }
+          }
+        },
+        "designImperatives": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "complianceFloor": {
+          "type": "string",
+          "const": "inherit"
+        }
+      }
     }
   }
 }
 ```
 
-### Behavioral Changes
+Add to Work Item schema:
 
-Describe any changes to reconciliation behavior, evaluation semantics, or enforcement logic.
+```json
+{
+  "properties": {
+    "targetedJourneys": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]*\\/(([a-z][a-z0-9-]*\\/)?[a-z][a-z0-9-]*)$",
+        "description": "Soul-id/Journey-id OR Soul-id/Variant-id/Journey-id"
+      }
+    }
+  }
+}
+```
 
-### Migration Path
+### 6.2 Behavioral changes
 
-If this is a breaking change, describe the migration path from the current behavior to the proposed behavior.
+- **Reconciliation** — journey state IDs / transitions are referenced by application code (instrumentation, analytics). The `Eτ_tessellation_drift` detector (RFC-0009 §13) MUST scan substrate code for journey state ID references parallel to soul/variant scans. Application code referencing a state that's been removed is a drift signal.
+- **Admission scoring** — when `targetedJourneys` is non-empty, the admission scorer routes Sα₂ + Cκ + Eρ₅ inputs through journey-level fields. Cκ specifically boosts work when journey success-metrics are below `alertBelow` thresholds.
+- **Compliance escalation** — work that targets a journey with `wcagLevel` ABOVE the soul-default MUST trigger Eρ₅ Compliance Clearance at the journey-elevated level, not the soul-default level.
 
-## Backward Compatibility
+### 6.3 Migration path
 
-Describe the backward compatibility implications:
+Soul DIDs without `journeys[]` are unchanged. Adding journeys is purely additive. Removing a journey requires:
 
-- Is this a breaking change?
-- Can existing resources be validated against the updated schema without modification?
-- What is the migration path for existing implementations?
+1. Sweep `targetedJourneys` across all open work items; reject removal if any work item references the journey
+2. Sweep substrate code for state ID references; report any matches as drift
+3. Provide deprecation window (default 90 days for journeys vs. 30 for variants — journeys carry more downstream code references)
+4. Emit `JourneyRemoved` event per RFC-0008 event taxonomy
 
-## Alternatives Considered
+## 7. Backward Compatibility
 
-Describe alternative approaches that were considered and why they were rejected.
+**Not a breaking change.** Soul DIDs (and Variants) without `journeys[]` continue to behave identically. Work items without `targetedJourneys` are scored at their existing (soul or variant) scope.
 
-### Alternative 1: [Name]
+The only soft regression: Sα₂ scoring previously aggregated across all flows in a soul. Surfacing journeys lets the framework score per-flow precision, which means SOME work that previously scored well at soul-aggregate may score lower if the specific journey it targets has weaker design intent than the soul average. This is the FEATURE, not a bug — it surfaces under-articulated journey design intent that the operator can then strengthen.
 
-Description and rationale for rejection.
+## 8. Alternatives Considered
 
-### Alternative 2: [Name]
+### 8.1 Use Variants for flows (RFC-0017's `cardinality: experimental` for A/B treatments)
 
-Description and rationale for rejection.
+Treat each flow as a variant. **Rejected** — variants are static configuration overlays; flows have temporal sequence (entry → intermediate → terminal) that doesn't fit the variant model. Forcing temporal data into a static schema produces awkward declarations + loses the completion-criteria + state-machine semantics.
 
-## Implementation Plan
+### 8.2 Use a separate `kind: Journey` resource
 
-- [ ] Update normative spec document(s)
-- [ ] Update JSON Schema(s)
-- [ ] Update glossary (if new terms introduced)
-- [ ] Update primer (if architectural changes)
-- [ ] Reference implementation proof-of-concept
-- [ ] Conformance test updates
-- [ ] Author/update each user-facing doc surface declared in `requiresDocs`
+Journeys as standalone resources composed at admission time. **Rejected** for the same reason as RFC-0017 §8.2 — journeys are tightly bound to their parent Soul/Variant. Standalone resources add ceremony for a sub-concern.
 
-## Open Questions
+### 8.3 Skip the schema; route through label-based tagging
 
-1. Question 1?
-2. Question 2?
+Add a `journey: <name>` label on work items; let admission heuristically aggregate. **Rejected** — same reasons as RFC-0017 §8.3 (no inheritance contract, doesn't compose with scoring, doesn't surface in design intent hierarchy). Plus journeys NEED state declarations to be useful for completion-criteria scoring.
 
-## References
+### 8.4 External workflow engine (Temporal, BPMN)
 
-- [RFC-0009 Tessellated Design Intent Documents](RFC-0009-tessellated-design-intent-documents.md)
-- [RFC-0017 In-Soul Variant Pattern](RFC-0017-in-soul-variant-pattern.md)
+Outsource journey state-machine modeling to a workflow engine. **Rejected** — out-of-scope per §4 non-goal #1. The framework defines journey AS A SCORING SCOPE; runtime state execution is application-side. Adopters who use Temporal/BPMN can keep doing so; this RFC just lets them ALSO declare the journey to the framework for scoring purposes.
+
+## 9. Implementation Plan
+
+- [ ] Soul DID schema addition (`journeys[]`)
+- [ ] Variant schema addition (`journeys[]` per RFC-0017 §5.1)
+- [ ] Work Item schema addition (`targetedJourneys`)
+- [ ] Admission scorer composition (Sα₂ + Cκ + Eρ₅ journey routing)
+- [ ] Journey inheritance validator (`JourneyInheritanceViolation` event)
+- [ ] `Eτ_tessellation_drift` detector extension for journey-scoped state-ID scans
+- [ ] Success-metrics ingestion adapter (where do `completion-rate` values come from? — likely an adapter pattern per RFC-0003)
+- [ ] SpryPoint accessibility audit pipeline as reference implementation (one journey per product flow, minimum)
+- [ ] Glossary additions (`Journey`, `targetedJourneys`, `completionCriteria`)
+- [ ] Conformance test suite — journey declaration round-trip; admission-scoring composition; inheritance + WCAG-elevation enforcement
+- [ ] Author/update each user-facing doc surface declared in `requiresDocs` (currently `[]` — pending tutorial/runbook decision)
+
+## 10. Open Questions
+
+These need design + operator walkthrough before Lifecycle: Draft → Ready for Review.
+
+**OQ-1 — Maximum journeys per Soul/Variant:** Should the schema cap journey count? Recommendation: soft warning at 10+, hard limit at 50. Journeys are heavier than variants — encourage discipline.
+
+**OQ-2 — State cardinality limits:** Per-journey state limit? Recommendation: NO hard limit; surface a soft warning at >12 states (suggests a journey should be split into sub-journeys).
+
+**OQ-3 — Sub-journeys (journey-within-journey):** Can a journey reference another journey as a sub-flow (e.g., "checkout journey embeds payment sub-journey")? Recommendation: NO for v1 — composition adds complexity for a use case we don't have practitioner evidence for. Revisit if multi-step flows surface.
+
+**OQ-4 — Completion-criteria expressiveness:** §5.2 sketches `terminal-success-state | all-states-reached | custom-predicate`. Is `custom-predicate` an arbitrary string DSL, a JS expression, a JsonLogic predicate, or off the table for v1? Recommendation: closed enum for v1 (`terminal-success-state` + `all-states-reached` only); defer `custom-predicate` until adopters surface a real need.
+
+**OQ-5 — Success-metrics source:** §9 mentions an adapter pattern for ingesting metrics like `completion-rate`. What's the adapter contract — operator-supplied numbers, or framework-side polling of an analytics backend? Recommendation: operator-supplied numbers via a typed `MetricSnapshot` resource (operator's analytics pipeline writes them). Frees the framework from analytics-backend integration.
+
+**OQ-6 — Accessibility cadence enforcement:** §5.1's `auditCadence: quarterly | annually | release-gated | continuous` declares cadence but the framework doesn't currently enforce it. Should overdue audits trigger Eρ₅ degradation (compliance-clearance gate fails until audit lands)? Recommendation: YES with a 30-day grace window past the cadence; configurable per Soul.
+
+**OQ-7 — WCAG version evolution:** WCAG 3.0 is in development. How does the schema handle a new WCAG version landing — bump `wcagVersion` enum, leave existing journey declarations valid? Recommendation: additive enum (existing journeys keep their declared version; new journeys can pick the latest); document migration in a follow-on RFC when WCAG 3.0 normative.
+
+**OQ-8 — Drift detection on state ID references:** §6.2 says substrate code referencing a removed state ID is a drift signal. How does the detector find these references — string match on the state ID, AST scan for typed references, or both? Recommendation: string match v1 (cheap, conservative); AST scan in a follow-on if false-positive rate is too high.
+
+**OQ-9 — Cross-soul journeys (the multi-product user path case):** §4 non-goal #5 explicitly excludes these. But practitioners DO have multi-product user flows (e.g., a SpryEngage onboarding that hands off to SpryMobile). What's the right operator pattern — separate journey per soul + a "handoff" terminal state, or document this as a known limitation? Recommendation: document as known limitation v1; surface as candidate for a "Cross-Soul Coordination" follow-on RFC if multiple adopters report this.
+
+**OQ-10 — Interaction with RFC-0009's Tessellation Drift detection:** RFC-0009 §13 lists 3 drift detection rules (AST scan, embedding distance, cross-soul provenance). Journey declarations add a 4th class of drift (state-ID drift). Should this be a 4th rule in the same engine, or a separate detector? Recommendation: 4th rule in the same engine — composability with the existing dispatcher is more important than separation of concerns.
+
+## 11. Practitioner Validation Plan
+
+SpryPoint's accessibility audit pipeline drives the validation pass:
+
+| Soul / Variant | Journeys (proposed) | Validates |
+|---|---|---|
+| SpryEngage | onboarding, daily-task-management, billing-inquiry-resolution | Multi-flow per soul; completion-rate + time-to-completion metrics |
+| SpryMobile | shift-start, route-completion, end-of-shift-handoff | Mobile-form-factor accessibility (touch targets, voice commands) |
+| SpryCIS | csr-onboarding, customer-self-service, dispute-resolution | Variant-scoped journeys (csr vs. customer-portal use the same product but different journeys) |
+| SpryBackflow / annual-test (variant) | submit-test-results, request-extension, view-historical-tests | Regulatory journey with elevated WCAG (`AAA` per state requirement) |
+
+Validation criteria (Mo's edits welcome):
+1. Each journey's states + transitions form a valid state machine (no unreachable states, terminal states correctly marked)
+2. WCAG audit reports map 1:1 to journey declarations (each audit has a target journey ID)
+3. Admission scoring on a real work item (e.g., "improve onboarding completion-rate") produces a higher score when the targeted journey's `completion-rate` metric is below `alertBelow`
+4. Variant-scoped journeys (e.g., backflow `annual-test` variant journeys) demonstrate journey-level WCAG elevation working independently of soul-level
+
+## 12. References
+
+- [RFC-0009 Tessellated Design Intent Documents](RFC-0009-tessellated-design-intent-documents.md) — parent Soul DID model
+- [RFC-0017 In-Soul Variant Pattern](RFC-0017-in-soul-variant-pattern.md) — journeys can be soul-scoped OR variant-scoped
+- [RFC-0008 PPA Triad Integration](RFC-0008-ppa-triad-integration-final-combined.md) — admission scoring foundation; journey scoring extends `targetedSouls`/`targetedVariants` pattern
+- [WCAG 2.1 Quick Reference](https://www.w3.org/WAI/WCAG21/quickref/) — referenced by `accessibility.wcagVersion` field
+
+## 13. Revision History
+
+| Version | Date | Author | Notes |
+|---|---|---|---|
+| v0.1 | 2026-05-04 | Morgan Hirtle | Initial stub (carve-out from RFC-0009 OQ-3). Established summary + practitioner-validation source. |
+| v0.2 | 2026-05-04 | Engineering pass (Dominique + Claude Opus 4.7) | Filled §3-§13 from boilerplate. Schema sketch with state machines + accessibility + success metrics; inheritance table; admission-scoring composition (Sα₂ + Cκ + Eρ₅); boundary-vs-just-a-feature; alternatives; 10 open questions; SpryPoint validation plan. Awaiting Mo's design-authority editorial pass on §5.4 success metrics + §10 OQs. |


### PR DESCRIPTION
Mo's v0.1 stubs of RFC-0017 (In-Soul Variant Pattern) + RFC-0018 (In-Soul Journey Pattern) — carved out from RFC-0009 OQ-3 — were left as boilerplate. This pass fills §3-§13 with substantive content while explicitly marking design-vertex semantics for Mo's editorial pass.

## RFC-0017 — Variants (configuration-based sub-themes)
- `soul.spec.variants[]` schema with id, audience, design overrides, complianceFloor=inherit
- Bounded inheritance table (variant cannot override compliance / substrate; can specialize voice / palette / density / imperatives)
- Admission scoring composition (Sα1 + Sα2 route through variant; Cκ + Eρ + Dπ stay soul-level)
- Boundary guidance: variant when same compliance + same substrate; separate Soul otherwise
- 4 alternatives considered + rejected (subclasses, composition, labels, just-spawn-Soul)
- 8 OQs (cardinality limits, nesting, lifecycle, scoring rule, override extensibility, URI representation, authority ownership, cardinality field)
- SpryPoint 4-product validation plan

## RFC-0018 — Journeys (flow-based sequences)
- `soul.spec.journeys[]` (or `variant.spec.journeys[]`) with states + transitions + completionCriteria + accessibility + successMetrics
- Composes with RFC-0017 — journey can be soul-scoped OR variant-scoped
- Journey-scoped WCAG elevation (journey may set HIGHER than soul, never lower)
- Admission scoring composition (Sα2 + Cκ + Eρ5 route through journey; Cκ boost when success metrics below alertBelow)
- Boundary guidance: journey when sequence + completion + WCAG-per-flow; not for stateless features
- 4 alternatives considered + rejected (variants for flows, standalone Journey kind, labels, external workflow engine)
- 10 OQs (cardinality, state limits, sub-journeys, completion expressiveness, metrics source, audit cadence enforcement, WCAG version evolution, drift detection, cross-soul, drift-engine integration)
- SpryPoint accessibility-audit-pipeline validation plan

## Sign-off state
- Both: Mo authored v0.1 ✍️ ; Engineering pass v0.2 ✏️ (Dominique + Claude); Product ⏸ pending; Mo's editorial review on the engineering pass ⏸ pending
- Lifecycle stays Draft pending Mo's editorial pass + OQ walkthroughs + SpryPoint validation

## Test plan
- [x] `node scripts/check-rfc-docs.mjs` — 23 RFCs walked, 0 drift
- [ ] Mo's editorial review of RFC-0017 §5.3 + §10 + RFC-0018 §5.4 + §10
- [ ] Operator OQ walkthroughs (8 + 10 OQs)
- [ ] SpryPoint practitioner validation pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)