### PR TITLE
chore(spec): close 2 stuck task lifecycle moves (AISDLC-216/217)

### DIFF
--- a/backlog/completed/aisdlc-216 - MCP-backlog-tools-must-respect-Pattern-C-—-route-writes-to-active-worktree-not-parent.md
+++ b/backlog/completed/aisdlc-216 - MCP-backlog-tools-must-respect-Pattern-C-—-route-writes-to-active-worktree-not-parent.md
@@ -3,7 +3,7 @@ id: AISDLC-216
 title: >-
   MCP backlog tools must respect Pattern C — route writes to active worktree,
   not parent
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-06 14:10'
 labels:
@@ -57,3 +57,7 @@ The MCP server's project-root resolver needs a Pattern-C-aware mode:
 - [ ] #6 Hermetic test: simulate cwd-from-worktree + task_create → asserts file lands in worktree's backlog/, not parent's
 - [ ] #7 Documentation in CLAUDE.md `## Plugin MCP server — project root resolution` section updated with Pattern C resolver behavior
 <!-- SECTION:DESCRIPTION:END -->
+
+## Final Summary
+
+Implementation shipped via PR for AISDLC-216; lifecycle close was lost when the now-retired `backlog-task-complete.yml` workflow's chore-close PR (#369/#371) failed to auto-merge. Moving to `backlog/completed/` retroactively as part of the post-AISDLC-220 sync sweep.

--- a/backlog/completed/aisdlc-217 - Auto-sync-untracked-parent-task-files-before-dispatch-Step-0.5.md
+++ b/backlog/completed/aisdlc-217 - Auto-sync-untracked-parent-task-files-before-dispatch-Step-0.5.md
@@ -1,7 +1,7 @@
 ---
 id: AISDLC-217
 title: Auto-sync untracked parent task files before dispatch (Step 0.5)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-06 14:11'
 labels:
@@ -56,3 +56,7 @@ Optional: if the parent has untracked files that AREN'T in `backlog/tasks/` (e.g
 - [ ] #8 Hermetic test: parent with 1 untracked file matching an already-on-origin path → skipped (already there)
 - [ ] #9 Documentation in `ai-sdlc-plugin/commands/execute.md` updated to describe Step 0.5
 <!-- SECTION:DESCRIPTION:END -->
+
+## Final Summary
+
+Implementation shipped via PR for AISDLC-217; lifecycle close was lost when the now-retired `backlog-task-complete.yml` workflow's chore-close PR (#369/#371) failed to auto-merge. Moving to `backlog/completed/` retroactively as part of the post-AISDLC-220 sync sweep.


### PR DESCRIPTION
Supersedes orphan chore PRs #369 + #371. Docs-only diff under backlog/completed/. Should auto-merge via paths-ignore.