### PR TITLE
docs: Product Authority sign-off on RFC-0024

### DIFF
--- a/spec/rfcs/RFC-0024-emergent-issue-capture-and-triage.md
+++ b/spec/rfcs/RFC-0024-emergent-issue-capture-and-triage.md
@@ -358,7 +358,7 @@ Per `project_team_roles.md`:
 | Owner | Role | Status | Date |
 |---|---|---|---|
 | Dominique Legault | CTO / Engineering Authority + AI-SDLC Operator | ⏳ Pending walkthrough | — |
-| Alexander Kline | Product Lead | ⏳ Pending walkthrough | — |
+| Alexander Kline | Product Lead | ✅ Signed v0.2 | 2026-05-04 |
 
 Lifecycle: Draft → Ready for Review (after OQ walkthrough) → Signed Off (after all owners sign).
 


### PR DESCRIPTION
## Summary

Product Authority sign-off on RFC-0024 (Emergent Issue Capture + Triage v0.2).

## Position

**Endorse with PPA integration.** Emergent issues bypass DoR (findings from in-flight work) and enter PPA admission directly via PPA v1.3 sourceType: emergent.

Three-way triage endorsed (quick-fix / scope-creep / new strategic). Suggested fourth disposition: 'park for later' / 'not actionable' as first-class outcome with structured findings log — preserves signal for findings that are real but not work-shaped.

Position cited from RFC-0029 Part II.