### PR TITLE
chore(spec): mark AISDLC-178.7 blocked (operator soak phase)

### DIFF
--- a/backlog/tasks/aisdlc-178.7 - Phase-7-Soak-corpus-aggregator-hybrid-promotion-runbook.md
+++ b/backlog/tasks/aisdlc-178.7 - Phase-7-Soak-corpus-aggregator-hybrid-promotion-runbook.md
@@ -18,6 +18,12 @@ references:
   - spec/rfcs/RFC-0024-emergent-issue-capture-and-triage.md
 parent_task_id: AISDLC-178
 priority: medium
+blocked:
+  reason: >-
+    Operator soak phase — implementation deferred until soak telemetry is in
+    place (operator monitors stability for ~1 week with the 178.x TUI in real
+    use, then promotes). NOT a dispatchable code task. Orchestrator's
+    BlockedFilter should skip this.
 ---
 
 ## Description


### PR DESCRIPTION
Mark 178.7 with blocked.reason so orchestrator's BlockedFilter skips it. 178.7 is the operator-monitored soak phase post-178.6 TUI ship — not a dispatchable code task. Without this, cli-orchestrator tick repeatedly picks it, runs ~20min of wasted dev work, then aborts on coverage gate.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)