### PR TITLE
docs: Product Authority sign-off on RFC-0019

### DIFF
--- a/spec/rfcs/RFC-0019-embedding-provider-adapter.md
+++ b/spec/rfcs/RFC-0019-embedding-provider-adapter.md
@@ -27,7 +27,7 @@ requiresDocs: []
 ## Sign-Off
 
 - [ ] Engineering owner — dominique@reliablegenius.io (pending)
-- [ ] Product owner — Alex (pending)
+- [x] Product owner — Alexander Kline (2026-05-04)
 - [ ] Operator owner — dominique@reliablegenius.io (pending)
 
 ## Revision History
@@ -620,7 +620,7 @@ The operator (dominique) will walk through these before promoting the RFC out of
 ## 17. Sign-Off
 
 - [ ] Engineering owner — dominique@reliablegenius.io (pending)
-- [ ] Product owner — Alex (pending)
+- [x] Product owner — Alexander Kline (2026-05-04)
 - [ ] Operator owner — dominique@reliablegenius.io (pending)
 
 ## 18. Revision History


### PR DESCRIPTION
## Summary

Product Authority sign-off on RFC-0019 (Embedding Provider Adapter Framework).

## Position

**Endorse with note.** PPA v1.2's structural layer uses BM25 (deterministic, model-independent). If embedding-based retrieval is ever added as supplement to BM25, RFC-0019's adapter framework provides the pluggable interface. PPA's structural weight floor (w_structural >= 0.20) ensures BM25 always contributes.

**Product position: BM25 remains primary structural scorer; embedding providers are enrichment, not replacement.**

Position cited from RFC-0029 Part II.