### PR TITLE
docs: Product Authority sign-off on RFC-0011

### DIFF
--- a/spec/rfcs/RFC-0011-definition-of-ready-gate.md
+++ b/spec/rfcs/RFC-0011-definition-of-ready-gate.md
@@ -15,8 +15,8 @@ requiresDocs: []
 
 # RFC-0011: Definition-of-Ready Gate for Pipeline Admission
 
-**Status:** Awaiting Product owner sign-off (Engineering + Operator signed off 2026-04-30)
-**Lifecycle:** Signed Off (per AISDLC-118 backfill — all three owners signed; design locked)
+**Status:** Signed off (Engineering + Operator 2026-04-30; Product 2026-05-04)
+**Lifecycle:** Signed Off (all three owners signed; design locked)
 **Author:** dominique@reliablegenius.io (with Claude assist)
 **Created:** 2026-04-30
 **Updated:** 2026-04-30
@@ -27,7 +27,7 @@ requiresDocs: []
 ## Sign-Off
 
 - [x] Engineering owner — dominique@reliablegenius.io (2026-04-30)
-- [ ] Product owner — Alex (pending review)
+- [x] Product owner — Alexander Kline (2026-05-04)
 - [x] Operator owner — dominique@reliablegenius.io (2026-04-30)
 
 ## Revision History


### PR DESCRIPTION
## Summary

Product Authority sign-off on RFC-0011 (Definition-of-Ready Gate for Pipeline Admission). Mechanical reconciliation of the in-doc Sign-Off table with the AISDLC-118 lifecycle backfill that already declared all three owners signed.

## What changed (3 lines)

- Status: `Awaiting Product owner sign-off` → `Signed off (Engineering + Operator 2026-04-30; Product 2026-05-04)`
- Lifecycle: drops the "per AISDLC-118 backfill" caveat
- Sign-Off checklist: Product owner row flipped from `[ ]` to `[x]` with full name + date

## Endorsement

Endorses the design as shipped through v4 (2026-05-03 enforce-mode promotion):

- Seven-gate fixed rubric — distinct failure modes, no overlap, binary-decidable per gate
- Deterministic-first evaluation order (Section 4.4): Stage A short-circuits ~40-60% of unready issues with no LLM call; Stage B runs only when Stage A passes
- Library-function-with-shims architecture (Section 5.0-5.2) — single `evaluateIssue()` callable from GitHub Action, Claude Code subagent, and future ingress channels
- Pluggable resolver registry (Q2) — separate "what to look up" from "how to look it up"; same pattern as RFC-0010 §13 harness adapters
- Dual-fanout notifications, two-stage staleness, three-tier confidence gating, grandfather-on-rubric-revision (Q4-Q8)
- Test corpus + 3-tier eval harness (Section 5.6) — Stage A 100%, Stage B ≥90%, end-to-end ≥95% as CI gates

## DoR composes with PPA cleanly

Orthogonal axes — DoR answers "is this actionable as written?", PPA answers "should we do this?". DoR before PPA is the right ordering: cheap before expensive, and DoR-failing issues would need re-scoring after clarification anyway.

## Test plan

- [ ] Dom merges → reconciles in-doc state with AISDLC-118 lifecycle backfill
- [ ] No follow-on work required from Product side

🤖 Generated with [Claude Code](https://claude.com/claude-code)