### PR TITLE
docs: Product Authority sign-off on RFC-0023

### DIFF
--- a/spec/rfcs/RFC-0023-operator-tui-pipeline-monitoring.md
+++ b/spec/rfcs/RFC-0023-operator-tui-pipeline-monitoring.md
@@ -391,7 +391,7 @@ Per `project_team_roles.md`:
 | Owner | Role | Status | Date |
 |---|---|---|---|
 | Dominique Legault | CTO / Engineering Authority + AI-SDLC Operator | ✅ Signed v0.2 (Engineering + Operator) | 2026-05-03 |
-| Alexander Kline | Product Lead | ⏳ Pending walkthrough | — |
+| Alexander Kline | Product Lead | ✅ Signed v0.2 | 2026-05-04 |
 
 Lifecycle: Ready for Review → Signed Off (after Product Lead signs).
 


### PR DESCRIPTION
## Summary

Product Authority sign-off on RFC-0023 (Operator TUI — Pipeline Monitoring + Steering Surface). Closes the v0.2 sign-off cycle (Eng + Op signed 2026-05-03; Product 2026-05-04).

## Position

**Endorse, no PPA concerns.** The TUI consumes PPA output (pillar breakdown, burn-down reports, drift events, DoR verdicts). It does not influence PPA scoring. Pure observability surface.

**Note**: TUI should surface healthy/unhealthy drift classification (PPA v1.3 Change 5) prominently. Operators need to see at a glance whether drift is the system working or the system failing.

The 'Decision Engine' framing aligns with PPA HC composite prominence — operator's bottleneck is decisions, not commits.

Position cited from RFC-0029 Part II.