### PR TITLE
docs: Product Authority sign-off on RFC-0025

### DIFF
--- a/spec/rfcs/RFC-0025-framework-quality-monitoring.md
+++ b/spec/rfcs/RFC-0025-framework-quality-monitoring.md
@@ -289,7 +289,7 @@ Per `project_team_roles.md`:
 | Owner | Role | Status | Date |
 |---|---|---|---|
 | Dominique Legault | CTO / Engineering Authority + AI-SDLC Operator | ⏳ Pending walkthrough | — |
-| Alexander Kline | Product Lead | ⏳ Pending walkthrough | — |
+| Alexander Kline | Product Lead | ✅ Signed v0.1 | 2026-05-04 |
 
 Lifecycle: Draft → Ready for Review (after OQ walkthrough) → Signed Off (after all owners sign).
 


### PR DESCRIPTION
## Summary

Product Authority sign-off on RFC-0025 (Framework Quality Monitoring v0.1).

## Position

**Endorse with calibration note.** The distinction between 'operator under-decided' and 'framework misbehaved' is important for PPA's calibration loop. A bad score caused by a framework bug is not evidence of a bad scoring model. When RFC-0025's failure taxonomy identifies a framework failure, the corresponding scoring decision should be excluded from CK calibration data. Otherwise the flywheel learns from noise.

PPA v1.3 notes this as a v1.4 deferral; Product wants it tracked. Suggested implementation: a one-bit flag on the calibration log entry (`frameworkFailureExcluded: true`) rather than a separate routing pipeline — keeps the data simple, lets the calibration aggregator decide whether to honor the flag.

Position cited from RFC-0029 Part II.