### PR TITLE
fix(ci): slash command body's slug + preflight bugs that block dispatch on long-titled tasks

### DIFF
--- a/ai-sdlc-plugin/commands/execute.md
+++ b/ai-sdlc-plugin/commands/execute.md
@@ -108,28 +108,28 @@ Before creating the worktree, refuse to start a task whose dependencies aren't a
 # cli-deps is the AISDLC-117 dependency-graph CLI shipped from @ai-sdlc/pipeline-cli.
 # Exits 0 if every dependency is in backlog/completed/; exits non-zero with a
 # JSON `{ok, reason, blockers, dangling}` envelope on stderr otherwise.
-PREFLIGHT_OUT=$(pnpm --filter @ai-sdlc/pipeline-cli exec cli-deps preflight "$TASK_ID" --work-dir "$(pwd)" 2>&1)
+PREFLIGHT_OUT=$(node pipeline-cli/bin/cli-deps.mjs preflight "$TASK_ID" --work-dir "$(pwd)" 2>&1)
 PREFLIGHT_EXIT=$?
 if [ "$PREFLIGHT_EXIT" -ne 0 ]; then
   echo "ERROR: dependency preflight failed for $TASK_ID:"
   echo "$PREFLIGHT_OUT"
   echo ""
-  echo "To inspect the dispatch-ready frontier instead: pnpm --filter @ai-sdlc/pipeline-cli exec cli-deps frontier --format table"
+  echo "To inspect the dispatch-ready frontier instead: node pipeline-cli/bin/cli-deps.mjs frontier --format table"
   exit 1
 fi
 ```
 
-This step is fail-closed: if `cli-deps` itself errors (binary not built, broken JSON, etc.) the slash command still aborts rather than dispatching blindly. Run `pnpm --filter @ai-sdlc/pipeline-cli build` if the binary is missing.
+This step is fail-closed: if `cli-deps` itself errors (binary not built, broken JSON, etc.) the slash command still aborts rather than dispatching blindly. Run `pnpm --filter @ai-sdlc/pipeline-cli build` if the binary is missing. **Never** invoke pipeline-cli binaries via `pnpm --filter @ai-sdlc/pipeline-cli exec cli-X` — `pnpm exec` does not resolve workspace own-bins, the call silently fails with `Command not found`, and any `|| echo <fallback>` safety net fires unconditionally (CLAUDE.md "## CI behavior", AISDLC-156).
 
 ### Step 1.6 — Frontier consultation (operator hint, AISDLC-117)
 
 For `/loop /ai-sdlc execute` runs (and ad-hoc multi-task dispatch), the operator should consult the dispatch-ready frontier before picking a candidate rather than relying on instinct. This is the same data the AISDLC-117 task description called out as the cure for "manual dependency tracing":
 
 ```bash
