### PR TITLE
chore: mark AISDLC-180 complete

### DIFF
--- a/backlog/completed/aisdlc-180 - Pipeline-branch-slug-computation-produces-empty-garbled-slug-for-YAML-block-scalar-titles.md
+++ b/backlog/completed/aisdlc-180 - Pipeline-branch-slug-computation-produces-empty-garbled-slug-for-YAML-block-scalar-titles.md
@@ -3,7 +3,7 @@ id: AISDLC-180
 title: >-
   Pipeline: branch slug computation produces empty/garbled slug for YAML
   block-scalar titles
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-04 02:49'
 labels:


### PR DESCRIPTION
## Summary

Lifecycle commit for AISDLC-180. The actual code fix shipped on main earlier via [PR #241](https://github.com/ai-sdlc-framework/ai-sdlc/pull/241) (commit 2754e7e — `fix(deps): parse YAML frontmatter via js-yaml in slug computation`). This PR closes the lifecycle gap: the task file was still in `backlog/tasks/` with `status: To Do`. We move it to `backlog/completed/` and flip status to `Done`.

## Why this lifecycle PR exists

The task spec describes the same root-cause fix that PR #241 already merged. When the orchestrator picked AISDLC-180 off the frontier in this run, the worktree was created on a branch off the post-fix `main`, so every AC was already satisfied by the merged code. Rather than re-doing the fix, this PR documents the verification + closes the task.

## Acceptance criteria — verified against `origin/main`

- **AC #1** — `pipeline-cli/src/steps/01-validate.ts::parseSimpleYaml()` uses `js-yaml.load()` (was line-based regex pre-fix). `02-compute-branch.ts` consumes the unwrapped title via `parseTaskFile() -> task.title`.
- **AC #2** — `02-compute-branch.ts` lines 72-80 throw `slug normalisation produced empty string from title <X>` when `slugify()` returns `""` and the branch pattern includes `{slug}`. Slug-less patterns (e.g. `manual/{issueIdLower}`) skip the guard.
- **AC #3** — `pipeline-cli/src/deps/dependency-graph.ts` imports the same `parseSimpleYaml` from `steps/01-validate.ts`. `cli-deps frontier` table render in `src/cli/deps.ts` uses `node.title` — the now-decoded string instead of the literal indicator `>-`.
- **AC #4** — `02-compute-branch.test.ts` has 17 tests covering: short title (`Demo`), long em-dash title (the AISDLC-178.1 reproducer string `Phase 1: Skeleton — cli-tui binary, Ink scaffold, Overview Mode placeholder panes`), assorted special chars + unicode + parens + brackets, and the empty-slug fail-loud branch (`title: '>-'`). `01-validate.test.ts` adds 5 `parseSimpleYaml` tests covering plain / single-quoted / double-quoted / folded `>-` / literal `|-` / scalar+list mix.
- **AC #5** — `02-compute-branch.test.ts` "every backlog/tasks/aisdlc-*.md file produces a non-empty slug" walks the live repo via `readdirSync(tasksDir)`, parses every task with `parseTaskFile()`, asserts `slugify(task.title) !== ''` for each. Currently green against all 226 tasks under `backlog/`.

## Verification

- `pnpm --filter @ai-sdlc/pipeline-cli test` — 1739 tests pass (106 files), including the 17 in `02-compute-branch.test.ts`.
- `pnpm --filter @ai-sdlc/pipeline-cli build` — clean.
- `pnpm format:check` — clean.
- `pnpm lint` — clean.
- `npx backlog-drift check --task AISDLC-180` — no drift.

## Test plan

- [x] All 5 ACs verified against the merged code on `origin/main`.
- [x] Lifecycle file move + status flip preserves task body verbatim (only frontmatter `status:` line changed).
- [x] No regression in the AC #5 backlog-walk test after moving 180's task file out of `backlog/tasks/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)