### PR TITLE
chore: close AISDLC-178.2 — move task file to completed

### DIFF
--- a/backlog/completed/aisdlc-178.2 - Phase-2-Data-sources-—-events.jsonl-tail-gh-PR-cache-dep-snapshot-reader-cli-status-poller-backlog-file-walker.md
+++ b/backlog/completed/aisdlc-178.2 - Phase-2-Data-sources-—-events.jsonl-tail-gh-PR-cache-dep-snapshot-reader-cli-status-poller-backlog-file-walker.md
@@ -3,7 +3,7 @@ id: AISDLC-178.2
 title: >-
   Phase 2: Data sources — events.jsonl tail, gh PR cache, dep-snapshot reader,
   cli-status poller, backlog file walker
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-04 02:02'
 labels:
@@ -42,13 +42,13 @@ Manual refresh via `r` keystroke is the escape hatch for "I want to see X now."
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 pipeline-cli/src/tui/sources/events-tail.ts implements rolling tail of events-YYYY-MM-DD.jsonl (5s cadence)
-- [ ] #2 pipeline-cli/src/tui/sources/gh-pr-cache.ts wraps `gh pr list --json` with 60s TTL cache + invalidation on `r` keystroke
-- [ ] #3 pipeline-cli/src/tui/sources/dep-snapshot-reader.ts reads $ARTIFACTS_DIR/_deps/snapshot.<iso>.<tag>.jsonl on-demand
-- [ ] #4 pipeline-cli/src/tui/sources/orchestrator-status.ts polls `cli-orchestrator status` every 10s
-- [ ] #5 pipeline-cli/src/tui/sources/backlog-walker.ts walks backlog/tasks/ + backlog/completed/ every 30s
-- [ ] #6 Each source exposes a React hook (useEvents, useGhPrs, useDepSnapshot, useOrchestratorStatus, useBacklogTasks) for downstream pane consumption
-- [ ] #7 Graceful degradation per RFC §12: missing data source surfaces banner instead of crashing pane
-- [ ] #8 Unit tests cover: cache TTL behavior, polling lifecycle, error-handling for missing/corrupt files
-- [ ] #9 New code reaches 80%+ patch coverage
+- [x] #1 pipeline-cli/src/tui/sources/events-tail.ts implements rolling tail of events-YYYY-MM-DD.jsonl (5s cadence)
+- [x] #2 pipeline-cli/src/tui/sources/gh-pr-cache.ts wraps `gh pr list --json` with 60s TTL cache + invalidation on `r` keystroke
+- [x] #3 pipeline-cli/src/tui/sources/dep-snapshot-reader.ts reads $ARTIFACTS_DIR/_deps/snapshot.<iso>.<tag>.jsonl on-demand
+- [x] #4 pipeline-cli/src/tui/sources/orchestrator-status.ts polls `cli-orchestrator status` every 10s
+- [x] #5 pipeline-cli/src/tui/sources/backlog-walker.ts walks backlog/tasks/ + backlog/completed/ every 30s
+- [x] #6 Each source exposes a React hook (useEvents, useGhPrs, useDepSnapshot, useOrchestratorStatus, useBacklogTasks) for downstream pane consumption
+- [x] #7 Graceful degradation per RFC §12: missing data source surfaces banner instead of crashing pane
+- [x] #8 Unit tests cover: cache TTL behavior, polling lifecycle, error-handling for missing/corrupt files
+- [x] #9 New code reaches 80%+ patch coverage
 <!-- AC:END -->


### PR DESCRIPTION
## Summary

- AISDLC-178.2 (Phase 2: TUI Data Sources) implementation was already shipped in PR #255 and merged to main.
- AISDLC-187 (fast-recovery follow-up for gh-pr-cache) was also shipped in PR #316.
- This PR moves the task file from `backlog/tasks/` to `backlog/completed/` to formally close the task lifecycle, updating all 9 ACs to checked and status to Done.

## What shipped in the original PR #255

Five data sources under `pipeline-cli/src/tui/sources/`:
1. `events-tail.ts` — rolling tail of events-YYYY-MM-DD.jsonl, 5s cadence (AC #1)
2. `gh-pr-cache.ts` — wraps `gh pr list --json` with 60s TTL cache + invalidation (AC #2)
3. `dep-snapshot-reader.ts` — reads `$ARTIFACTS_DIR/_deps/snapshot.<iso>.<tag>.jsonl` on-demand (AC #3)
4. `orchestrator-status.ts` — polls `cli-orchestrator status` every 10s (AC #4)
5. `backlog-walker.ts` — walks `backlog/tasks/` + `backlog/completed/` every 30s (AC #5)

Each source exposes a React hook (`useEvents`, `useGhPrs`, `useDepSnapshot`, `useOrchestratorStatus`, `useBacklogTasks`) (AC #6). Graceful degradation per RFC §12 surfaces banners instead of crashes on missing/corrupt sources (AC #7). Unit tests cover TTL behavior, polling lifecycle, error-handling (AC #8). Pipeline-cli coverage is 94.98% (AC #9: 80%+ target).

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm test` — 1909 tests passed (11 events-tail, 22 gh-pr-cache, 8 dep-snapshot-reader, 6 orchestrator-status, 15 backlog-walker, 9 types)
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] Coverage gate: pipeline-cli 94.98% lines (threshold 80%)

This is a docs-only changeset (backlog task file move) and bypasses the attestation requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)