-pnpm --filter @ai-sdlc/pipeline-cli exec cli-deps frontier --format table
+node pipeline-cli/bin/cli-deps.mjs frontier --format table
 ```
 
-If `$TASK_ID` is on the printed list (or independent of the listed items), proceed. If not, the task's blockers are still open — `cli-deps blockers $TASK_ID --format table` lists what to ship first. The loop driver SHOULD prefer frontier tasks; the slash command body's Step 1.5 is the hard gate that refuses non-ready tasks regardless of where the dispatch decision came from.
+If `$TASK_ID` is on the printed list (or independent of the listed items), proceed. If not, the task's blockers are still open — `node pipeline-cli/bin/cli-deps.mjs blockers $TASK_ID --format table` lists what to ship first. The loop driver SHOULD prefer frontier tasks; the slash command body's Step 1.5 is the hard gate that refuses non-ready tasks regardless of where the dispatch decision came from.
 
 ## Step 2 — Compute branch name
 
@@ -137,8 +137,17 @@ The branch pattern lives in `.ai-sdlc/pipeline-backlog.yaml` under `branching.pa
 
 ```bash
 BRANCH_PATTERN=$(grep -A2 'branching:' .ai-sdlc/pipeline-backlog.yaml | grep 'pattern:' | sed -E "s/.*pattern: *'([^']+)'.*/\1/")
-TITLE=$(grep -E '^title:' "$TASK_FILE" | sed -E 's/title: *"?([^"]+)"?/\1/')
-SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-50)
+# AISDLC-180: use ai-sdlc-plugin/scripts/compute-slug.mjs to parse the YAML
+# frontmatter title properly. The previous shell pipeline (`grep ^title: |
+# sed`) returned `>-` literally for any block-scalar title produced by
+# backlog.md (every long-titled task), then normalised to an empty slug,
+# then yielded a malformed branch like `ai-sdlc/aisdlc-178.1-`. The script
+# is dependency-free (no js-yaml), handles every title form the serializer
+# emits, and exits non-zero with a clear error if the slug would be empty.
+SLUG=$(node ai-sdlc-plugin/scripts/compute-slug.mjs "$TASK_FILE") || {
+  echo "ERROR: failed to compute slug for $TASK_ID — see stderr above"
+  exit 1
+}
 BRANCH=$(echo "$BRANCH_PATTERN" | sed "s|{issueIdLower}|$TASK_ID_LOWER|g; s|{slug}|$SLUG|g")
 WORKTREE_PATH=".worktrees/$TASK_ID_LOWER"
 ```
@@ -259,7 +268,7 @@ mkdir -p "$ARTIFACTS_DIR"
 # A non-zero exit from the CLI itself would abort, but the CLI is designed
 # to fall open and exit 0 with a fellOpen=true decision instead — see
 # pipeline-cli/src/cli/classify-pr.ts.
-CLASSIFIER_JSON=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-classify-pr classify \
+CLASSIFIER_JSON=$(node pipeline-cli/bin/cli-classify-pr.mjs classify \
   --paths-file "/tmp/pr-files-${TASK_ID}.txt" \
   --issue-id "$TASK_ID" \
   --artifacts-dir "$ARTIFACTS_DIR" 2>/dev/null || echo '{"reviewers":["testing","critic","security"],"fellOpen":true,"fellOpenReason":"invocation-failed","confidence":0}')
@@ -373,7 +382,7 @@ fi
 
 # Pass --comments-json-file (NOT --comments-file) so the CLI's trusted-author
 # filter runs as defense-in-depth on top of the gh --jq filter above.
-INCREMENTAL_JSON=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-incremental-decide decide \
+INCREMENTAL_JSON=$(node pipeline-cli/bin/cli-incremental-decide.mjs decide \
   --comments-json-file "$PR_COMMENTS_JSON" \
   --base-ref origin/main \
   --head-ref HEAD \
@@ -461,7 +470,7 @@ ONLY if the gate decision is APPROVED (skip when `[needs-human-attention]` is be
 
 ```bash
 HEAD_SHA=$(cd "$WORKTREE_PATH" && git rev-parse HEAD)
-MARKER_BODY=$(pnpm --silent --filter @ai-sdlc/pipeline-cli exec cli-incremental-decide format-marker \
+MARKER_BODY=$(node pipeline-cli/bin/cli-incremental-decide.mjs format-marker \
   --content-hash "$INCR_CONTENT_HASH" \
   --reviewed-sha "$HEAD_SHA")
 

--- a/ai-sdlc-plugin/scripts/compute-slug.mjs
+++ b/ai-sdlc-plugin/scripts/compute-slug.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Compute the kebab-case slug from a backlog task file's YAML frontmatter
+ * title. Self-contained — no js-yaml dependency, so the /ai-sdlc execute
+ * slash command body can call this from any cwd without needing pnpm
+ * install in the worktree.
+ *
+ * Handles every title form the backlog.md serializer produces:
+ *   title: foo bar              (plain)
+ *   title: 'foo bar'            (single-quoted)
+ *   title: "foo bar"            (double-quoted)
+ *   title: >-                   (folded block scalar — newlines → spaces)
+ *     foo bar
+ *     baz
+ *   title: |-                   (literal block scalar — preserves newlines,
+ *     foo bar                    treated same as folded for slug purposes)
+ *
+ * Usage:
+ *   node ai-sdlc-plugin/scripts/compute-slug.mjs <task-file-path>
+ *
+ * Output: kebab-case slug to stdout (single line, no trailing JSON).
+ *
+ * Exit non-zero with message on stderr if:
+ *   - file unreadable / no frontmatter
+ *   - title key not found
+ *   - title normalises to empty slug (per AISDLC-180 AC #2: fail loud,
+ *     never silently emit empty)
+ */
+
+import { readFileSync } from 'node:fs';
+
+const taskPath = process.argv[2];
+if (!taskPath) {
+  console.error('usage: compute-slug.mjs <task-file-path>');
+  process.exit(1);
+}
+
+let raw;
+try {
+  raw = readFileSync(taskPath, 'utf8');
+} catch (err) {
+  console.error(`ERROR: cannot read ${taskPath}: ${err.message}`);
+  process.exit(1);
+}
+
+const fmMatch = raw.match(/^---\n([\s\S]*?)\n---/);
+if (!fmMatch) {
+  console.error(`ERROR: no YAML frontmatter (no leading --- delimiter) in ${taskPath}`);
+  process.exit(1);
+}
+const frontmatter = fmMatch[1];
+
+function readTitle(fm) {
+  // Block scalar form: title: >- (or > | |- |+ etc.) followed by indented lines.
+  // Indentation level isn't anchored — backlog.md uses 2-space indents but be
+  // permissive on whitespace. Stop at the next top-level (non-indented) key.
+  const block = fm.match(/^title:[ \t]+[>|][-+]?[ \t]*\n((?:[ \t]+[^\n]*\n?)+)/m);
+  if (block) {
+    return block[1]
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .join(' ')
+      .trim();
+  }
+
+  // Inline form: title: foo | 'foo' | "foo".
+  const inline = fm.match(/^title:[ \t]+(.+)$/m);
+  if (inline) {
+    let t = inline[1].trim();
+    if ((t.startsWith("'") && t.endsWith("'")) || (t.startsWith('"') && t.endsWith('"'))) {
+      t = t.slice(1, -1);
+    }
+    return t;
+  }
+  return null;
+}
+
+const title = readTitle(frontmatter);
+if (!title) {
+  console.error(`ERROR: no 'title:' key in frontmatter of ${taskPath}`);
+  process.exit(1);
+}
+
+const slug = title
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, '-')
+  .replace(/^-+|-+$/g, '')
+  .slice(0, 50)
+  .replace(/-+$/, ''); // re-strip if cut-50 left a dangling dash
+
+if (!slug) {
+  console.error(
+    `ERROR: title '${title}' produces empty slug after normalization (no alphanumeric characters)`,
+  );
+  process.exit(1);
+}
+
+process.stdout.write(slug + '\n');

