### PR TITLE
docs(rfc): registry OQ column + critical-path graph + retrofit RFCs 0002-0005 against shipped impl

### DIFF
--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -8,7 +8,7 @@ Complete working examples demonstrating AI-SDLC SDK usage.
 |---|---|
 | [builder-examples.ts](builder-examples.ts) | All 5 resource builders with validation |
 | [gate-enforcement.ts](gate-enforcement.ts) | Programmatic quality gate evaluation with override and failure scenarios |
-| [adapter-implementation.ts](adapter-implementation.ts) | Custom adapter from scratch, registry, webhook bridge, EventBus |
+| [adapter-implementation.ts](adapter-implementation.ts) | Custom adapter from scratch, registry, webhook bridge, EventBus (RFC-0003 §3 example — IssueTracker pattern extended to the five infrastructure interfaces) |
 | [orchestration-patterns.ts](orchestration-patterns.ts) | All 5 orchestration patterns with execution and handoff validation |
 
 ## YAML Examples

--- a/spec/rfcs/README.md
+++ b/spec/rfcs/README.md
@@ -248,46 +248,284 @@ The registry covers four states:
 
 ## Registry
 
-| #     | Title                                                                                                | Status      | Lifecycle    | Author                                                          | File                                                                              | Notes                                                                                                       |
-| ----- | ---------------------------------------------------------------------------------------------------- | ----------- | ------------ | --------------------------------------------------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| 0001  | Template                                                                                             | n/a         | Template     | —                                                               | [RFC-0001-template.md](RFC-0001-template.md)                                      | Skeleton for new RFCs; not normative.                                                                       |
-| 0002  | Pipeline Orchestration Policy                                                                        | Draft       | Draft        | AI-SDLC Contributors                                            | [RFC-0002-pipeline-orchestration.md](RFC-0002-pipeline-orchestration.md)          | requiresDocs: tutorial, api-reference, example                                                              |
-| 0003  | Infrastructure Provider Adapters                                                                     | Draft       | Draft        | AI-SDLC Contributors                                            | [RFC-0003-infrastructure-adapters.md](RFC-0003-infrastructure-adapters.md)        | Slot collision resolved in AISDLC-109 (product-strategy renumbered to RFC-0013).                            |
-| 0004  | Cost Governance and Attribution                                                                      | Draft       | Draft        | AI-SDLC Contributors                                            | [RFC-0004-cost-governance-and-attribution.md](RFC-0004-cost-governance-and-attribution.md) | requiresDocs: tutorial, api-reference, operator-runbook                                                     |
-| 0005  | Product Priority Algorithm (PPA)                                                                     | Draft       | Draft        | Alexander Kline (Arcana Concept Studio), AI-SDLC Contributors    | [RFC-0005-product-priority-algorithm.md](RFC-0005-product-priority-algorithm.md)  | requiresDocs: api-reference, operator-runbook                                                               |
-| 0006  | Design System Governance Pipeline                                                                    | Final       | Implemented  | Dominique Legault, Morgan Hirtle, Alexander Kline                | [RFC-0006-design-system-governance-v5-final.md](RFC-0006-design-system-governance-v5-final.md) | requiresDocs: tutorial, operator-runbook, api-reference                                                     |
-| 0007  | Figma Make Pipeline Integration                                                                      | Final       | Signed Off   | Dominique Legault, Morgan Hirtle, Alexander Kline                | [RFC-0007-figma-make-pipeline-integration-v1-final.md](RFC-0007-figma-make-pipeline-integration-v1-final.md) | requires RFC-0002, RFC-0004, RFC-0006.                                                                      |
-| 0008  | PPA Triad Integration                                                                                | Final       | Implemented  | Dominique Legault, Morgan Hirtle, Alexander Kline                | [RFC-0008-ppa-triad-integration-final-combined.md](RFC-0008-ppa-triad-integration-final-combined.md) | requiresDocs: api-reference, operator-runbook                                                               |
-| 0009  | Tessellated Design Intent Documents                                                                  | Draft       | Ready for Review | Alexander Kline                                                  | [RFC-0009-tessellated-design-intent-documents.md](RFC-0009-tessellated-design-intent-documents.md) | v3.4 (2026-05-04) resolves all 13 OQs; OQ-3 + OQ-7 carve out follow-on patterns reserved as RFC-0017, RFC-0018, RFC-0020, RFC-0021. Engineering ✅ + Design ✅ signed v3.4; Product v3.4 sign-off pending (Alex authored v3.2). |
-| 0010  | Parallel Execution and Worktree Pooling                                                              | Draft       | Implemented  | Dominique Legault                                                | [RFC-0010-parallel-execution-worktree-pooling.md](RFC-0010-parallel-execution-worktree-pooling.md) | Legacy `status: Draft` retained; AISDLC-70.1–70.9 all Done. amends RFC-0002 + RFC-0004.                     |
-| 0011  | Definition-of-Ready Gate for Pipeline Admission                                                      | Draft       | Signed Off   | dominique@reliablegenius.io                                      | [RFC-0011-definition-of-ready-gate.md](RFC-0011-definition-of-ready-gate.md)      | requiresDocs: [] (phased rollout — docs land per phase).                                                    |
-| 0012  | Two-Tier Pipeline Architecture with Shared Core Library                                              | Approved    | Signed Off   | dominique@reliablegenius.io                                      | [RFC-0012-two-tier-pipeline-architecture.md](RFC-0012-two-tier-pipeline-architecture.md) | Internal architecture; no user-facing docs required.                                                        |
-| 0013  | AI-SDLC Orchestrator — Product Strategy                                                              | Draft       | Draft        | AI-SDLC Contributors                                            | [RFC-0013-product-first-implementation-strategy.md](RFC-0013-product-first-implementation-strategy.md) | Strategic / conceptual. Renumbered from former RFC-0003 collision (AISDLC-109).                             |
-| 0014  | Dependency Graph Composition for Pipeline Decisions                                                  | Draft       | Draft        | dominique@reliablegenius.io                                      | [RFC-0014-dependency-graph-composition.md](RFC-0014-dependency-graph-composition.md) | Phased rollout; no docs surfaces yet.                                                                       |
-| 0015  | Autonomous Pipeline Orchestrator                                                                     | Draft       | Ready for Review | dominique@reliablegenius.io                                  | [RFC-0015-autonomous-pipeline-orchestrator.md](RFC-0015-autonomous-pipeline-orchestrator.md) | requires RFC-0010, RFC-0011, RFC-0012, RFC-0014.                                                            |
-| 0016  | Estimation Calibration with T-Shirt Sizes                                                            | Draft       | Ready for Review | dominique@reliablegenius.io                                  | [RFC-0016-estimation-calibration-tshirt-sizes.md](RFC-0016-estimation-calibration-tshirt-sizes.md) | requires RFC-0011, RFC-0015.                                                                                |
-| 0017  | In-Soul Variant Pattern                                                              | Draft       | Draft        | Morgan Hirtle                                                   | [RFC-0017-in-soul-variant-pattern.md](RFC-0017-in-soul-variant-pattern.md)        | Carved out of RFC-0009 per OQ-3. Variant = a soul-scoped sub-theme with distinct visual identity and audience specialization. Practitioner validation via InternalAdopter product suite (ProductA / ProductB / ProductC / ProductD as four souls on shared substrate). requires RFC-0009. |
-| 0018  | In-Soul Journey Pattern                                                              | Draft       | Draft        | Morgan Hirtle                                                   | [RFC-0018-in-soul-journey-pattern.md](RFC-0018-in-soul-journey-pattern.md)        | Carved out of RFC-0009 per OQ-3. Journey = a temporally-ordered user flow within a soul that carries distinct design intent and completion criteria. Practitioner validation via InternalAdopter accessibility audit pipeline. requires RFC-0009, RFC-0017. |
-| 0019  | Embedding Provider Adapter Framework                                                                 | Draft       | Draft        | dominique@reliablegenius.io                                      | [RFC-0019-embedding-provider-adapter.md](RFC-0019-embedding-provider-adapter.md)  | Adapter framework for text→vector embedding providers; OpenAI text-embedding-3-small ships as default; adopters can plug custom adapters per the harness-adapter pattern (RFC-0010 §13). |
-| 0020  | Session-bug + Severity Scoring Rule                                                                  | Draft       | Draft        | —                                                               | (none yet — reservation only; draft ships in follow-on PR)                        | Carved out of RFC-0009 §13.5 per OQ-7 reversal of Position-stated; Dπ₃ refinement with practitioner validation.                          |
-| 0021  | Incident Monitoring + Root-Cause Analysis                                                            | Reserved    | Placeholder  | —                                                               | (none yet)                                                                        | Carved out of RFC-0009 §13.6 per OQ-7 reversal of Position-stated; pending adopter incident data before normative spec.                  |
-| 0022  | Compliance Posture + Audit Surface                                                                   | Draft       | Draft        | dominique@reliablegenius.io                                      | [RFC-0022-compliance-posture-audit-surface.md](RFC-0022-compliance-posture-audit-surface.md) | Adopter declares regulatory posture (HIPAA/SOC2/PCI-DSS/GDPR/etc.); framework derives gate defaults (DB pool isolation, secret-scan strictness, attestation requirement, retention) and exports audit evidence packs. RFC-0020 and RFC-0021 carved out of RFC-0009 (OQ-7); RFC-0009 OQ-11 trigger checklist references RFC-0022 as the canonical regime-declaration surface. |
-| 0023  | Operator TUI — Pipeline Monitoring + Steering Surface                                                | Draft       | Ready for Review | dominique@reliablegenius.io                                      | [RFC-0023-operator-tui-pipeline-monitoring.md](RFC-0023-operator-tui-pipeline-monitoring.md) | Operator-facing terminal interface to monitor + unblock the autonomous pipeline (post-RFC-0015). Required panes: PRs + next-step + human-in-loop blockers, dependency graph (RFC-0014 snapshot), pipeline journey overview, pipeline config editing, operator usage analytics. **All 10 OQs resolved** (Ink render boundary, $EDITOR config flow, both-analytics-surfaces, heuristic decision-pending detection, link-out-only kanban, polling v1, single-workspace v1, opt-OUT telemetry, affirming empty-state, aggregate-by-mode failures). Foregrounds decisions-pending per Decision Engine framing. Does not duplicate backlog.md kanban. |
-| 0024  | Emergent Issue Capture + Triage Pattern                                                              | Draft       | Draft        | dominique@reliablegenius.io                                      | [RFC-0024-emergent-issue-capture-and-triage.md](RFC-0024-emergent-issue-capture-and-triage.md) | Sidecar mechanism for capturing findings mid-work without breaking flow; triage rubric (quick-fix task vs scope-creep into current work vs new RFC); "decision-pending" → "decision-deferred" handoff so the orchestrator isn't blocked indefinitely. Addresses VISION.md §5 emergent-work gap. |
-| 0025  | Framework Quality Monitoring (Non-Decision Failure Modes)                                            | Draft       | Draft        | dominique@reliablegenius.io                                      | [RFC-0025-framework-quality-monitoring.md](RFC-0025-framework-quality-monitoring.md) | Distinguishes "operator under-decided" failures (fix the issue) from "framework misbehaved" failures (fix the framework); auto-routes the latter into bugfix backlog with severity scoring; closes the AISDLC-176-style "valid commit stranded" loop. Operationalizes VISION.md §4 honest failure modes. |
-| 0026  | Exploration Workstream Pattern                                                                       | Draft       | Draft        | dominique@reliablegenius.io                                      | [RFC-0026-exploration-workstream-pattern.md](RFC-0026-exploration-workstream-pattern.md) | First-class "spike/research" workstream type that bypasses DoR's decision-frontloading gate (since the goal IS to discover the unknowns); explicit time-box + handoff back to standard execution flow when knowns crystallize. Addresses VISION.md §5 exploration-mode gap. |
+The `OQs` column reports **unresolved open questions** per RFC. Source-of-truth is the RFC body's Open Questions section (typically §13 / §14 / §15). `0` means all OQs are resolved; `—` means the RFC has no OQ section (template, reserved-without-file, or non-normative strategic RFC). For the per-RFC OQ breakdown see [Open Questions Inventory](#open-questions-inventory); for the dependency graph rooted at RFC-0035 see [Critical Path to RFC-0035](#critical-path-to-rfc-0035-decision-catalog).
 
