### PR TITLE
fix(ci): pass --squash to auto-enable-auto-merge so PRs enter the queue (AISDLC-192)

### DIFF
--- a/.github/workflows/auto-enable-auto-merge.yml
+++ b/.github/workflows/auto-enable-auto-merge.yml
@@ -6,15 +6,27 @@ name: Auto-enable auto-merge on PR open
 # which then rebases against the queue tip + runs CI on the merge commit
 # + merges if green. No human click needed.
 #
-# Why no `--rebase` (or any explicit method): when the merge queue is
-# enabled on a branch, GitHub OWNS the merge method (configured in repo
-# settings → branch protection → merge queue settings). Recording an
-# explicit method here (e.g. `--rebase`) makes GitHub try to honor that
-# specific intent against a queue-only branch — the merge silently fails
-# to fire and the PR sits in MERGEABLE/UNSTABLE state without entering
-# the queue. Operators then have to disable + re-enable auto-merge
-# without the method flag to unstick. Dropping `--rebase` here means new
-# PRs default to "use whatever the branch policy dictates" → queue path.
+# Why `--squash` (and not `--rebase` or no flag): the merge queue on
+# `main` is configured for REBASE (queue's `mergeMethod`). When the
+# auto-merge `mergeMethod` MATCHES the queue's method, GitHub interprets
+# it as "merge directly" and silently refuses to enter the queue — the
+# PR sits MERGEABLE/UNSTABLE forever (witnessed on PRs #311 #312 + the
+# original failure mode PR #292 partially diagnosed).
+#
+# Passing no flag is NOT a fix: `gh pr merge --auto` falls back to the
+# viewer's `viewerDefaultMergeMethod` GraphQL field. On this repo only
+# REBASE is allowed (`mergeCommitAllowed:false squashMergeAllowed:false
+# rebaseMergeAllowed:true`), so the implicit default is REBASE — same
+# trap.
+#
+# Passing `--squash` ARMS the auto-merge with a method that DIFFERS from
+# the queue's REBASE config. GitHub then falls through to the queue,
+# which uses its own REBASE config — so linear history is preserved (no
+# squash actually happens at merge time; verified empirically on PRs
+# #311 + #312). The `--squash` is a workaround for GitHub's
+# "method-must-differ" semantic, not a real merge-strategy change.
+# AISDLC-192 captures the analysis; AISDLC-189 captures the related
+# auto-rebase token bug.
 #
 # Why a workflow (vs the per-PR button): the repo-level "Allow auto-merge"
 # setting just enables the BUTTON. It doesn't actually opt PRs into auto-merge.
@@ -46,8 +58,8 @@ jobs:
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - name: Enable auto-merge (queue chooses method)
-        run: gh pr merge --auto "${{ github.event.pull_request.number }}"
+      - name: Enable auto-merge with --squash (queue overrides at merge time)
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ GitHub Actions silently skips ALL workflows when ANY commit body contains `[skip
 - **Never merge PRs** — only humans merge.
 - **Never close** issues or PRs. **Never force-push to main/master.**
 - Dismiss stale reviews only with documented reason (truncation, API errors).
-- `auto-enable-auto-merge.yml` sets `--auto` (no method flag) on same-repo PRs; the merge queue on `main` owns the method. Setting `--auto` is NOT merging.
+- `auto-enable-auto-merge.yml` sets `--auto --squash` on same-repo PRs (NOT a real squash — workaround for GitHub's "auto-merge method must differ from queue's REBASE method" trap; queue overrides to REBASE at merge time). Setting `--auto` is NOT merging.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Fixes the **auto-merge → queue stranding** failure mode that blocked PRs #311 + #312 immediately after their PR-creation. PR #292 dropped `--rebase` from this workflow under the assumption that "no method" would let the queue choose. **Empirically false.**

## Root cause (verified 2026-05-04)

When `gh pr merge --auto` is invoked without a method flag, gh CLI falls back to `repository.viewerDefaultMergeMethod`. On this repo:

```
mergeCommitAllowed:  false
squashMergeAllowed:  false
rebaseMergeAllowed:  true     ← only method allowed
```

So the implicit default is **REBASE**. That matches the queue's `mergeMethod: REBASE` config — and GitHub interprets matching methods as "merge directly" rather than "fall through to queue." The PR sits at `mergeStateStatus: UNSTABLE` forever, never enters the queue.

## Fix

Pass `--squash` explicitly. The auto-merge state ends up with `mergeMethod: SQUASH` (different from the queue's REBASE), so GitHub falls through to the queue. The queue then rebases per its own config — **linear history preserved, no actual squash happens at merge time** (verified empirically on PRs #311 + #312 just now after manual unstick).

The `--squash` is a workaround for GitHub's "method-must-differ" semantic, not a real merge-strategy change.

## Why not enable SQUASH at the repo level?

Would expose squash as a clickable option in the PR merge button to humans, violating the project's "always rebase, keep linear history" policy. Keeping squash off at the repo level + passing `--squash` only at the auto-merge arming layer is the right scope.

## Files changed
- `.github/workflows/auto-enable-auto-merge.yml` — change `gh pr merge --auto` to `gh pr merge --auto --squash`; rewrite comment block to explain WHY (point at viewerDefaultMergeMethod + REBASE-only repo policy)
- `CLAUDE.md` — update existing line describing this workflow's behavior (per the "CLAUDE.md is not a changelog" rule, REWROTE the existing rule rather than appending)

## Composes with AISDLC-189

AISDLC-189 covers a different workflow (`auto-rebase-open-prs.yml`) but related symptom — both broke the auto-merge path. They should ship together.

## Test plan
- [x] Locally: confirmed manual `gh pr merge --auto --squash <pr>` enters the queue successfully on PRs #311 #312 (queue's REBASE config wins at merge time)
- [ ] After merge: open a trivial new PR, verify `gh pr view <pr> --json autoMergeRequest --jq .autoMergeRequest.mergeMethod` returns `SQUASH`
- [ ] After merge: verify the PR enters the merge queue automatically without manual disable+re-enable
- [ ] After merge: verify the resulting commit on main has a single parent (rebase happened, squash did not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)