### PR TITLE
chore: sync 3 untracked task files (AISDLC-212/218/219)

### DIFF
--- a/backlog/completed/aisdlc-212 - Dogfood-runner-exports.test.ts-times-out-under-concurrent-pnpm-r-—-forces-AI_SDLC_SKIP_COVERAGE_GATE-on-every-push.md
+++ b/backlog/completed/aisdlc-212 - Dogfood-runner-exports.test.ts-times-out-under-concurrent-pnpm-r-—-forces-AI_SDLC_SKIP_COVERAGE_GATE-on-every-push.md
@@ -1,0 +1,57 @@
+---
+id: AISDLC-212
+title: >-
+  Dogfood runner/exports.test.ts times out under concurrent pnpm -r — forces
+  AI_SDLC_SKIP_COVERAGE_GATE on every push
+status: Done
+assignee: []
+created_date: '2026-05-06 13:54'
+updated_date: '2026-05-06 18:30'
+labels:
+  - bug
+  - testing
+  - tech-debt
+  - framework-bug
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem
+
+`@ai-sdlc/dogfood`'s `src/runner/exports.test.ts` (or similar test in that file) times out consistently when run under `pnpm -r --parallel test:coverage` but passes in isolation. Reported by 3+ dev subagents during 2026-05-06 autopilot session (AISDLC-206, 198, 178.1, 204) — every push required `AI_SDLC_SKIP_COVERAGE_GATE=1` to bypass the pre-push coverage gate.
+
+## Impact
+
+- Every PR push from agents/operators requires manual env-var bypass
+- Hides real coverage regressions because the gate is always skipped
+- Erodes the "ship-with-confidence" property the coverage gate is meant to provide
+- Increases friction enough that the operator stops trusting the gate
+
+## Suspected root cause
+
+The test likely imports `@ai-sdlc/reference` or another workspace dep whose dist artifacts aren't built when `pnpm -r --parallel test:coverage` runs across all workspaces simultaneously. Race between dependent package's build and dependent test's import. Or: vitest's `testTimeout` default (5s) is too low for this specific test under parallel CPU pressure.
+
+## Fix options
+
+1. **Bump `testTimeout`** in `dogfood/vitest.config.ts` to 30s for that specific test (or globally in dogfood)
+2. **Add `pnpm -r build` as a prerequisite** to `pnpm test:coverage` script so dist artifacts are guaranteed before tests run
+3. **Mark the test `concurrent: false`** so it runs serially within its file
+4. **Investigate + fix the actual import / build-order issue** — most principled
+
+Recommend starting with option 4 (root-cause investigation) — read `src/runner/exports.test.ts`, identify the slow operation, fix it. If root cause is build-ordering, option 2 is the right structural fix. If it's a true async-resource-leak in the test, fix the test.
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 #1 Identify the actual cause of the timeout (build-order race, async leak, or something else)
+- [ ] #2 #2 Fix it so `pnpm test:coverage` from repo root passes without `AI_SDLC_SKIP_COVERAGE_GATE=1`
+- [ ] #3 #3 No regression in test runtime budget (runner/exports.test.ts should complete in < 5s in normal CI conditions)
+- [ ] #4 #4 Document any operator runbook changes if the fix involves new build-prereq semantics
+<!-- SECTION:DESCRIPTION:END -->
+<!-- AC:END -->
+
+## Final Summary
+
+Implementation shipped via PR #356 (`fix(dogfood): runner/exports.test.ts timeout under concurrent pnpm -r`). The lifecycle close was lost when the now-retired `.github/workflows/backlog-task-complete.yml` workflow failed to fire (one of the orphaned-PR cases that motivated AISDLC-220). This task file is moved to `backlog/completed/` retroactively as part of the post-AISDLC-220 sync sweep.