--- a/ai-sdlc-plugin/scripts/compute-slug.test.mjs
+++ b/ai-sdlc-plugin/scripts/compute-slug.test.mjs
@@ -1,0 +1,106 @@
+// Run with: node --test ai-sdlc-plugin/scripts/compute-slug.test.mjs
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = fileURLToPath(new URL('./compute-slug.mjs', import.meta.url));
+
+function run(content) {
+  const dir = mkdtempSync(join(tmpdir(), 'compute-slug-test-'));
+  const file = join(dir, 'task.md');
+  writeFileSync(file, content, 'utf8');
+  try {
+    const result = spawnSync('node', [SCRIPT, file], { encoding: 'utf8' });
+    return {
+      stdout: result.stdout.trim(),
+      stderr: result.stderr.trim(),
+      code: result.status,
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('compute-slug.mjs', () => {
+  it('handles plain inline title', () => {
+    const r = run(`---\nid: AISDLC-1\ntitle: Plain Title Here\n---\nbody`);
+    assert.equal(r.code, 0);
+    assert.equal(r.stdout, 'plain-title-here');
+  });
+
+  it('handles single-quoted inline title', () => {
+    const r = run(`---\nid: AISDLC-1\ntitle: 'Quoted: title with colon'\n---\nbody`);
+    assert.equal(r.code, 0);
+    assert.equal(r.stdout, 'quoted-title-with-colon');
+  });
+
+  it('handles double-quoted inline title', () => {
+    const r = run(`---\nid: AISDLC-1\ntitle: "Double quoted"\n---\nbody`);
+    assert.equal(r.code, 0);
+    assert.equal(r.stdout, 'double-quoted');
+  });
+
+  it('handles folded block scalar (>-) — the AISDLC-180 reproducer', () => {
+    const r = run(
+      `---\nid: AISDLC-180\ntitle: >-\n  Pipeline: branch slug computation produces empty/garbled slug for YAML\n  block-scalar titles\nstatus: To Do\n---\nbody`,
+    );
+    assert.equal(r.code, 0);
+    // The slug truncates at 50 chars then re-strips trailing dashes
+    assert.match(r.stdout, /^pipeline-branch-slug-computation/);
+    assert.ok(!r.stdout.endsWith('-'), 'slug must not end with dash');
+    assert.ok(r.stdout.length <= 50, `slug must be ≤50 chars, got ${r.stdout.length}`);
+  });
+
+  it('handles literal block scalar (|-)', () => {
+    const r = run(
+      `---\nid: AISDLC-1\ntitle: |-\n  Phase 1: Skeleton — cli-tui binary, Ink scaffold\nstatus: To Do\n---\nbody`,
+    );
+    assert.equal(r.code, 0);
+    assert.equal(r.stdout, 'phase-1-skeleton-cli-tui-binary-ink-scaffold');
+  });
+
+  it('handles em-dashes and unicode (AISDLC-178.1 case)', () => {
+    const r = run(
+      `---\nid: AISDLC-178.1\ntitle: >-\n  Phase 1: Skeleton — cli-tui binary, Ink scaffold, Overview Mode placeholder\n  panes\n---\nbody`,
+    );
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /^phase-1-skeleton-cli-tui-binary-ink-scaffold/);
+    assert.ok(!r.stdout.endsWith('-'));
+  });
+
+  it('fails loud if title produces empty slug (AC #2)', () => {
+    const r = run(`---\nid: AISDLC-1\ntitle: '!@#$%^&*()'\n---\nbody`);
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /produces empty slug/);
+  });
+
+  it('fails loud if no title key', () => {
+    const r = run(`---\nid: AISDLC-1\nstatus: To Do\n---\nbody`);
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /no 'title:' key/);
+  });
+
+  it('fails loud if no frontmatter', () => {
+    const r = run(`# Just a markdown body, no frontmatter`);
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /no YAML frontmatter/);
+  });
+
+  it('fails loud if file unreadable', () => {
+    const result = spawnSync('node', [SCRIPT, '/nonexistent/path/task.md'], { encoding: 'utf8' });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /cannot read/);
+  });
+
+  it('caps slug at 50 chars and strips trailing dash', () => {
+    const longTitle = 'a'.repeat(30) + ' ' + 'b'.repeat(30);
+    const r = run(`---\nid: AISDLC-1\ntitle: ${longTitle}\n---\nbody`);
+    assert.equal(r.code, 0);
+    assert.ok(r.stdout.length <= 50);
+    assert.ok(!r.stdout.endsWith('-'));
+  });
+});


