### PR TITLE
docs: Product Authority sign-off on RFC-0014

### DIFF
--- a/spec/rfcs/RFC-0014-dependency-graph-composition.md
+++ b/spec/rfcs/RFC-0014-dependency-graph-composition.md
@@ -24,7 +24,7 @@ requiresDocs: []
 ## Sign-Off
 
 - [ ] Engineering owner — dominique@reliablegenius.io (pending)
-- [ ] Product owner — Alex (pending)
+- [x] Product owner — Alexander Kline (2026-05-04)
 - [ ] Operator owner — dominique@reliablegenius.io (pending)
 
 ## Revision History


### PR DESCRIPTION
## Summary

Product Authority sign-off on RFC-0014 (Dependency Graph Composition for Pipeline Decisions).

## Position

**Endorse.** The formal dependency graph feeds ER3 (Dependency Clearance) with structured data instead of manual tracking. When RFC-0014 ships, PPA's ER3 should consume its graph output. This is Engineering-axis infrastructure that Product has no concerns about.

No PPA spec changes needed until implementation, at which point ER3's dependency resolution mechanism gets a formal adapter.

Position cited from RFC-0029 §Part II.