--- a/backlog/completed/aisdlc-219 - backlog-task-complete-auto-enable-auto-merge-use-GITHUB_TOKEN-—-chore-close-PRs-sit-orphaned-no-CI-no-auto-merge.md
+++ b/backlog/completed/aisdlc-219 - backlog-task-complete-auto-enable-auto-merge-use-GITHUB_TOKEN-—-chore-close-PRs-sit-orphaned-no-CI-no-auto-merge.md
@@ -1,0 +1,81 @@
+---
+id: AISDLC-219
+title: >-
+  backlog-task-complete + auto-enable-auto-merge use GITHUB_TOKEN — chore close
+  PRs sit orphaned (no CI, no auto-merge)
+status: Withdrawn
+assignee: []
+created_date: '2026-05-06 17:18'
+updated_date: '2026-05-06 18:30'
+labels:
+  - bug
+  - ci
+  - merge-queue
+  - framework-bug
+  - auto-rebase
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem
+
+Two workflows use `GITHUB_TOKEN` instead of `AI_SDLC_PAT`, both running into GitHub's [recursive-workflow-prevention rule](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow): pushes/PR-creates by `GITHUB_TOKEN` do NOT trigger downstream workflows.
+
+### `backlog-task-complete.yml` (line 52 + 81)
+
+When a PR with `(AISDLC-N)` in the title merges, this workflow opens a follow-up `chore: close AISDLC-N (auto)` PR to move the task file from `tasks/` to `completed/`. Uses `GITHUB_TOKEN` for both branch push (line 52) and `gh pr create` (line 81).
+
+Result: the chore PR opens but **no CI fires** on its branch (paths-ignore for docs-only PRs is one issue; GITHUB_TOKEN trigger blocking is another). And the `auto-enable-auto-merge.yml` workflow doesn't fire on the bot-created PR because of the same rule.
+
+### `auto-enable-auto-merge.yml` (line 66)
+
+Uses `GITHUB_TOKEN` to call `gh pr merge --auto --rebase`. Even when it DOES fire (on operator-opened PRs), the arm-action is a bot-level call that may hit the queue's `mergeMethod` trap (per `feedback_gh_auto_merge_method_quirk.md` — the workflow's `--rebase` flag is silently coerced to SQUASH when run as bot).
+
+## Observed (2026-05-06)
+
+4 stuck chore: close PRs sitting orphaned:
+- #360 (close AISDLC-215) — BEHIND
+- #362 (close AISDLC-214) — UNKNOWN, no auto-merge
+- #367 (close AISDLC-209) — UNKNOWN, no auto-merge
+- #368 (close AISDLC-210) — BLOCKED, no auto-merge
+
+None have auto-merge armed. None show CI activity on their branches.
+
+This will recur after EVERY code PR merge (the workflow opens a follow-up for each).
+
+## Fix
+
+Mirror AISDLC-189's PAT switch:
+
+1. `.github/workflows/backlog-task-complete.yml`:
+   - Line 52: `token: ${{ secrets.AI_SDLC_PAT || secrets.GITHUB_TOKEN }}`
+   - Line 81: `GH_TOKEN: ${{ secrets.AI_SDLC_PAT || secrets.GITHUB_TOKEN }}`
+2. `.github/workflows/auto-enable-auto-merge.yml`:
+   - Line 66: `GH_TOKEN: ${{ secrets.AI_SDLC_PAT || secrets.GITHUB_TOKEN }}`
+
+The `|| secrets.GITHUB_TOKEN` fallback ensures the workflows still run (in degraded mode) if the PAT secret is unset, with a clear `::warning::` log.
+
+## Composes with
+
+- **AISDLC-189**: same PAT pattern, already shipped for auto-rebase
+- **AISDLC-213**: auto-rebase re-arms auto-merge after force-push (same parent issue: clearing auto-merge state)
+- **AISDLC-211**: parent attestation root-cause cluster
+
+## Acceptance Criteria
+
+- [ ] #1 `backlog-task-complete.yml` uses `AI_SDLC_PAT || github.token` for push + PR creation
+- [ ] #2 `auto-enable-auto-merge.yml` uses `AI_SDLC_PAT || github.token` for the gh pr merge call
+- [ ] #3 If `AI_SDLC_PAT` secret is unset, both workflows log a clear `::warning::` and still run via fallback
+- [ ] #4 Empirically: open a test PR with `(AISDLC-NNN)` in title, merge it, confirm follow-up chore close PR auto-merges within 5 min without operator intervention
+- [ ] #5 Document operator setup in `docs/operations/auto-rebase-token-setup.md` (the existing doc for the same PAT) — note that `backlog-task-complete` and `auto-enable-auto-merge` also rely on it
+- [ ] #6 Backfill: 4 stuck PRs (#360, #362, #367, #368) need manual operator triage (close as superseded if file already on main, OR rebase + manually arm)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Final Summary
+
+**Withdrawn — superseded by AISDLC-220.**
+
+Originally filed as a band-aid (PAT switch for `backlog-task-complete.yml` to fire downstream workflow triggers). Operator preferred retiring the workflow entirely instead. AISDLC-220 implements the pre-push hook that auto-moves the task file in the originating PR — no orphan chore PRs, no GITHUB_TOKEN/PAT distinction needed.

