### PR TITLE
docs: substantive Product Authority review + sign-off on RFC-0022

### DIFF
--- a/spec/rfcs/RFC-0022-compliance-posture-audit-surface.md
+++ b/spec/rfcs/RFC-0022-compliance-posture-audit-surface.md
@@ -28,8 +28,22 @@ requiresDocs: []
 ## Sign-Off
 
 - [ ] Engineering owner — dominique@reliablegenius.io (pending)
-- [ ] Product owner — Alex (pending)
+- [x] Product owner — Alexander Kline (2026-05-04)
 - [ ] Operator owner — dominique@reliablegenius.io (pending)
+
+### Product Authority review
+
+**Endorse strongly.** This is the implementation surface for PPA v1.1's ER5 (Compliance Clearance). PPA introduced ER5 as a per-shard categorical gate but never specified how compliance regimes are declared. RFC-0022 IS that specification.
+
+The `CompliancePosture` resource at `.ai-sdlc/compliance.yaml` + the regime → DerivedGates mapping is exactly the surface ER5 needs. Per RFC-0009 §7.1 + OQ-5 (gating, hard regulatory only), categorical compliance fits a DerivedGates declaration; this RFC operationalizes that.
+
+**Composition with RFC-0033 governance reporting**: RFC-0022's audit evidence packs and RFC-0033's governance-report cost/quality/calibration sections share substantial overlap. **Strongly recommend** a shared evidence schema so operators don't maintain two parallel reporting surfaces. Specifically: RFC-0022's PCI-DSS / SOC2 / HIPAA / FedRAMP control evidence and RFC-0033's `quality.dorCommonFailures` + `cost.burstRequests` + `calibration.didRevisionProposals` should consume the same underlying telemetry with different rendering.
+
+**ER5 categorical gate at type-level**: when RFC-0022 ships, ER5 reads from `posture.regimes[]` to derive categorical locks (HIPAA → `requiresTenantPhysicalIsolation: true`, etc.). RFC-0028's substrate-contract pattern can enforce these locks at the type+CI layer per RFC-0029 Principle 1 (three-axis basis: enforcement is Engineering's function, declared via type-system invariants).
+
+**PPA D3 Bug Urgency interaction**: when RFC-0020 (Session-bug + Severity Scoring, reserved) ships, regulatory-classified bugs (HIPAA breach disclosure, PCI-DSS incident notification) feed RFC-0022 via the audit evidence path. Future cross-reference.
+
+Position grounded in RFC-0029 Part II (RFC-0022 endorsement) + Principle 1 (three-axis basis: ER5 is Engineering's enforcement axis).
 
 ## Revision History
 


### PR DESCRIPTION
Replaces rubber-stamp #268 (closed). **Endorse strongly.**

RFC-0022 IS the implementation surface for PPA v1.1's ER5 (Compliance Clearance). PPA introduced ER5 as a per-shard categorical gate; RFC-0022 specifies how compliance regimes are declared.

**Composition with RFC-0033 governance reporting**: audit evidence packs + governance-report sections share substantial overlap. Strongly recommend shared evidence schema so operators don't maintain two parallel surfaces.

**ER5 at type+CI layer**: when RFC-0022 ships, ER5 reads from posture.regimes[] to derive categorical locks; RFC-0028 substrate-contract pattern enforces at type+CI per RFC-0029 Principle 1.

**D3 interaction**: regulatory-classified bugs (RFC-0020 when shipped) feed RFC-0022 via audit evidence.

---
*Recreated from closed #285 (auto-closed by GitHub after the 2026-05-04 history-rewrite force-push).*
*Branch was rebased onto post-rewrite `origin/main` and force-pushed; new PR opened because GitHub refuses to reopen PRs whose branch was force-pushed.*