### PR TITLE
ci: flip auto-merge flag to --rebase after queue switched to SQUASH (AISDLC-192)

### DIFF
--- a/.github/workflows/auto-enable-auto-merge.yml
+++ b/.github/workflows/auto-enable-auto-merge.yml
@@ -6,27 +6,29 @@ name: Auto-enable auto-merge on PR open
 # which then rebases against the queue tip + runs CI on the merge commit
 # + merges if green. No human click needed.
 #
-# Why `--squash` (and not `--rebase` or no flag): the merge queue on
-# `main` is configured for REBASE (queue's `mergeMethod`). When the
-# auto-merge `mergeMethod` MATCHES the queue's method, GitHub interprets
-# it as "merge directly" and silently refuses to enter the queue — the
-# PR sits MERGEABLE/UNSTABLE forever (witnessed on PRs #311 #312 + the
-# original failure mode PR #292 partially diagnosed).
+# Why `--rebase` (and not `--squash` or no flag): the merge queue on
+# `main` is configured for SQUASH (queue's `mergeMethod`, verified via
+# `repository.mergeQueue(branch:"main").configuration.mergeMethod`).
+# When the auto-merge `mergeMethod` MATCHES the queue's method, GitHub
+# interprets it as "merge directly" and silently refuses to enter the
+# queue — the PR sits MERGEABLE/UNSTABLE forever (originally witnessed
+# on PRs #311 #312 #292 when the queue was REBASE; same failure mode
+# observed on PRs #326 #327 #328 after the queue was switched to SQUASH
+# and this workflow was still passing `--squash`).
 #
 # Passing no flag is NOT a fix: `gh pr merge --auto` falls back to the
-# viewer's `viewerDefaultMergeMethod` GraphQL field. On this repo only
-# REBASE is allowed (`mergeCommitAllowed:false squashMergeAllowed:false
-# rebaseMergeAllowed:true`), so the implicit default is REBASE — same
-# trap.
+# viewer's `viewerDefaultMergeMethod`. Whichever the default resolves
+# to, if it matches the queue's method it springs the same trap.
 #
-# Passing `--squash` ARMS the auto-merge with a method that DIFFERS from
-# the queue's REBASE config. GitHub then falls through to the queue,
-# which uses its own REBASE config — so linear history is preserved (no
-# squash actually happens at merge time; verified empirically on PRs
-# #311 + #312). The `--squash` is a workaround for GitHub's
-# "method-must-differ" semantic, not a real merge-strategy change.
-# AISDLC-192 captures the analysis; AISDLC-189 captures the related
-# auto-rebase token bug.
+# Passing `--rebase` ARMS the auto-merge with a method that DIFFERS from
+# the queue's SQUASH config. GitHub then falls through to the queue,
+# which uses its own SQUASH config at merge time — so PRs land as a
+# single squash commit on main. The `--rebase` flag is a workaround for
+# GitHub's "method-must-differ" semantic, NOT the actual merge strategy.
+# Whenever the queue's `mergeMethod` is changed in repo settings, this
+# flag must be re-flipped to whichever method the queue is NOT using.
+# AISDLC-192 captures the original analysis; AISDLC-189 captures the
+# related auto-rebase token bug.
 #
 # Why a workflow (vs the per-PR button): the repo-level "Allow auto-merge"
 # setting just enables the BUTTON. It doesn't actually opt PRs into auto-merge.
@@ -58,8 +60,8 @@ jobs:
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - name: Enable auto-merge with --squash (queue overrides at merge time)
-        run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
+      - name: Enable auto-merge with --rebase (queue's SQUASH overrides at merge time)
+        run: gh pr merge --auto --rebase "${{ github.event.pull_request.number }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ GitHub Actions silently skips ALL workflows when ANY commit body contains `[skip
 - **Never merge PRs** — only humans merge.
 - **Never close** issues or PRs. **Never force-push to main/master.**
 - Dismiss stale reviews only with documented reason (truncation, API errors).
-- `auto-enable-auto-merge.yml` sets `--auto --squash` on same-repo PRs (NOT a real squash — workaround for GitHub's "auto-merge method must differ from queue's REBASE method" trap; queue overrides to REBASE at merge time). Setting `--auto` is NOT merging.
+- `auto-enable-auto-merge.yml` sets `--auto --rebase` on same-repo PRs (NOT a real rebase — workaround for GitHub's "auto-merge method must differ from queue's method" trap; the queue's `mergeMethod` is SQUASH so the workflow flag must be its opposite, and the queue's SQUASH applies at merge time so PRs land as one commit on main). If the queue's method is ever flipped in repo settings, the workflow flag must be flipped to whichever method the queue is NOT using. Setting `--auto` is NOT merging.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Flip `.github/workflows/auto-enable-auto-merge.yml` from `--squash` to `--rebase` so the auto-merge method DIFFERS from the queue's new SQUASH `mergeMethod` (verified via `repository.mergeQueue(branch:"main").configuration.mergeMethod` GraphQL query).
- Update the workflow rationale comment + CLAUDE.md note to reflect the new state.

## Why
Earlier today the operator switched the merge queue's `mergeMethod` from REBASE → SQUASH (and enabled `allow_squash_merge` on the repo) so PRs would land as one squash commit on main instead of multiple commits per PR (cleaner history, attestation chore commits collapsed away).

But the auto-merge workflow was still passing `--squash`. That MATCHES the queue's now-SQUASH method, which fires GitHub's "auto-merge method must differ from queue's method" trap — the PR sits MERGEABLE/UNSTABLE forever and never merges. Witnessed today on PRs #326 #327 #328 (same failure pattern as previously observed on #311 #312 #292 when the trap-defeat flag was wrong).

Passing `--rebase` arms auto-merge with a method DIFFERENT from the queue's SQUASH. The queue accepts and applies its own SQUASH at merge time, so PRs land as one squash commit on main (the operator's original goal).

The flag is a workaround for GitHub's "method-must-differ" semantic, NOT the actual merge strategy. The doctrine documented in the workflow comment is unchanged; only the value flips when the queue's method changes.

## After-merge effect on stuck PRs
The 4 currently-stuck PRs (#326 #327 #328 + #296) had auto-merge enabled BEFORE this fix landed, with `merge_method: rebase` (silent fallback when `allow_squash_merge` was still `false`). Since `rebase ≠ queue.SQUASH` they SHOULD already be eligible to enqueue — yet they're still UNSTABLE 36+ min after all required checks went green. Possible cause: bot-enabled auto-merge on a protected branch where only the operator is on the bypass list. Once this PR is merged + the operator re-enables auto-merge on each stuck PR (or pushes to re-trigger this workflow), they should drain.

## Verification
- `pnpm -r --filter '!dashboard' build` — clean (dashboard has unrelated WIP typecheck errors that predate this PR; not in the diff)
- `pnpm exec prettier --check .github/workflows/auto-enable-auto-merge.yml CLAUDE.md` — clean
- `git diff --check` — clean

## Closes
- AISDLC-192

🤖 Generated with [Claude Code](https://claude.com/claude-code)