### PR TITLE
docs: Product Authority sign-off on RFC-0015

### DIFF
--- a/spec/rfcs/RFC-0015-autonomous-pipeline-orchestrator.md
+++ b/spec/rfcs/RFC-0015-autonomous-pipeline-orchestrator.md
@@ -30,7 +30,7 @@ requiresDocs: []
 ## Sign-Off
 
 - [x] Engineering owner — dominique@reliablegenius.io (2026-05-02)
-- [ ] Product owner — Alex (pending)
+- [x] Product owner — Alexander Kline (2026-05-04)
 - [x] Operator owner — dominique@reliablegenius.io (2026-05-02)
 
 ## Revision History


### PR DESCRIPTION
## Summary

Product Authority sign-off on RFC-0015 (Autonomous Pipeline Orchestrator). Closes the v1 sign-off cycle (Eng + Op signed 2026-05-02; Product 2026-05-04).

## Position

**Endorse with framing.** PPA's governance chain — signal ingestion → DoR → PPA admission → PPA runtime → execution → review → merge → calibration → DID evolution — IS the decision substrate that RFC-0015 orchestrates. The autonomous pipeline is not a separate system. It is the composition of every gate in the admission chain running continuously without human intervention except at the points where human judgment is structurally required.

The four points where human judgment is structurally required:
1. Soul authorship (DID v1 declaration)
2. Approving identity evolution proposals (DID Evolution Loop revisions)
3. Handling ambiguous drift classifications (healthy/unhealthy/ambiguous triage)
4. Burst spend arbitration when Product and Operator disagree (PPA v1.3 Change 1 escalation)
5. Click merge

Soul authorship plus exception handling. Position cited from RFC-0029 Part II.