### PR DESCRIPTION
## Summary

Discovered while attempting `/ai-sdlc execute AISDLC-180` (the slug-bug task itself — meta-irony fully embraced). Two bugs in `ai-sdlc-plugin/commands/execute.md` were independently blocking every dispatch on common task title shapes:

1. **Step 2's shell title parser fails on YAML block scalars.** `grep ^title: | sed` returned `>-` literally for any block-scalar title (which backlog.md emits for every long-titled task — including AISDLC-178.1, 174-177, 199-203, and AISDLC-180 itself), producing branches like `ai-sdlc/aisdlc-180-` (empty slug). Same root cause AISDLC-180 documents for `pipeline-cli/src/steps/`, but the slash command body has its own independent shell-pipeline copy of the same logic.

2. **Six `pnpm --filter @ai-sdlc/pipeline-cli exec cli-X` call sites are the AISDLC-156 banned pattern.** `pnpm exec` doesn't resolve workspace own-bins, so each call silently exited 1 with no output and the `|| echo '<fallback>'` safety nets fired unconditionally. Net effect: the preflight gate wasn't actually gating, the classifier always returned the fallback "spawn all 3" envelope, and the incremental-decide gate always returned the fallback "no marker" envelope — every dispatch.

## Fixes

- **New** `ai-sdlc-plugin/scripts/compute-slug.mjs` — dependency-free YAML title parser, handles plain / single-quoted / double-quoted / folded `>-` / literal `|-` forms, exits non-zero with clear error on empty slug (per AISDLC-180 AC #2: never silently emit empty).
- **New** `ai-sdlc-plugin/scripts/compute-slug.test.mjs` — 11 tests, including the AISDLC-180 + AISDLC-178.1 reproducers and three fail-loud branches (empty slug, missing title, missing frontmatter).
- **Modified** `ai-sdlc-plugin/commands/execute.md` — Step 2 calls the new script; six `pnpm --filter exec cli-X` call sites switched to direct `node pipeline-cli/bin/cli-X.mjs` invocation; doc note added at Step 1.5 explaining the rule.

## Out of scope (for AISDLC-180 itself to handle)

- The `pipeline-cli/src/steps/02-compute-branch.ts` TypeScript path — that's the CLI-side fix AISDLC-180 was filed for, and it has its own AC list.
- Worktree-sweep (`gh pr list --head <deleted-branch>`) returning empty after squash-merges deletes source branches — observed during this run; worth a separate task.

## Verification

- `node --test ai-sdlc-plugin/scripts/compute-slug.test.mjs` — 11/11 pass
- `node ai-sdlc-plugin/scripts/compute-slug.mjs <real task file>` — produces `pipeline-branch-slug-computation-produces-empty-ga` for AISDLC-180 (truncated at 50 chars, trailing dash stripped — exact behavior expected)
- `npx prettier --check ai-sdlc-plugin/commands/execute.md ai-sdlc-plugin/scripts/compute-slug.{mjs,test.mjs}` — clean
- Pre-push coverage gate — all packages ≥ 80% lines
- `grep "pnpm.*--filter.*exec" ai-sdlc-plugin/commands/execute.md` — only the doc-note "**Never** invoke..." warning remains (intentional)

## After this lands

Re-dispatch AISDLC-180 — it should compute a valid branch and complete preflight cleanly without falling through silent gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)