### PR TITLE
fix(ci): DoR ingress uses 3-dot diff + skip-if-missing (AISDLC-197)

### DIFF
--- a/.github/workflows/dor-ingress.yml
+++ b/.github/workflows/dor-ingress.yml
@@ -247,8 +247,16 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          # AISDLC-197: 3-dot diff (`A...B`) finds the merge-base of A and B
+          # then diffs from merge-base to B, scoping to only the changes
+          # introduced ON THE PR SIDE. With 2-dot (`A B`), when a sibling PR
+          # merges to main and moves a backlog file (e.g. `tasks/X.md` →
+          # `completed/X.md`), the diff would include that move in the file
+          # list even when the PR under evaluation didn't touch the file. The
+          # OLD path at `backlog/tasks/X.md` would then ENOENT in the evaluator
+          # below. Witnessed on PR #325 at 2026-05-05 02:33:44.
           # Limit to backlog/tasks/*.md additions/modifications (Added or Modified).
-          FILES=$(git diff --name-only --diff-filter=AM "$BASE_SHA" "$HEAD_SHA" -- 'backlog/tasks/*.md' || true)
+          FILES=$(git diff --name-only --diff-filter=AM "$BASE_SHA"..."$HEAD_SHA" -- 'backlog/tasks/*.md' || true)
           # GitHub Actions multiline output via heredoc.
           {
             echo 'files<<EOF'
@@ -274,6 +282,11 @@ jobs:
           : > /tmp/dor/results.jsonl
           while IFS= read -r f; do
             [ -z "$f" ] && continue
+            # AISDLC-197 defense-in-depth: even with 3-dot diff, skip if the
+            # file doesn't exist on HEAD (e.g. PR deleted it within its own
+            # diff). Prevents ENOENT crash on the dor-evaluate --body-file
+            # call below.
+            [ ! -f "$f" ] && { echo "::notice::Skipping non-existent file from diff: $f"; continue; }
             ID=$(basename "$f" .md | cut -d- -f1-2)
             set +e
             OUT=$(node pipeline-cli/bin/ai-sdlc-pipeline.mjs \

--- a/backlog/tasks/aisdlc-197 - DoR-ingress-workflow-uses-2-dot-diff-causing-ENOENT-on-file-renamed-by-sibling-PR.md
+++ b/backlog/tasks/aisdlc-197 - DoR-ingress-workflow-uses-2-dot-diff-causing-ENOENT-on-file-renamed-by-sibling-PR.md
@@ -13,7 +13,7 @@ labels:
   - framework-bug
 dependencies: []
 references:
-  - .github/workflows/ai-sdlc-dor-ingress.yml
+  - .github/workflows/dor-ingress.yml
 priority: medium
 ---
 
@@ -26,7 +26,7 @@ Surfaced on PR #325 (AISDLC-183 frontier filter) at 2026-05-05 02:33:44.
 
 ## Problem
 
-The `Evaluate backlog tasks changed by PR` step in `ai-sdlc-dor-ingress.yml` (or wherever the DoR ingress evaluator lives) uses 2-dot diff to enumerate changed files:
+The `Evaluate backlog tasks changed by PR` step in `dor-ingress.yml` (or wherever the DoR ingress evaluator lives) uses 2-dot diff to enumerate changed files:
 
 ```
 git diff --name-only $BASE $HEAD

--- a/backlog/tasks/aisdlc-197 - DoR-ingress-workflow-uses-2-dot-diff-causing-ENOENT-on-file-renamed-by-sibling-PR.md
+++ b/backlog/tasks/aisdlc-197 - DoR-ingress-workflow-uses-2-dot-diff-causing-ENOENT-on-file-renamed-by-sibling-PR.md
@@ -1,0 +1,72 @@
+---
+id: AISDLC-197
+title: >-
+  DoR ingress workflow uses 2-dot diff causing ENOENT on
+  file-renamed-by-sibling-PR
+status: To Do
+assignee: []
+created_date: '2026-05-05 02:44'
+labels:
+  - bug
+  - ci
+  - workflows
+  - framework-bug
+dependencies: []
+references:
+  - .github/workflows/ai-sdlc-dor-ingress.yml
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Source
+
+Surfaced on PR #325 (AISDLC-183 frontier filter) at 2026-05-05 02:33:44.
+
+## Problem
+
+The `Evaluate backlog tasks changed by PR` step in `ai-sdlc-dor-ingress.yml` (or wherever the DoR ingress evaluator lives) uses 2-dot diff to enumerate changed files:
+
+```
+git diff --name-only $BASE $HEAD
+```
+
+When a sibling PR moves a backlog task file (e.g., AISDLC-186 task moved from `backlog/tasks/` → `backlog/completed/` after #322 merged), the 2-dot diff includes that move in the file list — even when the PR under evaluation didn't touch the file.
+
+The workflow then tries to read the OLD path (`backlog/tasks/aisdlc-186 - ...md`) which no longer exists on either side → `ENOENT: no such file or directory` → workflow fails.
+
+## Reproduction
+1. Open PR A that doesn't touch backlog/
+2. Sibling PR B merges, moving a backlog file from `tasks/` → `completed/`
+3. PR A's `Evaluate backlog tasks changed by PR` step fails with ENOENT on the OLD path
+
+## Fix
+
+Use 3-dot diff to scope to PR-side changes only:
+
+```
+git diff --name-only $BASE...$HEAD   # 3-dot — only changes on the PR side
+```
+
+OR filter the resulting list to files that exist on HEAD before iterating:
+
+```bash
+for f in $(git diff --name-only ...); do
+  [ -f "$f" ] || continue   # skip deleted/renamed
+  evaluate "$f"
+done
+```
+
+Either approach prevents the ENOENT crash. 3-dot is the cleaner semantic fix.
+
+## Composes with
+AISDLC-189 (auto-rebase token) — without auto-rebase firing CI on rebased SHAs, PRs sit BEHIND longer + this race condition is more likely. Now that AISDLC-189 + AI_SDLC_PAT are working, PRs rebase faster and this bug should fire less often, but the underlying workflow gap remains.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 DoR ingress workflow uses 3-dot diff (`$BASE...$HEAD`) OR filters file list to existing files before iterating
+- [ ] #2 Test: open a no-op PR + merge a sibling PR that moves a backlog file; verify the no-op PR's DoR step doesn't fail with ENOENT on the moved path
+- [ ] #3 Workflow comment block updated with the 2-dot vs 3-dot rationale so future contributors don't re-introduce the bug
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

Fixes the recurring DoR ingress workflow ENOENT failure surfaced today on PR #325 (AISDLC-183 frontier filter) at 02:33:44.

## Root cause
`git diff --name-only "$BASE_SHA" "$HEAD_SHA"` (2-dot) includes file moves done by SIBLING PRs since the merge-base, even when the PR under evaluation didn't touch those files. When sibling PR moves a backlog file from \`tasks/\` → \`completed/\` (e.g. AISDLC-186 task moved when #322 merged), the OLD path appears in the diff list → \`dor-evaluate --body-file\` ENOENTs → workflow fails.

## Fix (two-part)
1. **Semantic**: 2-dot → 3-dot diff (\`$BASE_SHA"..."$HEAD_SHA\`). 3-dot finds the merge-base and scopes to PR-side changes only.
2. **Defense-in-depth**: \`[ ! -f "$f" ] && continue\` skips non-existent paths with a workflow ::notice:: instead of crashing.

## Verification
- 3/3 reviewers approved (code/test/security)
- Code-reviewer verified no other 2-dot patterns in `.github/workflows/`
- Inline-fixed reviewer minor (frontmatter references path was wrong)

🤖 Generated with [Claude Code](https://claude.com/claude-code)