--- a/backlog/tasks/aisdlc-218 - Reorder-ai-sdlc-execute-—-open-PR-as-draft-sign-envelope-before-flipping-to-ready-1-CI-run-instead-of-2.md
+++ b/backlog/tasks/aisdlc-218 - Reorder-ai-sdlc-execute-—-open-PR-as-draft-sign-envelope-before-flipping-to-ready-1-CI-run-instead-of-2.md
@@ -1,0 +1,90 @@
+---
+id: AISDLC-218
+title: >-
+  Reorder /ai-sdlc execute — open PR as draft, sign envelope before flipping to
+  ready (1 CI run instead of 2)
+status: To Do
+assignee: []
+created_date: '2026-05-06 17:14'
+labels:
+  - enhancement
+  - ci
+  - performance
+  - framework-bug
+  - pipeline-cli
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem
+
+Current `/ai-sdlc execute` flow opens the PR before reviewers/attestation complete. CI fires twice per PR:
+
+1. Dev subagent commits + pushes + opens PR → triggers CI run #1
+2. CI runs full check suite. `Verify attestation` fails (no envelope at HEAD)
+3. Operator spawns 3 reviewers on the open PR
+4. Reviewers complete → write verdicts file → push triggers pre-push hook → auto-sign envelope as separate `chore: auto-sign attestation` commit
+5. Push includes envelope chore commit → triggers CI run #2 (same checks except attestation now passes)
+
+Both runs do identical work for build/test/coverage/lint. ~5-10 min × 2 = 10-20 min wasted CI per PR + reviewer cost spent on a sha that won't be the final HEAD.
+
+Observed in the 2026-05-06 autopilot session across 6+ PRs (#346, #348, #350, #351, #352, #353, #355, #356, #358, #359, #363, #364, #365). Every single PR went through the 2-CI-run cycle.
+
+## Operator preference: draft PR approach
+
+The dev should:
+1. Commit work locally
+2. Push branch (no CI fires — workflows are gated on `pull_request` events with `if: !github.event.pull_request.draft`)
+3. Run `gh pr create --draft` with the dev's crafted title + body (preserves authorship)
+4. Return the draft PR URL + commit SHA
+
+Then operator:
+5. Spawns 3 reviewers using `gh pr diff` on the draft
+6. Reviewers complete → write verdicts file → push triggers pre-push hook → auto-sign envelope
+7. Re-push (envelope at HEAD)
+8. `gh pr ready <pr>` flips draft → ready → triggers CI ONCE on the complete state
+
+## Workflow audit needed
+
+This requires verifying that ALL relevant workflows skip draft PRs. Today's workflows fire on `pull_request: [opened, synchronize, reopened]` regardless of draft state. Need to add `if: !github.event.pull_request.draft` to each workflow's job-level condition (or move to `pull_request: [ready_for_review, synchronize, reopened]`).
+
+Workflows to audit:
+- `ai-sdlc-review.yml`
+- `verify-attestation.yml`
+- `ai-sdlc-gate.yml` (rollup)
+- `ci.yml`
+- `coverage` workflow
+- `backlog-drift` workflow
+- `verify-bundle` workflow
+- `lint-format` workflow
+
+## Implementation
+
+1. Update `ai-sdlc-plugin/commands/execute.md` Step 11 (push) + Step 12 (PR open):
+   - Step 11a: dev pushes branch (no PR yet)
+   - Step 11b: dev runs `gh pr create --draft` — crafts title/body
+   - Step 12: operator runs reviewers + sign envelope
+   - Step 13: `gh pr ready` flips draft → ready
+2. Update `developer` agent definition to default to `--draft` when invoking `gh pr create` (or have the slash command handle it)
+3. Update workflows to skip drafts (job-level `if: !github.event.pull_request.draft` or trigger swap to `[ready_for_review, synchronize, reopened]`)
+4. Hermetic test: simulate full pipeline run, assert CI fires exactly once (on ready_for_review transition)
+
+## Cost / time savings
+
+- **CI minutes**: ~50% reduction per PR
+- **Wall-clock per PR**: ~10-20 min faster
+- **Reviewer billing**: 0% saved (reviewers run once either way) but they review the FINAL sha
+- **Operator notification noise**: one "CI passed" instead of "CI failed → re-pushed → CI passed"
+
+## Acceptance Criteria
+
+- [ ] #1 Dev subagent / `/ai-sdlc execute` opens PRs as draft via `gh pr create --draft`
+- [ ] #2 Slash command body Step 11/12/13 reordered: push → draft PR → reviewers + sign → `gh pr ready`
+- [ ] #3 All required-check workflows skip draft PRs (job-level `if: !github.event.pull_request.draft` OR trigger swapped to `[ready_for_review, synchronize, reopened]`)
+- [ ] #4 Hermetic test confirms CI fires exactly once per PR (on the ready_for_review transition)
+- [ ] #5 Documentation in CLAUDE.md `## Hooks` and the slash command body updated to reflect the draft-then-ready pattern
+- [ ] #6 Operator runbook entry on `/ai-sdlc execute` flow updated
+<!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
## Summary

Backstop sync for tasks that landed (or were filed) before AISDLC-220 made the pre-push auto-close hook live. Docs-only PR (paths-ignore covers `backlog/{tasks,completed}/`) — should auto-merge once CI passes.

| Task | Final state | Reason |
|---|---|---|
| AISDLC-212 | ✅ Done (in completed/) | Implementation shipped via PR #356; lifecycle close was lost when the now-retired `backlog-task-complete.yml` workflow failed to fire (the orphan-PR class of bug that motivated AISDLC-220). |
| AISDLC-218 | 📋 To Do (in tasks/) | New task: reorder `/ai-sdlc execute` to open PR as draft + sign before flipping to ready (1 CI run instead of 2). |
| AISDLC-219 | ❌ Withdrawn (in completed/) | Originally a band-aid (PAT-switch). Operator preferred retiring the workflow entirely → AISDLC-220. |

## Test plan

- [x] `npx backlog-drift check --task AISDLC-{212,218,219}` → all clean
- [ ] CI green (docs-only paths-ignore should make this trivial)
- [ ] Auto-merge fires