### PR TITLE
docs: Product Authority sign-off on RFC-0022

### DIFF
--- a/spec/rfcs/RFC-0022-compliance-posture-audit-surface.md
+++ b/spec/rfcs/RFC-0022-compliance-posture-audit-surface.md
@@ -28,7 +28,7 @@ requiresDocs: []
 ## Sign-Off
 
 - [ ] Engineering owner — dominique@reliablegenius.io (pending)
-- [ ] Product owner — Alex (pending)
+- [x] Product owner — Alexander Kline (2026-05-04)
 - [ ] Operator owner — dominique@reliablegenius.io (pending)
 
 ## Revision History
@@ -488,7 +488,7 @@ The operator (dominique) will walk through these before promoting the RFC out of
 ## 15. Sign-Off
 
 - [ ] Engineering owner — dominique@reliablegenius.io (pending)
-- [ ] Product owner — Alex (pending)
+- [x] Product owner — Alexander Kline (2026-05-04)
 - [ ] Operator owner — dominique@reliablegenius.io (pending)
 
 ## 16. Revision History


### PR DESCRIPTION
## Summary

Product Authority sign-off on RFC-0022 (Compliance Posture + Audit Surface).

## Position

**Endorse strongly.** This is the implementation surface for PPA v1.1's ER5 (Compliance Clearance). PPA introduced ER5 as a dimension but never specified how compliance regimes are declared. RFC-0022 IS that specification. Every tessellated platform with shard-specific compliance regimes needs this.

Additional note: RFC-0022's audit evidence packs should share format with PPA v1.3's governance reporting layer (cost section + compliance audit pack), so operators don't maintain two parallel reporting surfaces.

Position cited from RFC-0029 Part II.