### PR TITLE
docs: Product Authority sign-off on RFC-0017

### DIFF
--- a/spec/rfcs/RFC-0017-in-soul-variant-pattern.md
+++ b/spec/rfcs/RFC-0017-in-soul-variant-pattern.md
@@ -33,7 +33,7 @@ requiresDocs: []
 |--------|------|--------|------|
 | Morgan Hirtle | Chief of Design / Design Authority | ✍️ Authored v0.1 stub | 2026-05-04 |
 | Dominique Legault | CTO / Engineering Authority | ✏️ Engineering pass on v0.2 (pending Design editorial) | 2026-05-04 |
-| Alexander Kline | Head of Product Strategy / Product Authority | ⏸ Pending | — |
+| Alexander Kline | Head of Product Strategy / Product Authority | ✅ Signed v0.2 (endorse pending Mo's editorial pass) | 2026-05-04 |
 
 ---
 


### PR DESCRIPTION
## Summary

Product Authority sign-off on RFC-0017 (In-Soul Variant Pattern v0.2).

## Position

**Endorse pending Mo's editorial pass on Design-vertex semantics.** Variant=audience-specific carries SA1 (audience definition) implications. Co-review per RFC-0009 v3.4 Mo's C2 condition applies: variants reach into product.targetAudience + product.problemResonance territory, which are Product-Design co-authorship fields.

PPA v1.1 §5 already incorporates variant scoring (inherits shard, may add ER5 gates). Endorsement contingent on the v0.2 + future v1.0+ normative spec preserving parent-soul tightening-only inheritance for compliance regimes — child variants must not loosen parent compliance locks.

Position cited from RFC-0029 Part II.