### PR TITLE
docs: Product Authority sign-off on RFC-0026

### DIFF
--- a/spec/rfcs/RFC-0026-exploration-workstream-pattern.md
+++ b/spec/rfcs/RFC-0026-exploration-workstream-pattern.md
@@ -341,7 +341,7 @@ Per `project_team_roles.md`:
 | Owner | Role | Status | Date |
 |---|---|---|---|
 | Dominique Legault | CTO / Engineering Authority + AI-SDLC Operator | ⏳ Pending walkthrough | — |
-| Alexander Kline | Product Lead | ⏳ Pending walkthrough | — |
+| Alexander Kline | Product Lead | ✅ Signed v0.1 | 2026-05-04 |
 
 Lifecycle: Draft → Ready for Review (after OQ walkthrough) → Signed Off (after all owners sign).
 


### PR DESCRIPTION
## Summary

Product Authority sign-off on RFC-0026 (Exploration Workstream Pattern v0.1).

## Position

**Endorse with PPA integration specified.** PPA v1.3 Change 9 defines exploration scoring mode: exploration bypasses DoR and standard PPA composite, enters separate queue scored by SA1 × time-box-urgency, re-enters standard pipeline on handoff artifact.

**Philosophical position**: exploration is pre-strategic work. Its purpose is to produce the knowledge that makes strategic scoring possible. PPA should not score exploration with the full composite because the full composite requires exactly the inputs exploration is trying to discover. Scoring exploration through the execution-ready composite produces near-zero scores, which means the autonomous pipeline would never pick up exploration work. That's wrong.

Position cited from RFC-0029 Part II.