-| 0027  | Design Coherence Drift Detection                                                                     | Reserved    | Placeholder  | Morgan Hirtle                                                   | (none yet)                                                                        | Design Authority sign-off condition C3 from RFC-0009. Defines DesignCoherenceDrift reconciliation event: fires when delta between soul's design.imperatives and what DSB/component catalog implements exceeds threshold. Fourth Eτ_tessellation_drift detection rule. requires RFC-0009, RFC-0006. |
-| 0028  | Engineering-Axis Substrate Enforcement for Multi-Soul Platforms                                      | Draft       | Draft        | Alexander Kline                                                 | [RFC-0028-engineering-axis-substrate-enforcement.md](RFC-0028-engineering-axis-substrate-enforcement.md) | requires RFC-0008, RFC-0009. Substrate Contract pattern: which fields are `core` (locked, identity-class) vs `evolving` (override-permitted) at substrate level for multi-soul platforms. **4 open questions remaining (§7.1–7.4).** |
-| 0029  | Product Pillar — Architectural Vision (Design Principles, Framework Positions, Strategic Direction)  | Draft       | Draft        | Alexander Kline                                                 | [RFC-0029-product-pillar-architectural-vision.md](RFC-0029-product-pillar-architectural-vision.md) | requires RFC-0005, RFC-0008, RFC-0009. Strategic / vision RFC: Product pillar's positions on active RFCs (0014/0015/0016/0017/0018/0019/0022/0023/0024) + six design principles. **0 open questions** (vision doc; positions stated). |
-| 0030  | Signal Ingestion Pipeline (Demand Sources → D1)                                                       | Draft       | Draft        | Alexander Kline                                                 | [RFC-0030-signal-ingestion-pipeline.md](RFC-0030-signal-ingestion-pipeline.md)    | requires RFC-0005, RFC-0008, RFC-0011, RFC-0029. Adapter framework for ingesting demand signals (interviews, tickets, telemetry, ICP cohort data) into PPA's D1 channel. Tier weighting + clustering + SA Resonance filtering. **5 open questions remaining (§13.1–13.5).** |
-| 0031  | Calibration-Driven DID Revision Proposal Mechanism                                                   | Draft       | Draft        | Alexander Kline                                                 | [RFC-0031-calibration-driven-did-revision-proposal.md](RFC-0031-calibration-driven-did-revision-proposal.md) | requires RFC-0005, RFC-0008, RFC-0009, RFC-0029, RFC-0030. Closes calibration loop: framework auto-proposes DID revisions for operator review when calibration data shows consistent drift. **5 open questions remaining (§12.1–12.5).** |
-| 0032  | Cost-Governance Seam (Continuous ER Cost Pressure + Burst Spend Mechanism)                           | Draft       | Draft        | Alexander Kline                                                 | [RFC-0032-cost-governance-seam.md](RFC-0032-cost-governance-seam.md) | requires RFC-0004, RFC-0005, RFC-0008, RFC-0009, RFC-0010. Adds continuous Eρ_cost pressure to PPA scoring + explicit burst-spend mechanism for high-priority work bypassing steady-state ceilings. **5 open questions remaining (§10.1–10.5).** |
-| 0033  | Governance Reporting Layer (Periodic Synthesis of the Admission Chain)                                | Draft       | Draft        | Alexander Kline                                                 | [RFC-0033-governance-reporting-layer.md](RFC-0033-governance-reporting-layer.md) | requires RFC-0005, RFC-0008, RFC-0011, RFC-0014, RFC-0015. GovernanceReport resource: read-only periodic synthesis (scoring + cost + quality + calibration + R&D evidence sections). Composes with RFC-0022 audit packs. **5 open questions remaining (§9.1–9.5).** |
-| 0034  | PR Merge Critical-Path Ordering                                                                       | Reserved    | Placeholder  | dominique@reliablegenius.io                                      | (none yet — reservation only; AISDLC-178.4.1 ships the minimum derivation in RFC-0023 §7.2) | Longer-term home for auto-rebase trigger semantics, `depends-on` label conventions (canonical syntax + body-marker spec), and multi-repo PR ordering. AISDLC-178.4.1 reserved this number per its AC #8 (originally numbered RFC-0028 in the task spec; that slot was already taken by Engineering-Axis Substrate Enforcement, so this is the actual reservation). requires RFC-0014, RFC-0023.                                              |
-| 0035  | Decision Catalog and Operator Decision Routing                                                        | Draft       | Draft        | dominique@reliablegenius.io                                      | [RFC-0035-decision-catalog-operator-routing.md](RFC-0035-decision-catalog-operator-routing.md) | requires RFC-0011, RFC-0023, RFC-0024, RFC-0029. Operationalizes VISION.md §3 (operator-as-decision-steward): `Decision` resource type + deterministic-first evaluation ladder (mirrors RFC-0011 §4.4 + review-calibration) + actor-routing rubric (RFC-0029 pillar model) + capacity/fatigue model + decision-support surface (recommendation, counter-arguments, sub-decision graphs). **14 open questions** (§15). |
-| 0036  | Spec-Kit Bridge and Adopter Spec-Authoring Surface                                                    | Draft       | Draft        | dominique@reliablegenius.io                                      | [RFC-0036-spec-kit-bridge-adopter-authoring.md](RFC-0036-spec-kit-bridge-adopter-authoring.md) | requires RFC-0010, RFC-0011. Bridges [GitHub Spec Kit](https://github.com/github/spec-kit) (front-of-funnel artifact authoring) with ai-sdlc (back-of-funnel execution + governance). Defines the three-tier adopter authoring model (RFC → Spec → Task), the spec-kit import path (`ai-sdlc import-spec`), an optional adopter RFC scaffold (`ai-sdlc rfc init`), and the positioning updates that operationalize the AISDLC-248 repositioning. **12 open questions** (§14). |
+| #    | Title                                                                                                | Status      | Lifecycle    | OQs | Author                                                       | File                                                                              | Notes                                                                                                       |
+| ---- | ---------------------------------------------------------------------------------------------------- | ----------- | ------------ | --- | ------------------------------------------------------------ | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| 0001 | Template                                                                                             | n/a         | Template     | —   | —                                                            | [RFC-0001-template.md](RFC-0001-template.md)                                      | Skeleton for new RFCs; not normative.                                                                       |
+| 0002 | Pipeline Orchestration Policy                                                                        | Implemented | Implemented  | 1   | AI-SDLC Contributors                                         | [RFC-0002-pipeline-orchestration.md](RFC-0002-pipeline-orchestration.md)          | requiresDocs: tutorial, api-reference, example. Retrofit 2026-05-13 — design locked; OQ-3 `onTimeout: escalate` runtime not wired (RFC-0015 PR-labeling is the de-facto path). |
+| 0003 | Infrastructure Provider Adapters                                                                     | Implemented | Implemented  | 0   | AI-SDLC Contributors                                         | [RFC-0003-infrastructure-adapters.md](RFC-0003-infrastructure-adapters.md)        | Slot collision resolved in AISDLC-109 (product-strategy renumbered to RFC-0013). Retrofit 2026-05-13 — all 3 OQs resolved (no transactions, no ack, no versioning); RFC-0010 §13 `HarnessAdapter` is orthogonal, not superseding. |
+| 0004 | Cost Governance and Attribution                                                                      | Implemented | Implemented  | 3   | AI-SDLC Contributors                                         | [RFC-0004-cost-governance-and-attribution.md](RFC-0004-cost-governance-and-attribution.md) | requiresDocs: tutorial, api-reference, operator-runbook. Retrofit 2026-05-13 — CostPolicy / CostReconciler / CostTracker shipped end-to-end; 3 OQs deferred (humanReviewCost compute, cross-provider normalization, infra cost allocation). RFC-0032 extends, does not supersede. |
+| 0005 | Product Priority Algorithm (PPA)                                                                     | Approved    | Signed Off   | 2   | Alexander Kline (Arcana Concept Studio), AI-SDLC Contributors | [RFC-0005-product-priority-algorithm.md](RFC-0005-product-priority-algorithm.md)  | requiresDocs: api-reference, operator-runbook. Retrofit 2026-05-13 — design locked; admission subset wired (`orchestrator/src/admission-composite.ts`, `sa-scoring/`); full runtime composite deferred to PPA v1.1 per RFC-0008 §17. 2 OQs deferred (lifecycle weights for non-Eρ₄ dimensions, calibration retention). |
+| 0006 | Design System Governance Pipeline                                                                    | Final       | Implemented  | 1   | Dominique Legault, Morgan Hirtle, Alexander Kline             | [RFC-0006-design-system-governance-v5-final.md](RFC-0006-design-system-governance-v5-final.md) | requiresDocs: tutorial, operator-runbook, api-reference. Design locked; OQ-7 tooling-decision portion remains. |
+| 0007 | Figma Make Pipeline Integration                                                                      | Final       | Signed Off   | 5   | Dominique Legault, Morgan Hirtle, Alexander Kline             | [RFC-0007-figma-make-pipeline-integration-v1-final.md](RFC-0007-figma-make-pipeline-integration-v1-final.md) | requires RFC-0002, RFC-0004, RFC-0006. Design locked; 5 OQs framed as implementation-refinement items.        |
+| 0008 | PPA Triad Integration                                                                                | Final       | Implemented  | 0   | Dominique Legault, Morgan Hirtle, Alexander Kline             | [RFC-0008-ppa-triad-integration-final-combined.md](RFC-0008-ppa-triad-integration-final-combined.md) | requiresDocs: api-reference, operator-runbook                                                               |
+| 0009 | Tessellated Design Intent Documents                                                                  | Draft       | Ready for Review | 0 | Alexander Kline                                              | [RFC-0009-tessellated-design-intent-documents.md](RFC-0009-tessellated-design-intent-documents.md) | v3.4 (2026-05-04) resolves all 13 OQs; OQ-3 + OQ-7 carve out follow-on patterns reserved as RFC-0017, RFC-0018, RFC-0020, RFC-0021. Engineering ✅ + Design ✅ signed v3.4; Product v3.4 sign-off pending (Alex authored v3.2). |
+| 0010 | Parallel Execution and Worktree Pooling                                                              | Draft       | Implemented  | 0   | Dominique Legault                                            | [RFC-0010-parallel-execution-worktree-pooling.md](RFC-0010-parallel-execution-worktree-pooling.md) | Legacy `status: Draft` retained; AISDLC-70.1–70.9 all Done. amends RFC-0002 + RFC-0004.                     |
+| 0011 | Definition-of-Ready Gate for Pipeline Admission                                                      | Draft       | Signed Off   | 1   | dominique@reliablegenius.io                                  | [RFC-0011-definition-of-ready-gate.md](RFC-0011-definition-of-ready-gate.md)      | requiresDocs: [] (phased rollout — docs land per phase). Design locked; Q10 cost confirmation deferred to Phase 2b. |
+| 0012 | Two-Tier Pipeline Architecture with Shared Core Library                                              | Approved    | Signed Off   | 4   | dominique@reliablegenius.io                                  | [RFC-0012-two-tier-pipeline-architecture.md](RFC-0012-two-tier-pipeline-architecture.md) | Internal architecture; no user-facing docs required. Design locked; Q5–Q8 are implementation questions.       |
+| 0013 | AI-SDLC Orchestrator — Product Strategy                                                              | Draft       | Draft        | 3   | AI-SDLC Contributors                                         | [RFC-0013-product-first-implementation-strategy.md](RFC-0013-product-first-implementation-strategy.md) | Strategic / conceptual. Renumbered from former RFC-0003 collision (AISDLC-109).                             |
+| 0014 | Dependency Graph Composition for Pipeline Decisions                                                  | Draft       | Draft        | 0   | dominique@reliablegenius.io                                  | [RFC-0014-dependency-graph-composition.md](RFC-0014-dependency-graph-composition.md) | All 6 OQs resolved inline 2026-05-01; lifecycle promotion pending. Phased rollout; no docs surfaces yet.    |
+| 0015 | Autonomous Pipeline Orchestrator                                                                     | Draft       | Ready for Review | 0 | dominique@reliablegenius.io                              | [RFC-0015-autonomous-pipeline-orchestrator.md](RFC-0015-autonomous-pipeline-orchestrator.md) | requires RFC-0010, RFC-0011, RFC-0012, RFC-0014. All 12 OQs resolved 2026-05-01.                              |
+| 0016 | Estimation Calibration with T-Shirt Sizes                                                            | Draft       | Ready for Review | 0 | dominique@reliablegenius.io                              | [RFC-0016-estimation-calibration-tshirt-sizes.md](RFC-0016-estimation-calibration-tshirt-sizes.md) | requires RFC-0011, RFC-0015. All 8 OQs resolved via operator walkthrough 2026-05-03 (documented in §15 Resolutions). |
+| 0017 | In-Soul Variant Pattern                                                                              | Draft       | Draft        | 8   | Morgan Hirtle                                                | [RFC-0017-in-soul-variant-pattern.md](RFC-0017-in-soul-variant-pattern.md)        | Carved out of RFC-0009 per OQ-3. Variant = a soul-scoped sub-theme with distinct visual identity and audience specialization. Practitioner validation via InternalAdopter product suite (ProductA / ProductB / ProductC / ProductD as four souls on shared substrate). requires RFC-0009. |
+| 0018 | In-Soul Journey Pattern                                                                              | Draft       | Draft        | 10  | Morgan Hirtle                                                | [RFC-0018-in-soul-journey-pattern.md](RFC-0018-in-soul-journey-pattern.md)        | Carved out of RFC-0009 per OQ-3. Journey = a temporally-ordered user flow within a soul that carries distinct design intent and completion criteria. Practitioner validation via InternalAdopter accessibility audit pipeline. requires RFC-0009, RFC-0017. |
+| 0019 | Embedding Provider Adapter Framework                                                                 | Draft       | Draft        | 7   | dominique@reliablegenius.io                                  | [RFC-0019-embedding-provider-adapter.md](RFC-0019-embedding-provider-adapter.md)  | Adapter framework for text→vector embedding providers; OpenAI text-embedding-3-small ships as default; adopters can plug custom adapters per the harness-adapter pattern (RFC-0010 §13). |
+| 0020 | Session-bug + Severity Scoring Rule                                                                  | Draft       | Draft        | —   | —                                                            | (none yet — reservation only; draft ships in follow-on PR)                        | Carved out of RFC-0009 §13.5 per OQ-7 reversal of Position-stated; Dπ₃ refinement with practitioner validation. |
+| 0021 | Incident Monitoring + Root-Cause Analysis                                                            | Reserved    | Placeholder  | —   | —                                                            | (none yet)                                                                        | Carved out of RFC-0009 §13.6 per OQ-7 reversal of Position-stated; pending adopter incident data before normative spec. |
+| 0022 | Compliance Posture + Audit Surface                                                                   | Draft       | Draft        | 7   | dominique@reliablegenius.io                                  | [RFC-0022-compliance-posture-audit-surface.md](RFC-0022-compliance-posture-audit-surface.md) | Adopter declares regulatory posture (HIPAA/SOC2/PCI-DSS/GDPR/etc.); framework derives gate defaults (DB pool isolation, secret-scan strictness, attestation requirement, retention) and exports audit evidence packs. RFC-0020 and RFC-0021 carved out of RFC-0009 (OQ-7); RFC-0009 OQ-11 trigger checklist references RFC-0022 as the canonical regime-declaration surface. |
+| 0023 | Operator TUI — Pipeline Monitoring + Steering Surface                                                | Draft       | Ready for Review | 0 | dominique@reliablegenius.io                              | [RFC-0023-operator-tui-pipeline-monitoring.md](RFC-0023-operator-tui-pipeline-monitoring.md) | requires RFC-0014, RFC-0015. Operator-facing terminal interface to monitor + unblock the autonomous pipeline (post-RFC-0015). Required panes: PRs + next-step + human-in-loop blockers, dependency graph (RFC-0014 snapshot), pipeline journey overview, pipeline config editing, operator usage analytics. All 10 OQs resolved via operator walkthrough 2026-05-03 (§15 Resolved questions). Foregrounds decisions-pending per Decision Engine framing. Does not duplicate backlog.md kanban. |
+| 0024 | Emergent Issue Capture + Triage Pattern                                                              | Draft       | Draft        | 12  | dominique@reliablegenius.io                                  | [RFC-0024-emergent-issue-capture-and-triage.md](RFC-0024-emergent-issue-capture-and-triage.md) | requires RFC-0011, RFC-0015. Sidecar mechanism for capturing findings mid-work without breaking flow; triage rubric (quick-fix task vs scope-creep into current work vs new RFC); "decision-pending" → "decision-deferred" handoff so the orchestrator isn't blocked indefinitely. Addresses VISION.md §5 emergent-work gap. |
+| 0025 | Framework Quality Monitoring (Non-Decision Failure Modes)                                            | Draft       | Draft        | 10  | dominique@reliablegenius.io                                  | [RFC-0025-framework-quality-monitoring.md](RFC-0025-framework-quality-monitoring.md) | requires RFC-0015, RFC-0024. Distinguishes "operator under-decided" failures (fix the issue) from "framework misbehaved" failures (fix the framework); auto-routes the latter into bugfix backlog with severity scoring; closes the AISDLC-176-style "valid commit stranded" loop. Operationalizes VISION.md §4 honest failure modes. |
+| 0026 | Exploration Workstream Pattern                                                                       | Draft       | Draft        | 12  | dominique@reliablegenius.io                                  | [RFC-0026-exploration-workstream-pattern.md](RFC-0026-exploration-workstream-pattern.md) | requires RFC-0011, RFC-0015, RFC-0024. First-class "spike/research" workstream type that bypasses DoR's decision-frontloading gate (since the goal IS to discover the unknowns); explicit time-box + handoff back to standard execution flow when knowns crystallize. Addresses VISION.md §5 exploration-mode gap. |
+| 0027 | Design Coherence Drift Detection                                                                     | Reserved    | Placeholder  | —   | Morgan Hirtle                                                | (none yet)                                                                        | Design Authority sign-off condition C3 from RFC-0009. Defines DesignCoherenceDrift reconciliation event: fires when delta between soul's design.imperatives and what DSB/component catalog implements exceeds threshold. Fourth Eτ_tessellation_drift detection rule. requires RFC-0009, RFC-0006. |
+| 0028 | Engineering-Axis Substrate Enforcement for Multi-Soul Platforms                                      | Draft       | Draft        | 4   | Alexander Kline                                              | [RFC-0028-engineering-axis-substrate-enforcement.md](RFC-0028-engineering-axis-substrate-enforcement.md) | requires RFC-0008, RFC-0009. Substrate Contract pattern: which fields are `core` (locked, identity-class) vs `evolving` (override-permitted) at substrate level for multi-soul platforms. |
+| 0029 | Product Pillar — Architectural Vision (Design Principles, Framework Positions, Strategic Direction)  | Draft       | Draft        | —   | Alexander Kline                                              | [RFC-0029-product-pillar-architectural-vision.md](RFC-0029-product-pillar-architectural-vision.md) | requires RFC-0005, RFC-0008, RFC-0009. Strategic / vision RFC: Product pillar's positions on active RFCs (0014/0015/0016/0017/0018/0019/0022/0023/0024) + six design principles. No OQ section by design (vision doc; positions stated).             |
+| 0030 | Signal Ingestion Pipeline (Demand Sources → D1)                                                      | Draft       | Draft        | 5   | Alexander Kline                                              | [RFC-0030-signal-ingestion-pipeline.md](RFC-0030-signal-ingestion-pipeline.md)    | requires RFC-0005, RFC-0008, RFC-0011, RFC-0029. Adapter framework for ingesting demand signals (interviews, tickets, telemetry, ICP cohort data) into PPA's D1 channel. Tier weighting + clustering + SA Resonance filtering. |
+| 0031 | Calibration-Driven DID Revision Proposal Mechanism                                                   | Draft       | Draft        | 5   | Alexander Kline                                              | [RFC-0031-calibration-driven-did-revision-proposal.md](RFC-0031-calibration-driven-did-revision-proposal.md) | requires RFC-0005, RFC-0008, RFC-0009, RFC-0029, RFC-0030. Closes calibration loop: framework auto-proposes DID revisions for operator review when calibration data shows consistent drift. |
+| 0032 | Cost-Governance Seam (Continuous ER Cost Pressure + Burst Spend Mechanism)                           | Draft       | Draft        | 5   | Alexander Kline                                              | [RFC-0032-cost-governance-seam.md](RFC-0032-cost-governance-seam.md) | requires RFC-0004, RFC-0005, RFC-0008, RFC-0009, RFC-0010, RFC-0029. Adds continuous Eρ_cost pressure to PPA scoring + explicit burst-spend mechanism for high-priority work bypassing steady-state ceilings. |
+| 0033 | Governance Reporting Layer (Periodic Synthesis of the Admission Chain)                               | Draft       | Draft        | 5   | Alexander Kline                                              | [RFC-0033-governance-reporting-layer.md](RFC-0033-governance-reporting-layer.md) | requires RFC-0005, RFC-0008, RFC-0011, RFC-0014, RFC-0015, RFC-0022, RFC-0029, RFC-0030. GovernanceReport resource: read-only periodic synthesis (scoring + cost + quality + calibration + R&D evidence sections). Composes with RFC-0022 audit packs. |
+| 0034 | PR Merge Critical-Path Ordering                                                                      | Reserved    | Placeholder  | —   | dominique@reliablegenius.io                                  | (none yet — reservation only; AISDLC-178.4.1 ships the minimum derivation in RFC-0023 §7.2) | Longer-term home for auto-rebase trigger semantics, `depends-on` label conventions (canonical syntax + body-marker spec), and multi-repo PR ordering. AISDLC-178.4.1 reserved this number per its AC #8 (originally numbered RFC-0028 in the task spec; that slot was already taken by Engineering-Axis Substrate Enforcement, so this is the actual reservation). requires RFC-0014, RFC-0023. |
+| 0035 | Decision Catalog and Operator Decision Routing                                                       | Draft       | Draft        | 14  | dominique@reliablegenius.io                                  | [RFC-0035-decision-catalog-operator-routing.md](RFC-0035-decision-catalog-operator-routing.md) | requires RFC-0011, RFC-0023, RFC-0024, RFC-0029. Operationalizes VISION.md §3 (operator-as-decision-steward): `Decision` resource type + deterministic-first evaluation ladder (mirrors RFC-0011 §4.4 + review-calibration) + actor-routing rubric (RFC-0029 pillar model) + capacity/fatigue model + decision-support surface (recommendation, counter-arguments, sub-decision graphs). |
+| 0036 | Spec-Kit Bridge and Adopter Spec-Authoring Surface                                                   | Draft       | Draft        | 12  | dominique@reliablegenius.io                                  | [RFC-0036-spec-kit-bridge-adopter-authoring.md](RFC-0036-spec-kit-bridge-adopter-authoring.md) | requires RFC-0010, RFC-0011. Bridges [GitHub Spec Kit](https://github.com/github/spec-kit) (front-of-funnel artifact authoring) with ai-sdlc (back-of-funnel execution + governance). Defines the three-tier adopter authoring model (RFC → Spec → Task), the spec-kit import path (`ai-sdlc import-spec`), an optional adopter RFC scaffold (`ai-sdlc rfc init`), and the positioning updates that operationalize the AISDLC-248 repositioning. |
 
 **Next available number:** RFC-0037.
 
 > **Historical note (RFC-0003 collision):** Two different proposals (`-infrastructure-adapters` and `-product-first-implementation-strategy`) were both numbered 0003. AISDLC-109 resolved the collision by renumbering the product-strategy RFC to RFC-0013; RFC-0003 now refers unambiguously to the infrastructure-adapters RFC. Numbers are NOT recycled — slot collisions are confusing, so withdrawn entries keep their row in the registry.
+
+## Open Questions Inventory
+
+> **Audited:** 2026-05-13 (manual). Until [RFC-0035](RFC-0035-decision-catalog-operator-routing.md) ships the Decision Catalog, this section is regenerated by hand when meaningful RFC churn happens. Source-of-truth for each OQ is the body of the linked RFC; titles below are summarized.
+>
+> **Totals:** 31 active RFCs audited (excluding template + reservation-only entries). **~146 unresolved OQs**, **~84 resolved**. RFC-0029 has no OQ section by design (vision doc; positions stated). 2026-05-13 retrofit closed 12 OQs in RFC-0002 / RFC-0003 / RFC-0004 / RFC-0005 against shipped implementation; remaining residuals are documented in *Design locked* below.
+
+### Active design walkthroughs (Draft lifecycle, OQs pending resolution)
+
+These RFCs need operator / owner decisions before they can promote to Ready for Review.
+
+**RFC-0013 — Orchestrator Product Strategy** (3 OQs)
+- License choice for orchestrator
+- Agent compute cost attribution
+- AAIF contribution timing
+
+**RFC-0017 — In-Soul Variant Pattern** (8 OQs; first 5)
+- Maximum variants per Soul
+- Nested variants
+- Variant lifecycle (deprecation, removal)
+- Cross-variant scoring rule precedence
+- `designOverrides` extensibility
+
+**RFC-0018 — In-Soul Journey Pattern** (10 OQs; first 5)
+- Maximum journeys per Soul/Variant
+- State cardinality limits
+- Sub-journeys (journey-within-journey)
+- Completion-criteria expressiveness
+- Success-metrics source
+
+**RFC-0019 — Embedding Provider Adapter** (7 OQs; first 5)
+- Vector storage backend for v1 (JSONL vs sqlite)
+- Stale-vector policy default (lazy-re-embed vs fail-loud)
+- Cross-provider compatibility (explicit no-op vs auto-migrate)
+- Embedding provider deprecation grace period
+- Where in pipeline-cli vs orchestrator the framework lives
+
+**RFC-0022 — Compliance Posture + Audit Surface** (7 OQs; first 5)
+- Regime → controls mapping location
+- Operator override audit trail
+- Source of truth for control mappings
+- Audit export format (single tar vs per-kind directory)
+- Real-time compliance monitoring vs on-demand export
+
+**RFC-0024 — Emergent Issue Capture + Triage** (12 OQs; first 5) — *on RFC-0035 critical path*
+- Capture privacy
+- AI-agent auto-triage threshold
+- Capture-vs-comment for in-PR findings
+- In-code marker syntax
+- Severity inference
+
+**RFC-0025 — Framework Quality Monitoring** (10 OQs; first 5)
+- Default classification when ambiguous
+- Severity weight tuning surface
+- Recurrence detection window
+- Framework-bug attribution to module owners
+- Adopter telemetry opt-in
+
+**RFC-0026 — Exploration Workstream Pattern** (12 OQs; first 5)
+- Default budget
+- Crystallization required to close
+- Iteration vs Exploration boundary
+- Multi-operator exploration
+- Exploration of explorations
+
+**RFC-0028 — Engineering-Axis Substrate Enforcement** (4 OQs)
+- `identityClass: core | evolving` at substrate-field level (§7.1)
+- Structural-vs-statistical drift pairing (§7.2)
+- Centroid computation slot (§7.3)
+- Cross-reference path back to RFC-0009 §7.2 (§7.4)
+
+**RFC-0030 — Signal Ingestion Pipeline** (5 OQs)
+- Adapter authentication / credential management (§13.1)
+- Multi-language signal processing (§13.2)
+- Privacy / customer-data residency (§13.3)
+- Manual signal entry (§13.4)
+- Adversarial signal injection (§13.5)
+
+**RFC-0031 — Calibration-Driven DID Revision** (5 OQs)
+- Confidence calibration (§12.1)
+- Multi-field bundling (§12.2)
+- Operator opt-out per field (§12.3)
+- Cross-pillar coordination (§12.4)
+- Rejection learnings (§12.5)
+
+**RFC-0032 — Cost-Governance Seam** (5 OQs)
+- Executive layer identity (§10.1)
+- Multi-shard burst contention (§10.2)
+- Auto-approve thresholds (§10.3)
+- Burst-rejection learnings (§10.4)
+- Per-pillar cost-veto (§10.5)
+
+**RFC-0033 — Governance Reporting Layer** (5 OQs)
+- LLM-augmented narrative generation (§9.1)
+- Cross-project rollups (§9.2)
+- Evidence freshness (§9.3)
+- PII / sensitive content in narratives (§9.4)
+- Tamper-evidence (§9.5)
+
+**RFC-0035 — Decision Catalog and Operator Decision Routing** (14 OQs; first 5) — *target RFC*
+- Catalog vs projection
+- Load-bearing measurement
+- LLM-confidence cold start
+- Task-vs-decision boundary
+- Cross-source dedup
+
+**RFC-0036 — Spec-Kit Bridge and Adopter Spec-Authoring Surface** (12 OQs; first 5)
+- Seam artifact granularity
+- `specRef` drift semantics
+- DoR strictness at import
+- Adopter RFC storage convention
+- RFC template variants
+
+### Awaiting lifecycle promotion (0 OQs; sign-off mechanics only)
+
+OQs are resolved; what remains is per-owner sign-off ceremony, not new design work.
+
+- **RFC-0009** Tessellated Design Intent — Lifecycle: Ready for Review. v3.4 resolves all 13 OQs; awaiting Product (Alex) sign-off on v3.4.
+- **RFC-0014** Dependency Graph Composition — Lifecycle: Draft. All 6 OQs resolved 2026-05-01; lifecycle promotion to Ready for Review pending.
+- **RFC-0015** Autonomous Pipeline Orchestrator — Lifecycle: Ready for Review. All 12 OQs resolved 2026-05-01; awaiting sign-off.
+- **RFC-0016** Estimation Calibration (T-Shirt Sizes) — Lifecycle: Ready for Review. All 8 OQs resolved via operator walkthrough 2026-05-03.
+- **RFC-0023** Operator TUI — Lifecycle: Ready for Review. All 10 OQs resolved via operator walkthrough 2026-05-03.
+
+### Design locked (residual OQs are implementation refinements)
+
+These RFCs are Signed Off or Implemented. Remaining OQs are implementation-tier questions; they do not affect downstream RFCs' design contracts.
+
+- **RFC-0002** Pipeline Orchestration Policy — Lifecycle: Implemented (retrofit 2026-05-13). 1 residual: OQ-3 `onTimeout: escalate` runtime not wired — the schema enum lands but `ApprovalWorkflow` has no timeout reconciler; RFC-0015's PR-labeling is the de-facto escalation path.
+- **RFC-0003** Infrastructure Provider Adapters — Lifecycle: Implemented (retrofit 2026-05-13). All 3 OQs resolved as "stay simple" (no transactions, no ack, no versioning); design closed. RFC-0010 §13 `HarnessAdapter` is orthogonal, not superseding.
+- **RFC-0004** Cost Governance and Attribution — Lifecycle: Implemented (retrofit 2026-05-13). 3 deferred OQs: OQ-1 humanReviewCost compute, OQ-2 cross-provider normalization, OQ-5 infrastructure cost allocation — all revisitable when a concrete consumer materializes. RFC-0032 (Draft) extends, does NOT supersede.
+- **RFC-0005** Product Priority Algorithm — Lifecycle: Signed Off (retrofit 2026-05-13). Admission subset wired (`orchestrator/src/admission-composite.ts`, `sa-scoring/`); full runtime composite deferred to PPA v1.1 per RFC-0008 §17. 2 deferred OQs: OQ-2 lifecycle weights for non-Eρ₄ dimensions, OQ-5 calibration data retention.
+- **RFC-0006** Design System Governance — Lifecycle: Implemented. 1 partial OQ (Q7 autonomy-threshold tooling decision); design locked.
+- **RFC-0007** Figma Make Pipeline Integration — Lifecycle: Signed Off. 5 OQs framed as "must be resolved before advancing from draft," but RFC is Signed Off; treat as implementation-refinement queue.
+- **RFC-0011** DoR Gate — Lifecycle: Signed Off. 1 partial OQ (Q10 cost confirmation deferred to Phase 2b); design locked.
+- **RFC-0012** Two-Tier Pipeline Architecture — Lifecycle: Signed Off. 4 implementation questions (subagent invocation discovery, per-tenant spawner config, integration testing without quota burn, plugin install path).
+
+## Critical Path to RFC-0035 (Decision Catalog)
+
+This section computes the dependency chain that must be design-stable for **RFC-0035 (Decision Catalog and Operator Decision Routing)** to ship. Source: `requires:` frontmatter edges, traced transitively. Two milestones are distinct:
+
+1. **Sign-off-ready** — RFC-0035's direct dependencies are Signed Off (or Ready for Review with no open design questions) so the contract surface is stable. This is the near-term milestone the operator burns OQs to reach.
+2. **Implementation-ready** — the dependent infrastructure (DoR Gate, dep graph, TUI, emergent-capture) is shipped to a degree that RFC-0035's Phase 1-11 implementation plan can land. This follows sign-off and is driven by milestone tracking, not OQ debt.
+
+### Dependency graph
+
+```mermaid
+graph BT
+    %% Critical-path graph rooted at RFC-0035 (Decision Catalog)
+    %% Edge direction: child requires parent (bottom-up)
+    %% Color: green = design locked, blue = signed off, yellow = ready for review / 0 OQs draft, red = OQs open, bold = target
+
+    RFC0002["RFC-0002<br/>Pipeline Orch.<br/>Implemented"]
+    RFC0004["RFC-0004<br/>Cost Gov.<br/>Implemented (3 deferred)"]
+    RFC0005["RFC-0005<br/>PPA<br/>Signed Off (2 deferred)"]
+    RFC0006["RFC-0006<br/>Design Sys.<br/>Implemented"]
+    RFC0008["RFC-0008<br/>PPA Triad<br/>Implemented"]
+    RFC0009["RFC-0009<br/>TDID<br/>Ready for Review / 0 OQs"]
+    RFC0010["RFC-0010<br/>Parallel Exec<br/>Implemented"]
+    RFC0011["RFC-0011<br/>DoR Gate<br/>Signed Off"]
+    RFC0012["RFC-0012<br/>2-Tier Pipeline<br/>Signed Off"]
+    RFC0014["RFC-0014<br/>Dep Graph<br/>Draft / 0 OQs"]
+    RFC0015["RFC-0015<br/>Auto Orchestrator<br/>Ready for Review / 0 OQs"]
+    RFC0023["RFC-0023<br/>Operator TUI<br/>Ready for Review / 0 OQs"]
+    RFC0024["RFC-0024<br/>Emergent Capture<br/>Draft / 12 OQs"]
+    RFC0029["RFC-0029<br/>Product Pillar<br/>Draft / no OQ section"]
+    RFC0035["RFC-0035<br/>Decision Catalog<br/>Draft / 14 OQs"]
+
+    RFC0002 --> RFC0006
+    RFC0004 --> RFC0006
+    RFC0006 --> RFC0008
+    RFC0002 --> RFC0010
+    RFC0008 --> RFC0010
+    RFC0010 --> RFC0015
+    RFC0011 --> RFC0015
+    RFC0012 --> RFC0015
+    RFC0014 --> RFC0015
+    RFC0014 --> RFC0023
+    RFC0015 --> RFC0023
+    RFC0011 --> RFC0024
+    RFC0015 --> RFC0024
+    RFC0005 --> RFC0029
+    RFC0008 --> RFC0029
+    RFC0009 --> RFC0029
+    RFC0011 --> RFC0035
+    RFC0023 --> RFC0035
+    RFC0024 --> RFC0035
+    RFC0029 --> RFC0035
+
+    classDef implemented fill:#d4edda,stroke:#155724,color:#155724
+    classDef signedOff fill:#d1ecf1,stroke:#0c5460,color:#0c5460
+    classDef readyOrZero fill:#fff3cd,stroke:#856404,color:#856404
+    classDef draftOpen fill:#f8d7da,stroke:#721c24,color:#721c24
+    classDef target fill:#cce5ff,stroke:#004085,color:#004085,stroke-width:3px
+
+    class RFC0002,RFC0004,RFC0006,RFC0008,RFC0010 implemented
+    class RFC0005,RFC0011,RFC0012 signedOff
+    class RFC0009,RFC0014,RFC0015,RFC0023 readyOrZero
+    class RFC0024,RFC0029 draftOpen
+    class RFC0035 target
+```
+
+### Critical-path status table
+
+The rows are listed in dependency order (ancestors first). The **Blocks RFC-0035?** column reports whether the RFC's current state blocks RFC-0035's near-term sign-off.
+
+| RFC | Title | Lifecycle | Unresolved OQs | Blocks RFC-0035 sign-off? | Recommended next action |
+|---|---|---|---|---|---|
+| RFC-0008 | PPA Triad | Implemented | 0 | No | — |
+| RFC-0009 | Tessellated Design Intent | Ready for Review | 0 | No (transitive only) | Land Alex's Product sign-off on v3.4 |
+| RFC-0011 | DoR Gate | Signed Off | 1 partial | No | Q10 confirmation deferred to Phase 2b — non-blocking |
+| RFC-0023 | Operator TUI | Ready for Review | 0 | Yes — direct dep | Promote to Signed Off (Engineering + Operator + Product sign-offs) |
+| RFC-0024 | Emergent Issue Capture | Draft | **12** | **Yes — direct dep** | Run operator walkthrough of all 12 OQs; promote to Ready for Review then Signed Off |
+| RFC-0029 | Product Pillar | Draft | — (no OQ section) | Yes — direct dep | Promote to Signed Off (Product sign-off; vision doc, no OQ walkthrough needed) |
+| RFC-0035 | Decision Catalog | Draft | **14** | (target) | Run operator walkthrough of all 14 OQs once RFC-0024 + RFC-0029 sign-offs unblock the design contract |
+
+### Action sequence (near-term decision burn)
+
+The bulk of operator decision time before RFC-0035 sign-off is concentrated in two RFCs:
+
+1. **RFC-0024 walkthrough** — 12 OQs. RFC-0035's `source: emergent-finding` feeder behavior depends on RFC-0024's capture / triage contract. Resolve first because RFC-0035 OQs (e.g. OQ-5 cross-source dedup, OQ-7 catalog vs projection) read out of RFC-0024's resolution.
+2. **RFC-0035 walkthrough** — 14 OQs. Resolve after RFC-0024 lands so design coherence is preserved.
+
+**Parallel sign-off ceremonies (no new design work):**
+
+- RFC-0023 → Signed Off (Engineering + Operator + Product sign on §15 Resolved questions)
+- RFC-0029 → Signed Off (Product sign-off; vision doc has no OQ surface)
+- RFC-0009 → Signed Off (Alex's v3.4 Product sign-off)
+
+**Total operator decision-burn for RFC-0035 sign-off: ~26 OQs** (12 in RFC-0024 + 14 in RFC-0035).
+
+### What this section becomes once RFC-0035 ships
+
+Once the Decision Catalog ships, this manually-curated section is replaced by a `cli-decisions critical-path --target RFC-0035` query that traverses the live catalog and the registry's `requires:` edges automatically. The Mermaid graph above is a snapshot — the live tool will regenerate it per-target on demand and reflect override events, deferred decisions, and capacity-aware prioritization (§7 of RFC-0035). For now, regenerate this section by hand when:
+
+- A critical-path RFC's lifecycle changes (Draft → Ready for Review → Signed Off → Implemented)
+- A critical-path RFC's OQs are resolved or new ones are added
+- RFC-0035's `requires:` edges change

--- a/spec/rfcs/RFC-0002-pipeline-orchestration.md
+++ b/spec/rfcs/RFC-0002-pipeline-orchestration.md
@@ -1,11 +1,11 @@
 ---
 id: RFC-0002
 title: Pipeline Orchestration Policy
-status: Draft
-lifecycle: Draft
+status: Implemented
+lifecycle: Implemented
 author: AI-SDLC Contributors
 created: 2026-02-09
-updated: 2026-02-09
+updated: 2026-05-13
 targetSpecVersion: v1alpha1
 requiresDocs:
   - tutorial
@@ -15,11 +15,11 @@ requiresDocs:
 
 # RFC-0002: Pipeline Orchestration Policy
 
-**Status:** Draft
-**Lifecycle:** Draft
+**Status:** Implemented
+**Lifecycle:** Implemented
 **Author:** AI-SDLC Contributors
 **Created:** 2026-02-09
-**Updated:** 2026-02-09
+**Updated:** 2026-05-13
 **Target Spec Version:** v1alpha1
 
 ---
@@ -569,15 +569,27 @@ This minimal pipeline is valid under both the current and proposed schemas. All 
 
 ## Open Questions
 
+> **Retrofit (2026-05-13):** OQs resolved against the implementation that shipped. Resolution markers added inline per question. Lifecycle promoted to `Implemented`.
+
 1. **Stage dependencies vs. strict ordering** — Should stages support a `dependsOn` field for DAG-style execution, or is the current sequential ordering sufficient? Sequential ordering covers the common case. DAG support adds significant complexity and may be better deferred to a future RFC.
+
+   **Resolution (2026-05-13):** Sequential ordering kept; no DAG support added. `Pipeline.spec.stages` is normatively an "Ordered list of execution stages" (spec.md §5.1.1); no `dependsOn` was added to the Stage object in `spec/schemas/pipeline.schema.json`. Cross-issue parallelism shipped via `Pipeline.spec.parallelism` (RFC-0010) at a higher granularity (one whole pipeline run per worktree slot). The only stage-to-stage cross-reference is `requiresIndependentHarnessFrom` for harness-exclusion (RFC-0010 §13.10) — not a scheduling DAG. DAG support remains explicitly out of scope.
 
 2. **Notification template language** — Is simple `{placeholder}` interpolation sufficient, or do templates need conditionals (e.g., "show reviewer name if present")? The proposal starts with simple interpolation; a future RFC could introduce a lightweight template language if needed.
 
+   **Resolution (2026-05-13):** Simple `{placeholder}` interpolation shipped; no template engine adopted. Both code paths — `orchestrator/src/notifications.ts:renderTemplate` (issue/PR comments) and `orchestrator/src/notifications/notification-router.ts:renderTemplate` (Slack/Teams) — implement `{key}` placeholder substitution with the unknown-key-passthrough behavior the RFC specified. No `handlebars`/`mustache`/`eta` dependency was introduced. Stage-specific content is rendered upstream and passed in via `{details}`. Future RFC if conditional rendering becomes a real demand.
+
 3. **Approval escalation semantics** — When `onTimeout: escalate` is specified, what does "escalate" mean concretely? The proposal leaves this to implementations (e.g., notify a higher-level approver, post to a Slack channel). Should the spec define escalation targets?
+
+   **Resolution (2026-05-13):** **Partially resolved.** The schema enum `abort | escalate | auto-approve` shipped as-specified (`spec/schemas/pipeline.schema.json:428-432`), but the reference runtime did not wire approval-timeout polling — `ApprovalWorkflow` (`reference/dist/security/interfaces.d.ts:70-79`) only exposes `submit / approve / reject / getStatus`. Today's "escalation" is the RFC-0015 autonomous-orchestrator concept implemented in `pipeline-cli/src/orchestrator/loop.ts:buildDefaultEscalate` — labels the PR `needs-human-attention` and logs a warning. `escalate` as an approval-timeout response is **not implemented**; declaring `onTimeout: escalate` on a Stage today is schema-valid but a runtime no-op. Either future work wires `ApprovalWorkflow` to a timeout reconciler, or a future RFC narrows the enum to `abort | auto-approve`.
 
 4. **Fix-CI as a separate pipeline or stage** — The dogfood pipeline has a distinct fix-CI flow (`fix-ci.ts`) that is triggered by CI failures, not by issue assignment. Should the spec model this as a separate Pipeline resource triggered by `ci.failed`, or as a retry strategy within the `implement` stage? The current proposal models it via `onFailure.strategy: retry`, but the fix-CI flow has distinct logic (fetching CI logs, passing error context to agent).
 
+   **Resolution (2026-05-13):** **Hybrid.** Fix-CI shipped as an independent execution path, not a stage within the main Pipeline. The trigger is `workflow_run.conclusion == 'failure'` in `.github/workflows/ai-sdlc-fix-ci.yml`, the implementation is a standalone `@ai-sdlc/orchestrator` entry point (`executeFixCI` / `executeFixReview`), and the local-operator shim `/ai-sdlc fix-pr` chains the two. However, the retry caps are sourced from the *main* Pipeline's `stages[code].onFailure.maxRetries` and `stages[review].onFailure.maxRetries` (`fix-ci.ts:191`, `fix-review.ts:219`) — so this RFC's failure-policy schema *is* the source of truth for the bound. Fix-CI is neither a "separate Pipeline" nor an "embedded retry strategy" but a third option: a sibling executor that consumes the RFC-0002 retry policy. The spec was not extended with a `ci.failed` trigger enum or a `kind: FixCiPipeline`.
+
 5. **Credential scope standardization** — Should the spec define a standard set of scope strings (e.g., `repo:read`, `repo:write`, `ci:trigger`), or leave them adapter-specific? Standardizing enables portable policies but may not cover all adapter capabilities.
+
+   **Resolution (2026-05-13):** Left adapter-specific; no canonical vocabulary defined. `CredentialPolicy.scope` is `array[string]` with no enum (`spec/schemas/pipeline.schema.json:381-403`); `DEFAULT_JIT_SCOPE = ['repo:read', 'repo:write']` (`orchestrator/src/defaults.ts:154`) is a sensible default, not a normative vocabulary. In production, the framework distinguishes credentials by *identity*, not by scope-string semantics: `AI_SDLC_PAT` (recursive-workflow-trigger-capable PAT, AISDLC-189), `GITHUB_TOKEN` (default per-job), and the ed25519 attestation signing key (per-contributor, via `/ai-sdlc init-signing-key`). `CredentialPolicy.scope` is honored end-to-end (`orchestrator/src/execute.ts:773-874`); the strings remain adapter-defined.
 
 ## References
 

--- a/spec/rfcs/RFC-0003-infrastructure-adapters.md
+++ b/spec/rfcs/RFC-0003-infrastructure-adapters.md
@@ -1,11 +1,11 @@
 ---
 id: RFC-0003
 title: Infrastructure Provider Adapters
-status: Draft
-lifecycle: Draft
+status: Implemented
+lifecycle: Implemented
 author: AI-SDLC Contributors
 created: 2026-02-10
-updated: 2026-02-10
+updated: 2026-05-13
 targetSpecVersion: v1alpha1
 requiresDocs:
   - tutorial
@@ -16,11 +16,11 @@ requiresDocs:
 
 # RFC-0003: Infrastructure Provider Adapters
 
-**Status:** Draft
-**Lifecycle:** Draft
+**Status:** Implemented
+**Lifecycle:** Implemented
 **Author:** AI-SDLC Contributors
 **Created:** 2026-02-10
-**Updated:** 2026-02-10
+**Updated:** 2026-05-13
 **Target Spec Version:** v1alpha1
 
 ---
@@ -240,11 +240,19 @@ Implement a separate plugin system with lifecycle hooks, distinct from the adapt
 
 ## Open Questions
 
+> **Retrofit (2026-05-13):** OQs resolved against the implementation that shipped. All three questions answered the same way: stay simple. RFC-0010 §13 (`HarnessAdapter`) is orthogonal to this RFC's infrastructure-adapter framework, not a supersession. Lifecycle promoted to `Implemented`.
+
 1. **Should `MemoryStore` support transactions?** The current key-value interface is intentionally simple. Backends like Redis and DynamoDB support atomic operations, but adding transactions increases interface complexity. The proposal starts simple; a future RFC could add optional transaction support.
+
+   **Resolution (2026-05-13):** **No.** `MemoryStore` shipped with the four-method key-value contract (`read`, `write`, `delete`, `list`) at `reference/src/agents/memory/types.ts` and published in `spec/adapters.md §3.4`. The only built-in implementation (`createInMemoryMemoryStore`) is a `Map` wrapper with no atomicity beyond per-call. No subsequent RFC has revisited transactions; the tier interfaces (`WorkingMemory`/`SharedMemory`/etc.) carry their own per-tier semantics on top of the store. Future adapters that wrap transactional backends MAY surface atomic helpers via their concrete factory's options, but the abstract `MemoryStore` interface stays at lowest-common-denominator KV.
 
 2. **Should `EventBus` support message acknowledgment?** Cloud pub/sub systems (SQS, Cloud Pub/Sub) support at-least-once delivery with ack/nack. The current fire-and-forget interface is simpler but may lose events. The proposal starts with at-most-once delivery; a future RFC could add delivery guarantees.
 
+   **Resolution (2026-05-13):** **No.** `EventBus` shipped with the two-method fire-and-forget contract (`publish`, `subscribe`) at `reference/src/adapters/interfaces.ts:379-384`. The reference `createInProcessEventBus` is an `EventEmitter` wrapper with at-most-once delivery; the published spec (`adapters.md §3.5`) constrains the contract to async delivery without ack semantics. The framework has not adopted a durable pub/sub backend in production usage to date — operators wanting at-least-once semantics would today encode ack handling inside their concrete adapter. If/when a durable backend lands, a future RFC should add an optional `subscribeAck(topic, handler)` variant rather than retrofitting the existing `subscribe`.
+
 3. **Should `SecretStore` support secret versioning?** Vault and AWS Secrets Manager support versioned secrets. The current interface returns the latest version. Adding version support would complicate the interface but enable secret rotation workflows.
+
+   **Resolution (2026-05-13):** **No.** `SecretStore` shipped with the read-biased contract (`get`, `getRequired`, optional `set(name, value, ttl?)`, optional `delete`) at `reference/src/security/interfaces.ts:32-41`. There is no `version` parameter on any method and no version-listing surface. The only built-in implementation (`createEnvSecretStore`) is environment-variable-backed and intrinsically un-versioned. Operator-side secret rotation is handled out-of-band today (Vault leases, AWS Secrets Manager rotation lambdas, GitHub Actions environment redeploys). If a future adapter needs to address a specific historical version, it MAY expose a versioned helper on its concrete type, but the abstract `SecretStore` interface stays unversioned.
 
 ## References
 

--- a/spec/rfcs/RFC-0004-cost-governance-and-attribution.md
+++ b/spec/rfcs/RFC-0004-cost-governance-and-attribution.md
@@ -1,11 +1,11 @@
 ---
 id: RFC-0004
 title: Cost Governance and Attribution
-status: Draft
-lifecycle: Draft
+status: Implemented
+lifecycle: Implemented
 author: AI-SDLC Contributors
 created: 2026-02-16
-updated: 2026-02-16
+updated: 2026-05-13
 targetSpecVersion: v1alpha1
 requiresDocs:
   - tutorial
@@ -15,11 +15,11 @@ requiresDocs:
 
 # RFC-0004: Cost Governance and Attribution
 
-**Status:** Draft
-**Lifecycle:** Draft
+**Status:** Implemented
+**Lifecycle:** Implemented
 **Author:** AI-SDLC Contributors
 **Created:** 2026-02-16
-**Updated:** 2026-02-16
+**Updated:** 2026-05-13
 **Target Spec Version:** v1alpha1
 
 ---
@@ -1030,15 +1030,27 @@ spec:
 
 ## Open Questions
 
+> **Retrofit (2026-05-13):** OQs resolved against the implementation that shipped. The CostPolicy / CostReconciler / CostTracker surface is shipped end-to-end (`orchestrator/src/cost-tracker.ts`, `orchestrator/src/cost-governance.ts`, `reference/src/reconciler/cost-reconciler.ts`); lifecycle promoted to `Implemented`. Three of the five OQs remain genuinely open as explicit deferrals — they wait for a concrete consumer demand. RFC-0032 (Cost-Governance Seam, Draft) extends this RFC's substrate but does NOT supersede it.
+
 1. **Human review cost estimation** — How should the orchestrator estimate the cost of human review time? Options: (a) configure an hourly rate per reviewer role, (b) measure actual review time via PR event timestamps (review_requested → review_submitted), (c) use industry averages. Option (b) is most accurate but requires tracking PR review lifecycle events.
+
+   **Resolution (2026-05-13):** **Open / deferred.** The `humanReviewCost` field is reserved on `CostBreakdown` (`reference/src/core/types.ts:269`) and documented as the dominant TCO term (`docs/api-reference/cost.md:208-210`), but no implementation populates it — `CostTracker.computeCost` (`orchestrator/src/cost-tracker.ts:47-74`) covers only token math. Question remains open and is appropriate to revisit when a concrete consumer (chargeback report, TCO dashboard) materializes. Recommended approach when re-opened: option (b) — measured `review_requested → review_submitted` latency × configurable role rate.
 
 2. **Cross-provider cost normalization** — When the fallback chain routes to a different provider (Anthropic → OpenAI), costs are not directly comparable (different pricing, different token counts for the same task). Should the spec define a normalized cost unit, or report raw provider-specific costs?
 
+   **Resolution (2026-05-13):** **Open / deferred — raw provider-specific costs reported.** The `DEFAULT_MODEL_COSTS` table (`orchestrator/src/defaults.ts:210-219`) covers only Anthropic Claude models; unknown-model fallback collapses to Sonnet pricing (`orchestrator/src/cost-tracker.ts:55-65`) — silently wrong for non-Anthropic providers. The implicit shipped answer is "raw provider-specific costs in USD," but cross-provider parity remains unsolved. Currently latent: the dogfood stack is Anthropic-only, making the normalization gap academic. Revisit when the framework genuinely operates a cross-provider fleet.
+
 3. **Cache savings attribution** — When a cached response avoids a $2 API call, who gets credit for the $2 savings? The agent that populated the cache, or the agent that benefited from the cache hit? This affects cost-per-agent metrics.
+
+   **Resolution (2026-05-13):** **Resolved — consumer attribution.** The shipped implementation attributes cache-read tokens (and the reduced cost) to the **consuming agent** — the one whose API call returned `cache_read_input_tokens`. `CostTracker.computeCost` (`orchestrator/src/cost-tracker.ts:47-74`) accepts `cacheReadTokens` and applies the model's `cacheReadPer1M` rate; the `cost_ledger` table (`orchestrator/src/state/store.ts:507,525`) stores `cache_read_tokens` per entry keyed by `agent_name` + `stage_name`. No bookkeeping exists for "who populated the cache," so the populating agent receives no credit. Defensible default: provider-side prompt caching is an Anthropic-managed implementation detail and there's no reliable way for the orchestrator to know which prior call seeded a given hit.
 
 4. **Cost forecasting model** — The CostReconciler uses linear extrapolation for `projectedMonthEnd`. Real usage patterns are often non-linear (higher at sprint start, lower at sprint end). Should the spec define a specific forecasting method, or leave it to implementations?
 
+   **Resolution (2026-05-13):** **Resolved — linear extrapolation with injectable override.** `CostTracker.getBudgetStatus` (`orchestrator/src/cost-tracker.ts:144-157`) computes `projectedMonthlyUsd` as `dailyRate × 30` (straight linear); the `CostReconciler` deps interface (`reference/src/reconciler/cost-reconciler.ts:58,87`) leaves the door open via `getProjectedSpend` for adopters who need seasonality. Same approach in `orchestrator/src/scheduling/burn-down.ts:25` for subscription-quota burn-down. The schema description (`reference/src/core/generated-schemas.ts:3640`) explicitly acknowledges linear extrapolation. Adopters needing sprint-start spikes or deadline crunches supply their own `getProjectedSpend`.
+
 5. **Infrastructure cost allocation** — The orchestrator itself consumes compute (CI/CD runners, server hosting). How should this baseline cost be allocated? Options: (a) exclude from pipeline costs (treat as overhead), (b) distribute evenly across all pipeline executions, (c) allocate proportionally to execution duration.
+
+   **Resolution (2026-05-13):** **Open / deferred — option (a) by omission.** The `computeCost` field is reserved on `CostBreakdown` (`reference/src/core/types.ts:268`) for self-hosted GPU scenarios but is never populated by the reference. No CI-runner-minute accounting, proportional allocation logic, or overhead bucket ships. The shipped framework treats orchestrator infrastructure as out-of-band overhead not attributed to individual pipeline executions. Revisit when a self-hosted-model deployment or a chargeback consumer with sufficient fidelity need materializes.
 
 ## References
 

--- a/spec/rfcs/RFC-0005-product-priority-algorithm.md
+++ b/spec/rfcs/RFC-0005-product-priority-algorithm.md
@@ -1,11 +1,11 @@
 ---
 id: RFC-0005
 title: Product Priority Algorithm (PPA)
-status: Draft
-lifecycle: Draft
+status: Approved
+lifecycle: Signed Off
 author: Alexander Kline (Arcana Concept Studio), AI-SDLC Contributors
 created: 2026-03-24
-updated: 2026-03-24
+updated: 2026-05-13
 targetSpecVersion: v1alpha1
 requiresDocs:
   - api-reference
@@ -14,11 +14,11 @@ requiresDocs:
 
 # RFC-0005: Product Priority Algorithm (PPA)
 
-**Status:** Draft
-**Lifecycle:** Draft
+**Status:** Approved
+**Lifecycle:** Signed Off
 **Author:** Alexander Kline (Arcana Concept Studio), AI-SDLC Contributors
 **Created:** 2026-03-24
-**Updated:** 2026-03-24
+**Updated:** 2026-05-13
 **Target Spec Version:** v1alpha1
 
 ---
@@ -342,15 +342,27 @@ Adopt an existing prioritization framework rather than creating a new composite 
 
 ## Open Questions
 
+> **Retrofit (2026-05-13):** OQs resolved against the implementation that shipped. Most of the runtime resolution lives under RFC-0008 (PPA Triad Integration, Implemented), which extends rather than supersedes this RFC. The admission subset is wired; the full runtime composite (Mφ, Eτ, Cκ as products of feedback flywheel) is currently deferred to PPA v1.1 per RFC-0008 §17. Lifecycle promoted to `Signed Off` (design locked; implementation partial).
+
 1. **Soul Alignment via LLM**: Computing Sα₂ (Vibe Coherence) requires an LLM call. Should this be computed asynchronously on a schedule (e.g., when issues are created) or synchronously in the scoring path? The current implementation accepts pre-computed `soulAlignment` as input, deferring this decision to the caller.
+
+   **Resolution (2026-05-13):** **Resolved by RFC-0008 Addendum B.** SA scoring uses a three-layer architecture: Layer 1 (deterministic scope/constraint gating), Layer 2 (BM25 structural relevance, deterministic), Layer 3 (LLM-structured assessment with confidence filter ≥ 0.5 and a CI-Boundary preamble that forbids re-assessing Layer 1's verified findings). The decision is *neither* purely sync nor purely async — it is **phase-staged**: Phase 2a runs all three layers but uses label-based `soulAlignment` for ranking (shadow); Phase 2b/2c blend the structural+LLM result with calibrating weights; Phase 3 is flywheel-calibrated. The admission composite (`AdmissionCompositeOptions.soulAlignmentOverride` at `orchestrator/src/admission-composite.ts:62-67`) accepts the resolved SA-1 from the upstream scorer, leaving the caller control over sync invocation vs. async pre-computation. Implementation: `orchestrator/src/sa-scoring/{layer1-deterministic,layer2-structural,layer3-llm,composite,index}.ts`.
 
 2. **Product lifecycle sensitivity**: Should dimension weights shift based on product phase? Pre-launch products may need Soul Alignment to dominate; post-launch may need Demand Pressure. If so, the model needs a lifecycle-phase parameter.
 
+   **Resolution (2026-05-13):** **Partially resolved — Eρ₄ only; deferred for other dimensions to PPA v1.1.** RFC-0008 Amendment 3 adds a `lifecyclePhase: preDesignSystem | catalogBootstrap | postDesignSystem` qualifier scoped to **Eρ₄ Design System Readiness only** (an escape valve, not a general weight schedule). RFC-0008 §17 (v1.1-3) explicitly acknowledges this is "an ad-hoc escape valve, not a general solution" and queues "a `ProductLifecyclePhase` classifier (bootstrap, growth, maturity, plateau) and a dimension weight schedule keyed to lifecycle phase" as PPA v1.1 work. The shipped code (`orchestrator/src/admission-composite.ts`, `orchestrator/src/admission-enrichment.ts`) consumes only the design-system-scoped flag (`DesignSystemContext.inBootstrapPhase`). Broader lifecycle-aware Soul/Demand/Market weights remain the canonical PPA v1.1 input.
+
 3. **Multi-product portfolio**: Does each product get its own PPA instance or is there a portfolio-level meta-algorithm? This is explicitly a non-goal for v1 but should be considered for the schema's extensibility.
+
+   **Resolution (2026-05-13):** **Open / explicit non-goal preserved.** Single-product remains the v1 contract. The implementation operates on a single DID per scoring call; no `productId` / `portfolioId` discriminator exists on `AdmissionInput`, `PriorityConfig`, or the calibration feedback store. RFC-0008's "portfolio-level" framing of the `SoulDriftDetected` event (`orchestrator/src/sa-scoring/drift-monitor.ts`) refers to the population of scored items inside a single product, not multiple products in an org. Multi-product portfolio resource allocation remains future work; the schema extension hooks identified in §Alternatives (a standalone `PriorityPolicy` resource type) are the right escape hatch when this becomes a real requirement.
 
 4. **Soul health diagnostic**: When PPA scores cluster in the 0.3-0.5 range (nothing high, nothing low), it may signal the product's soul purpose needs revisiting. Should this trigger an automatic alert?
 
+   **Resolution (2026-05-13):** **Resolved by RFC-0008 Addendum B §B.9.2.** The `SoulDriftDetected` event is the soul-health diagnostic — but the trigger is sharper than this RFC's sketch: instead of detecting a mid-range cluster (0.3-0.5), it fires when the 30-day rolling mean of SA-1 drops below 0.4 OR stddev exceeds 0.15 for 3 consecutive windows. The event payload separates `structuralScoreMean` from `llmScoreMean` so operators distinguish product-identity drift (DID review needed) from LLM-layer drift (exemplar-bank recalibration needed). Notification routes to product-lead, design-lead, and engineering-lead. Hysteresis (`recoveryMs`, default 7d) prevents alert thrash. Implementation: `orchestrator/src/sa-scoring/drift-monitor.ts`.
+
 5. **Calibration data retention**: How long should priority-vs-outcome calibration data be retained? The default `lookbackPeriod: 90d` is a starting point but may need tuning per product velocity.
+
+   **Resolution (2026-05-13):** **Open / genuinely deferred.** The implementation chose "keep everything, filter by query-time window" rather than enforcing retention. The DoR calibration log (`pipeline-cli/src/dor/calibration-log.ts`) is documented as intentionally append-only with no GC. The SA feedback store (`orchestrator/src/sa-scoring/feedback-store.ts`) supports a `PrecisionWindow.since` query filter, and the drift monitor uses a 30-day rolling window, but neither prunes underlying storage. The `priorityPolicy.calibration.lookbackPeriod: 90d` schema field declared in this RFC §1 is **not consumed by any production code path**. Retention policy becomes necessary once the JSONL log size becomes operationally relevant; at current scale, deferral is rational. Likely resolution when re-opened: per-product configurable retention window with an Operator TUI surface, not a hard-coded global default.
 
 ## References
 


### PR DESCRIPTION
## Summary

Two related changes to combat RFC lifecycle drift.

### 1. Registry + inventory + critical-path scaffolding (`spec/rfcs/README.md`)

- Add **`OQs` column** to the registry table (count of unresolved Open Questions per RFC)
- Add **§Open Questions Inventory** grouping every active RFC by status (Active design walkthroughs / Awaiting lifecycle promotion / Design locked)
- Add **§Critical Path to RFC-0035** with Mermaid dep graph + status table + action sequence. Headline: **~26 OQs to burn** (12 in RFC-0024 + 14 in RFC-0035) for near-term Decision Catalog sign-off
- Self-deprecating footer — this section is hand-curated until RFC-0035 ships `cli-decisions critical-path --target` automation

### 2. Retrofit RFC-0002 through RFC-0005 against shipped implementation

These four RFCs (created Feb–Mar 2026) were substantively implemented in `pipeline-cli/` and `orchestrator/` but stuck at `lifecycle: Draft` for ~3 months because no implementation task closed the loop. Per-OQ resolution markers added inline, citing actual code paths.

| RFC | New Lifecycle | OQ disposition |
|---|---|---|
| RFC-0002 Pipeline Orchestration | **Implemented** | 4 Resolved, 1 Partial (`onTimeout: escalate` schema enum lands; runtime not wired — RFC-0015's PR-labeling is de-facto path) |
| RFC-0003 Infrastructure Provider Adapters | **Implemented** | All 3 Resolved as "stay simple" (no transactions, no ack, no versioning). RFC-0010 §13 `HarnessAdapter` is orthogonal, not superseding. |
| RFC-0004 Cost Governance | **Implemented** | 2 Resolved (cache attribution → consuming agent; forecasting → linear with injectable override). 3 explicit deferrals. RFC-0032 extends, does NOT supersede. |
| RFC-0005 PPA | **Signed Off** | 2 Resolved by RFC-0008 Addendum B (three-layer SA scorer, `SoulDriftDetected`). Admission subset wired; full runtime composite deferred to PPA v1.1 per RFC-0008 §17. |

**Net:** 12 OQs closed (~158 unresolved → ~146); 4 RFCs moved from *Active design walkthroughs* to *Design locked* in the inventory.

## Process note

A separate memory note now flags the underlying drift pattern: when an RFC's contract ships in code, a follow-up retrofit task should be filed at task-close. RFC-0035 (Decision Catalog) will eventually automate this audit via `cli-decisions critical-path --target`.

## Test plan

- [ ] Registry table renders with the new `OQs` column (9 columns total)
- [ ] Mermaid critical-path graph renders; RFC-0002 / RFC-0004 in green (Implemented), RFC-0005 in blue (Signed Off)
- [ ] All `RFC-NNNN` cross-references resolve (`scripts/check-rfc-docs.mjs` clean)
- [ ] Frontmatter validates against `spec/schemas/rfc.schema.json` for RFC-0002 through RFC-0005
- [ ] Docs-only `paths-ignore` carves out review/attestation gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)