### PR TITLE
chore: sync AISDLC-216 + 217 task files

### DIFF
--- a/backlog/tasks/aisdlc-216 - MCP-backlog-tools-must-respect-Pattern-C-—-route-writes-to-active-worktree-not-parent.md
+++ b/backlog/tasks/aisdlc-216 - MCP-backlog-tools-must-respect-Pattern-C-—-route-writes-to-active-worktree-not-parent.md
@@ -1,0 +1,59 @@
+---
+id: AISDLC-216
+title: >-
+  MCP backlog tools must respect Pattern C — route writes to active worktree,
+  not parent
+status: To Do
+assignee: []
+created_date: '2026-05-06 14:10'
+labels:
+  - bug
+  - framework-bug
+  - mcp-server
+  - pattern-c
+  - drift-prevention
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem
+
+`mcp__backlog__task_create`, `mcp__backlog__task_edit`, and `mcp__backlog__task_complete` resolve project root via `cwd`-walk → almost always lands at the parent repo root. They then write task files (or modify in-place) at `<parent>/backlog/tasks/<id>.md`.
+
+In Pattern C (project memory `project_orchestrator_repo_layout.md`), the parent's working tree is **READ-ONLY** by contract. All edits should happen inside `.worktrees/<task-id>/`. But the MCP tools bypass this, accumulating untracked files + modified-but-uncommitted state on parent that:
+
+- Won't sync to origin until manually PR'd
+- Block Step 0 self-heal (which refuses to reset a dirty parent)
+- Get LOST on `git reset --hard origin/main` if not synced first
+- Force operator manual cleanup every multi-task session
+
+## Observed tonight (2026-05-06)
+
+6 task files (AISDLC-210/211/212/213/214/215) accumulated as untracked in parent during one autopilot session. 5 status flips (To Do → In Progress) modified files in-place. Operator had to file PR #354 manually + `git reset --hard origin/main` to unstick.
+
+## Fix
+
+The MCP server's project-root resolver needs a Pattern-C-aware mode:
+
+1. **Detect Pattern C**: project root has a `.worktrees/` directory containing at least one worktree
+2. **Refuse to write at parent**: if no `.active-task` sentinel at parent root AND we're NOT inside a worktree, refuse the write with a clear error: "Pattern C detected — specify which worktree via `--worktree <task-id>` or set `AI_SDLC_ACTIVE_TASK_ID` env"
+3. **Auto-route to active worktree**: if the caller's `cwd` is inside `.worktrees/<task-id>/`, write into THAT worktree's `backlog/tasks/<id>.md` (not parent's)
+4. **Lookup via env**: if `AI_SDLC_ACTIVE_TASK_ID` is set, route to `<parent>/.worktrees/<task-id-lower>/backlog/tasks/`
+
+## Composes with
+
+- AISDLC-217 (auto-sync untracked parent files) — backstop for cases this fix misses
+- `feedback_bash_cwd_persists.md` memory — same root cause class (cwd assumptions break Pattern C)
+
+## Acceptance Criteria
+- [ ] #1 MCP server's project-root resolver detects Pattern C (parent + .worktrees/ exists)
+- [ ] #2 In Pattern C, writes refuse + return helpful error if cwd is parent root AND no active-task signal
+- [ ] #3 If cwd is inside `.worktrees/<task-id>/`, MCP tools route to that worktree's backlog/, not parent's
+- [ ] #4 If `AI_SDLC_ACTIVE_TASK_ID` is set, MCP tools route to that worktree
+- [ ] #5 Hermetic test: simulate Pattern C cwd-from-parent + task_create → asserts refusal with helpful message
+- [ ] #6 Hermetic test: simulate cwd-from-worktree + task_create → asserts file lands in worktree's backlog/, not parent's
+- [ ] #7 Documentation in CLAUDE.md `## Plugin MCP server — project root resolution` section updated with Pattern C resolver behavior
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/aisdlc-217 - Auto-sync-untracked-parent-task-files-before-dispatch-Step-0.5.md
+++ b/backlog/tasks/aisdlc-217 - Auto-sync-untracked-parent-task-files-before-dispatch-Step-0.5.md
@@ -1,0 +1,58 @@
+---
+id: AISDLC-217
+title: Auto-sync untracked parent task files before dispatch (Step 0.5)
+status: To Do
+assignee: []
+created_date: '2026-05-06 14:11'
+labels:
+  - enhancement
+  - pipeline-cli
+  - drift-prevention
+  - framework-bug
+dependencies:
+  - AISDLC-216
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem
+
+Step 0 of `/ai-sdlc execute` self-heals the parent (resets HEAD to `origin/main`) ONLY if the working tree is clean. If parent has untracked files in `backlog/tasks/` (e.g. from prior MCP `task_create` calls that bypassed Pattern C), the self-heal refuses to reset.
+
+Result: parent stays dirty across the whole session, untracked task files never make it to origin, and a `git reset --hard` would silently drop them. Operator had to manually file PR #354 tonight to sync 4 such files.
+
+## Fix
+
+Insert a new pipeline step (Step 0.5) between the existing Step 0 sweep and Step 1 validation:
+
+1. **Detect**: scan parent for untracked files matching `backlog/{tasks,completed}/aisdlc-N*.md`
+2. **Verify each is NEW** (not duplicate of an existing on-origin file): `git ls-tree origin/main <path>` returns nothing
+3. **If genuinely new**: create a new sync worktree on a generated branch (e.g., `chore/sync-tasks-<sha>`), copy the files there, commit, push, open a docs-only PR titled `chore: sync N untracked task files`, exit Step 0.5 letting the operator handle the sync PR (it'll auto-merge as docs-only)
+4. **After sync PR opens**: parent's untracked files get reaped by the next Step 0 self-heal (they're now on origin → no longer "untracked vs origin" semantically; operator can just `git clean -f backlog/tasks/aisdlc-N*.md` or wait for next pull)
+
+## Composes with
+
+- **AISDLC-216 (Pattern-C-aware MCP tools)** is the source-side fix — most untracked files won't appear in the first place. AISDLC-217 is the backstop for cases #216 misses (e.g. external tooling, operator-pasted files).
+
+## Implementation notes
+
+The sync PR should be:
+- docs-only (only adds files under `backlog/tasks/`) so paths-ignore + docs-only fallback handle attestation
+- auto-mergeable (no required reviews on docs-only)
+- non-blocking (Step 0.5 should NOT wait for the sync PR to merge — it just kicks it off and proceeds with main dispatch)
+
+Optional: if the parent has untracked files that AREN'T in `backlog/tasks/` (e.g. orphan attestation envelopes, build artifacts), Step 0.5 should refuse to proceed and surface the manual-cleanup-needed signal to the operator (don't auto-sync arbitrary files).
+
+## Acceptance Criteria
+- [ ] #1 New Step 0.5 in pipeline-cli (`pipeline-cli/src/steps/00-5-sync-parent.ts`) detects untracked backlog task files in parent
+- [ ] #2 For each genuinely-new file (not on origin/main), opens a sync PR on a fresh worktree
+- [ ] #3 Step 0.5 does NOT block — it logs the sync PR URL and proceeds to Step 1 (the sync PR auto-merges in parallel)
+- [ ] #4 If non-backlog untracked files exist in parent, Step 0.5 EXITS with operator-attention message (don't auto-sync arbitrary content)
+- [ ] #5 Wired into `ai-sdlc-plugin/commands/execute.md` Step 0 section
+- [ ] #6 Hermetic test: parent with 3 untracked task files → Step 0.5 opens 1 sync PR with all 3
+- [ ] #7 Hermetic test: parent with 1 untracked random file (not in backlog/) → Step 0.5 surfaces error
+- [ ] #8 Hermetic test: parent with 1 untracked file matching an already-on-origin path → skipped (already there)
+- [ ] #9 Documentation in `ai-sdlc-plugin/commands/execute.md` updated to describe Step 0.5
+<!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
## Summary
- **AISDLC-216** — MCP backlog tools must respect Pattern C
- **AISDLC-217** — Auto-sync untracked parent task files (Step 0.5)

Same pattern as PR #354 sync.