### PR TITLE
docs: Product Authority sign-off on RFC-0016

### DIFF
--- a/spec/rfcs/RFC-0016-estimation-calibration-tshirt-sizes.md
+++ b/spec/rfcs/RFC-0016-estimation-calibration-tshirt-sizes.md
@@ -16,8 +16,8 @@ requiresDocs: []
 # RFC-0016: Estimation Calibration with T-Shirt Sizes
 
 **Document type:** Normative
-**Status:** Ready for Product owner sign-off (Engineering + Operator signed off 2026-05-03; 8 open questions resolved per §15)
-**Lifecycle:** Ready for Review
+**Status:** Signed off (Engineering + Operator 2026-05-03; Product 2026-05-04; 8 open questions resolved per §15)
+**Lifecycle:** Signed Off
 **Author:** dominique@reliablegenius.io (with Claude assist)
 **Created:** 2026-05-01
 **Updated:** 2026-05-03
@@ -28,7 +28,7 @@ requiresDocs: []
 ## Sign-Off
 
 - [x] Engineering owner — dominique@reliablegenius.io (2026-05-03)
-- [ ] Product owner — Alex (pending review)
+- [x] Product owner — Alexander Kline (2026-05-04)
 - [x] Operator owner — dominique@reliablegenius.io (2026-05-03)
 
 ## Revision History


### PR DESCRIPTION
## Summary

Product Authority sign-off on RFC-0016 (Estimation Calibration with T-Shirt Sizes). Closes the v3 sign-off cycle.

- Engineering Authority — ✅ signed 2026-05-03
- Operator — ✅ signed 2026-05-03
- Product Authority — ✅ this PR (2026-05-04)

All 8 open questions resolved per §15. Lifecycle: Ready for Review → Signed Off.

## Endorsement

Endorses the architecture as shipped through v3:

- Stage A 9-signal pure-function lookup → Stage B LLM tie-breaker only when Stage A signals genuinely conflict — joins the deterministic-first cluster pattern (PPA SA / RFC-0006 / RFC-0007 / RFC-0011 / this RFC = 5 artifacts now)
- XS / S / M / L / XL bucket schema with wall-clock anchors; ranges narrower than 2 buckets allowed (`S-M`); wider forbidden; bucket-math thresholds (1-bucket miss = noise; 2-bucket = correction; 3+ = systemic mismodel)
- Per-class bias adjustment over 30d / 20-est window; surface both raw and adjusted to operator; `|mean_miss| ≥ 1.0 bucket AND n ≥ 5` as the trigger
- 3-state token enum (`uncalibrated` / `warming` / `calibrated`) with appendable variance qualifier — single shared formatter across CLI / PR-comment / dashboard / Slack
- Content-hash-keyed ensemble sampling for mid-task revisions (Q5) — `estimateInputHash` aggregates same-hash batches on median bucket; variance ≥2 escalates to Stage B
- 6-phase rollout with class-default fallback (signal #9) in Phase 1 retiring gracefully in Phase 3 as historical actuals populate — same flywheel as PPA SA's phase-weight progression

## Per-agent stratification

`predictedBy` field stratifies calibration per agent. Operator estimates kept as ground truth (uncalibrated forever). Right architecture; no Product-side changes requested.

## Test plan

- [ ] Dom merges → unblocks RFC-0016 Phase 1+ implementation
- [ ] Phase 3 actuals collection unblocks the class-default → calibrated retirement flywheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)