### PR TITLE
chore(backlog): file RFC-0024 / 0025 / 0031 retrofit-followup tasks

### DIFF
--- a/backlog/tasks/aisdlc-269 - chore-complete-RFC-0024-capture-authoring-triage-flow.md
+++ b/backlog/tasks/aisdlc-269 - chore-complete-RFC-0024-capture-authoring-triage-flow.md
@@ -1,0 +1,63 @@
+---
+id: AISDLC-269
+title: 'chore: complete RFC-0024 capture authoring + triage flow'
+status: To Do
+assignee: []
+created_date: '2026-05-13 18:48'
+labels:
+  - rfc-0024
+  - retrofit-followup
+  - emergent-capture
+  - critical-path-rfc-0035
+dependencies: []
+references:
+  - spec/rfcs/RFC-0024-emergent-issue-capture-and-triage.md
+  - spec/rfcs/RFC-0035-decision-catalog-operator-routing.md
+  - pipeline-cli/src/tui/blockers/detector.ts
+  - pipeline-cli/src/tui/corpus/aggregate.ts
+  - 'https://github.com/ai-sdlc-framework/ai-sdlc/pull/467'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Complete the unbuilt portion of [RFC-0024 (Emergent Issue Capture + Triage Pattern)](../../spec/rfcs/RFC-0024-emergent-issue-capture-and-triage.md). The detection substrate ships today; the capture authoring and triage decision flow do not.
+
+## What ships today (per 2026-05-13 audit)
+
+- `pipeline-cli/src/tui/blockers/detector.ts` Rule 3 — detects `triage: tbd` capture records and surfaces them as TUI blockers (cites RFC-0024 directly)
+- `pipeline-cli/src/tui/corpus/aggregate.ts` — `TuiCaptureFiled` event aggregation tied to RFC-0024 capture IDs
+
+## What's missing
+
+The authoring half of the loop — operators and AI agents currently have nowhere to record a capture, so the detector has no input. The triage decision flow that consumes capture records and produces backlog Issues or scope decisions also does not exist.
+
+## Why this matters
+
+RFC-0024 sits on the critical path for [RFC-0035 (Decision Catalog)](../../spec/rfcs/RFC-0035-decision-catalog-operator-routing.md): RFC-0035's `source: emergent-finding` decision feeder reads capture records as input. RFC-0035's design contract cannot stabilize until RFC-0024's capture + triage flow is shipped.
+
+## Pre-work required
+
+The 12 Open Questions in RFC-0024 §15 still need an operator walkthrough before this implementation can land. Each OQ has an author "Recommendation" in the RFC body; the walkthrough resolves recommendations into normative answers and unblocks Phase 1 of this task.
+
+## References
+
+- RFC-0024 body §5 (Capture sources), §6 (Capture record schema), §7 (Triage rubric), §9.2 (Decision-pending → decision-deferred handoff)
+- `pipeline-cli/src/tui/blockers/detector.ts` (existing detector Rule 3)
+- `pipeline-cli/src/tui/corpus/aggregate.ts` (existing event aggregator)
+- PR #467 — Partial implementation status annotation that surfaced this gap
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `cli-capture` CLI ships per RFC-0024 §5.1 (subcommands: file, list, redact, against-current-pr) with the capture record schema from §6
+- [ ] #2 PR-comment marker parser ships per §5.2 (parses `ai-sdlc:capture` markers in PR review comments and creates capture records)
+- [ ] #3 In-code marker linter ships per §5.3 (`// ai-sdlc:capture` prefix detection; non-blocking warning)
+- [ ] #4 AI-agent direct-capture path ships per §5.4 (subagents can emit captures via prompted output protocol)
+- [ ] #5 Triage rubric implementation per §7 — operator promotes a capture to backlog Issue, scope-creep merge, or new RFC; default `tbd` until decision
+- [ ] #6 DoR integration per §8 — DoR clarification rounds can spawn captures; capture corpus is one input to PPA scoring
+- [ ] #7 RFC-0011 + RFC-0015 integration tests confirm capture flow does not block dispatch (decision-deferred handoff per §9.2)
+- [ ] #8 RFC-0024 §15 OQs resolved with normative answers (operator walkthrough required first); §15 retrofit follows the 2026-05-13 partial-impl pattern
+- [ ] #9 RFC-0024 lifecycle flipped to Implemented; registry row + inventory entry updated
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-269 - chore-complete-RFC-0024-capture-authoring-triage-flow.md
+++ b/backlog/tasks/aisdlc-269 - chore-complete-RFC-0024-capture-authoring-triage-flow.md
@@ -15,19 +15,18 @@ references:
   - spec/rfcs/RFC-0035-decision-catalog-operator-routing.md
   - pipeline-cli/src/tui/blockers/detector.ts
   - pipeline-cli/src/tui/corpus/aggregate.ts
-  - 'https://github.com/ai-sdlc-framework/ai-sdlc/pull/467'
 priority: medium
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Complete the unbuilt portion of [RFC-0024 (Emergent Issue Capture + Triage Pattern)](../../spec/rfcs/RFC-0024-emergent-issue-capture-and-triage.md). The detection substrate ships today; the capture authoring and triage decision flow do not.
+Complete the unbuilt portion of RFC-0024 (Emergent Issue Capture + Triage Pattern). The detection substrate ships today; the capture authoring and triage decision flow do not.
 
 ## What ships today (per 2026-05-13 audit)
 
-- `pipeline-cli/src/tui/blockers/detector.ts` Rule 3 — detects `triage: tbd` capture records and surfaces them as TUI blockers (cites RFC-0024 directly)
-- `pipeline-cli/src/tui/corpus/aggregate.ts` — `TuiCaptureFiled` event aggregation tied to RFC-0024 capture IDs
+- pipeline-cli/src/tui/blockers/detector.ts — Rule 3 detects pending-triage capture records and surfaces them as TUI blockers (cites RFC-0024 directly)
+- pipeline-cli/src/tui/corpus/aggregate.ts — TuiCaptureFiled event aggregation tied to RFC-0024 capture IDs
 
 ## What's missing
 
@@ -35,18 +34,18 @@ The authoring half of the loop — operators and AI agents currently have nowher
 
 ## Why this matters
 
-RFC-0024 sits on the critical path for [RFC-0035 (Decision Catalog)](../../spec/rfcs/RFC-0035-decision-catalog-operator-routing.md): RFC-0035's `source: emergent-finding` decision feeder reads capture records as input. RFC-0035's design contract cannot stabilize until RFC-0024's capture + triage flow is shipped.
+RFC-0024 sits on the critical path for RFC-0035 (Decision Catalog): RFC-0035 source emergent-finding decision feeder reads capture records as input. RFC-0035 design contract cannot stabilize until RFC-0024 capture and triage flow is shipped.
 
 ## Pre-work required
 
-The 12 Open Questions in RFC-0024 §15 still need an operator walkthrough before this implementation can land. Each OQ has an author "Recommendation" in the RFC body; the walkthrough resolves recommendations into normative answers and unblocks Phase 1 of this task.
+The 12 Open Questions in RFC-0024 §15 still need an operator walkthrough before this implementation can land. Each OQ has an author Recommendation in the RFC body; the walkthrough resolves recommendations into normative answers and unblocks Phase 1 of this task.
 
 ## References
 
-- RFC-0024 body §5 (Capture sources), §6 (Capture record schema), §7 (Triage rubric), §9.2 (Decision-pending → decision-deferred handoff)
-- `pipeline-cli/src/tui/blockers/detector.ts` (existing detector Rule 3)
-- `pipeline-cli/src/tui/corpus/aggregate.ts` (existing event aggregator)
-- PR #467 — Partial implementation status annotation that surfaced this gap
+- RFC-0024 §5 (Capture sources), §6 (Capture record schema), §7 (Triage rubric), §9.2 (Decision-pending → decision-deferred handoff)
+- pipeline-cli/src/tui/blockers/detector.ts (existing detector Rule 3)
+- pipeline-cli/src/tui/corpus/aggregate.ts (existing event aggregator)
+- Surfaced by the 2026-05-13 partial-implementation status retrofit pass
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -55,7 +54,7 @@ The 12 Open Questions in RFC-0024 §15 still need an operator walkthrough before
 - [ ] #2 PR-comment marker parser ships per §5.2 (parses `ai-sdlc:capture` markers in PR review comments and creates capture records)
 - [ ] #3 In-code marker linter ships per §5.3 (`// ai-sdlc:capture` prefix detection; non-blocking warning)
 - [ ] #4 AI-agent direct-capture path ships per §5.4 (subagents can emit captures via prompted output protocol)
-- [ ] #5 Triage rubric implementation per §7 — operator promotes a capture to backlog Issue, scope-creep merge, or new RFC; default `tbd` until decision
+- [ ] #5 Triage rubric implementation per §7 — operator promotes a capture to backlog Issue, scope-creep merge, or new RFC; default pending until decision
 - [ ] #6 DoR integration per §8 — DoR clarification rounds can spawn captures; capture corpus is one input to PPA scoring
 - [ ] #7 RFC-0011 + RFC-0015 integration tests confirm capture flow does not block dispatch (decision-deferred handoff per §9.2)
 - [ ] #8 RFC-0024 §15 OQs resolved with normative answers (operator walkthrough required first); §15 retrofit follows the 2026-05-13 partial-impl pattern

--- a/backlog/tasks/aisdlc-270 - chore-complete-RFC-0025-quality-monitoring-auto-classification.md
+++ b/backlog/tasks/aisdlc-270 - chore-complete-RFC-0025-quality-monitoring-auto-classification.md
@@ -1,0 +1,66 @@
+---
+id: AISDLC-270
+title: 'chore: complete RFC-0025 quality monitoring auto-classification'
+status: To Do
+assignee: []
+created_date: '2026-05-13 18:48'
+labels:
+  - rfc-0025
+  - retrofit-followup
+  - framework-quality
+dependencies: []
+references:
+  - spec/rfcs/RFC-0025-framework-quality-monitoring.md
+  - pipeline-cli/src/tui/analytics/quality-reader.ts
+  - pipeline-cli/src/orchestrator/playbook/handlers/
+  - 'https://github.com/ai-sdlc-framework/ai-sdlc/pull/467'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Complete the unbuilt portion of [RFC-0025 (Framework Quality Monitoring — Non-Decision Failure Modes)](../../spec/rfcs/RFC-0025-framework-quality-monitoring.md). The reliability-trend reader and failure-mode handlers ship today; the auto-classification, framework-bug routing, and severity rubric do not.
+
+## What ships today (per 2026-05-13 audit)
+
+- `pipeline-cli/src/tui/analytics/quality-reader.ts` — reads `_quality/captures.jsonl` and computes the §8 reliability trend. The file itself notes "RFC-0025 has not yet shipped Phase 5" and treats missing input as `available: false`
+- `pipeline-cli/src/orchestrator/playbook/handlers/` — 9 catalogued failure-mode handlers (verification-failure, push-race, rebase-conflict, attestation-verify-mismatch, etc.) — implements the spirit of the §3 failure-mode taxonomy
+
+## What's missing
+
+- `cli-quality-corpus aggregate` CLI (referenced as "eventual" in the reader)
+- Automatic classification of failures into `operator-under-decided` / `framework-misbehaved` / `ambiguous` / `external-dependency-failed` per §5
+- Automatic routing of `framework-misbehaved` cases into the backlog with `triage: framework-bug` (§6)
+- Severity-scoring rubric in code per §7 (operator-time-cost × blast-radius × frequency)
+- MTTR / recurrence metric computation per §8
+- `framework-determinism-violated` detection mechanism (RFC-0025 OQ-7)
+
+## Why this matters
+
+RFC-0025 operationalizes `VISION.md` §4 "honest failure modes" — when the framework misbehaves (vs. when the operator under-decided), the framework should route a bugfix into its own backlog rather than blaming the operator. Without auto-classification, the framework's failure modes get silently absorbed as operator-time-cost.
+
+## Pre-work required
+
+The 10 Open Questions in RFC-0025 §13 still need an operator walkthrough before this implementation can land. Each OQ has an author "Recommendation"; the walkthrough resolves them.
+
+## References
+
+- RFC-0025 body §3 (failure-mode taxonomy), §5 (classification), §6 (detection), §7 (severity rubric), §8 (self-improvement metrics)
+- `pipeline-cli/src/tui/analytics/quality-reader.ts` (existing trend reader)
+- `pipeline-cli/src/orchestrator/playbook/handlers/` (existing failure-mode handlers)
+- PR #467 — Partial implementation status annotation that surfaced this gap
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `cli-quality-corpus aggregate` CLI ships and produces `_quality/captures.jsonl` from per-run logs
+- [ ] #2 Classifier ships per §5 (operator-under-decided / framework-misbehaved / ambiguous / external-dependency-failed); default to `ambiguous` per OQ-1 recommendation
+- [ ] #3 Auto-routing of `framework-misbehaved` cases into backlog with `triage: framework-bug` per §6 (composes with RFC-0024's capture flow)
+- [ ] #4 Severity scoring rubric in code per §7 (operator-time-cost × blast-radius × frequency)
+- [ ] #5 MTTR + recurrence-rate metrics computed per §8 and surfaced in TUI analytics
+- [ ] #6 `framework-determinism-violated` detection per OQ-7 (sampled 1-in-50 baseline, always for `requires-determinism: true` tasks)
+- [ ] #7 Vendor-namespace enforcement for adopter custom subclasses per §10 + OQ-10 (schema rejects un-namespaced)
+- [ ] #8 RFC-0025 §13 OQs resolved with normative answers (operator walkthrough required first)
+- [ ] #9 RFC-0025 lifecycle flipped to Implemented; registry row + inventory entry updated
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-270 - chore-complete-RFC-0025-quality-monitoring-auto-classification.md
+++ b/backlog/tasks/aisdlc-270 - chore-complete-RFC-0025-quality-monitoring-auto-classification.md
@@ -12,49 +12,47 @@ dependencies: []
 references:
   - spec/rfcs/RFC-0025-framework-quality-monitoring.md
   - pipeline-cli/src/tui/analytics/quality-reader.ts
-  - pipeline-cli/src/orchestrator/playbook/handlers/
-  - 'https://github.com/ai-sdlc-framework/ai-sdlc/pull/467'
 priority: medium
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Complete the unbuilt portion of [RFC-0025 (Framework Quality Monitoring — Non-Decision Failure Modes)](../../spec/rfcs/RFC-0025-framework-quality-monitoring.md). The reliability-trend reader and failure-mode handlers ship today; the auto-classification, framework-bug routing, and severity rubric do not.
+Complete the unbuilt portion of RFC-0025 (Framework Quality Monitoring — Non-Decision Failure Modes). The reliability-trend reader and failure-mode handlers ship today; the auto-classification, framework-bug routing, and severity rubric do not.
 
 ## What ships today (per 2026-05-13 audit)
 
-- `pipeline-cli/src/tui/analytics/quality-reader.ts` — reads `_quality/captures.jsonl` and computes the §8 reliability trend. The file itself notes "RFC-0025 has not yet shipped Phase 5" and treats missing input as `available: false`
-- `pipeline-cli/src/orchestrator/playbook/handlers/` — 9 catalogued failure-mode handlers (verification-failure, push-race, rebase-conflict, attestation-verify-mismatch, etc.) — implements the spirit of the §3 failure-mode taxonomy
+- pipeline-cli/src/tui/analytics/quality-reader.ts — reads the framework-quality capture corpus and computes the §8 reliability trend. The file notes that RFC-0025 has not yet shipped Phase 5 and treats missing input as available false
+- pipeline-cli/src/orchestrator/playbook/handlers — 9 catalogued failure-mode handlers (verification-failure, push-race, rebase-conflict, attestation-verify-mismatch, etc.) implementing the spirit of the §3 failure-mode taxonomy
 
 ## What's missing
 
-- `cli-quality-corpus aggregate` CLI (referenced as "eventual" in the reader)
-- Automatic classification of failures into `operator-under-decided` / `framework-misbehaved` / `ambiguous` / `external-dependency-failed` per §5
-- Automatic routing of `framework-misbehaved` cases into the backlog with `triage: framework-bug` (§6)
+- cli-quality-corpus aggregate CLI (referenced as eventual in the reader)
+- Automatic classification of failures into operator-under-decided / framework-misbehaved / ambiguous / external-dependency-failed per §5
+- Automatic routing of framework-misbehaved cases into the backlog with framework-bug triage labels per §6
 - Severity-scoring rubric in code per §7 (operator-time-cost × blast-radius × frequency)
-- MTTR / recurrence metric computation per §8
-- `framework-determinism-violated` detection mechanism (RFC-0025 OQ-7)
+- MTTR and recurrence metric computation per §8
+- framework-determinism-violated detection mechanism (RFC-0025 OQ-7)
 
 ## Why this matters
 
-RFC-0025 operationalizes `VISION.md` §4 "honest failure modes" — when the framework misbehaves (vs. when the operator under-decided), the framework should route a bugfix into its own backlog rather than blaming the operator. Without auto-classification, the framework's failure modes get silently absorbed as operator-time-cost.
+RFC-0025 operationalizes VISION.md §4 honest failure modes — when the framework misbehaves (vs. when the operator under-decided), the framework should route a bugfix into its own backlog rather than blaming the operator. Without auto-classification, the framework's failure modes get silently absorbed as operator-time-cost.
 
 ## Pre-work required
 
-The 10 Open Questions in RFC-0025 §13 still need an operator walkthrough before this implementation can land. Each OQ has an author "Recommendation"; the walkthrough resolves them.
+The 10 Open Questions in RFC-0025 §13 still need an operator walkthrough before this implementation can land. Each OQ has an author Recommendation; the walkthrough resolves them.
 
 ## References
 
-- RFC-0025 body §3 (failure-mode taxonomy), §5 (classification), §6 (detection), §7 (severity rubric), §8 (self-improvement metrics)
-- `pipeline-cli/src/tui/analytics/quality-reader.ts` (existing trend reader)
-- `pipeline-cli/src/orchestrator/playbook/handlers/` (existing failure-mode handlers)
-- PR #467 — Partial implementation status annotation that surfaced this gap
+- RFC-0025 §3 (failure-mode taxonomy), §5 (classification), §6 (detection), §7 (severity rubric), §8 (self-improvement metrics)
+- pipeline-cli/src/tui/analytics/quality-reader.ts (existing trend reader)
+- pipeline-cli/src/orchestrator/playbook/handlers (existing failure-mode handlers)
+- Surfaced by the 2026-05-13 partial-implementation status retrofit pass
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `cli-quality-corpus aggregate` CLI ships and produces `_quality/captures.jsonl` from per-run logs
+- [ ] #1 cli-quality-corpus aggregate CLI ships and produces the framework-quality capture corpus file from per-run logs
 - [ ] #2 Classifier ships per §5 (operator-under-decided / framework-misbehaved / ambiguous / external-dependency-failed); default to `ambiguous` per OQ-1 recommendation
 - [ ] #3 Auto-routing of `framework-misbehaved` cases into backlog with `triage: framework-bug` per §6 (composes with RFC-0024's capture flow)
 - [ ] #4 Severity scoring rubric in code per §7 (operator-time-cost × blast-radius × frequency)

--- a/backlog/tasks/aisdlc-271 - chore-complete-RFC-0031-DIDRevisionProposal-mechanism.md
+++ b/backlog/tasks/aisdlc-271 - chore-complete-RFC-0031-DIDRevisionProposal-mechanism.md
@@ -1,0 +1,69 @@
+---
+id: AISDLC-271
+title: 'chore: complete RFC-0031 DIDRevisionProposal mechanism'
+status: To Do
+assignee: []
+created_date: '2026-05-13 18:48'
+labels:
+  - rfc-0031
+  - retrofit-followup
+  - ppa-calibration
+dependencies: []
+references:
+  - spec/rfcs/RFC-0031-calibration-driven-did-revision-proposal.md
+  - spec/rfcs/RFC-0008-ppa-triad-integration-final-combined.md
+  - orchestrator/src/sa-scoring/drift-monitor.ts
+  - orchestrator/src/sa-scoring/feedback-store.ts
+  - orchestrator/src/sa-scoring/calibration.ts
+  - orchestrator/src/sa-scoring/auto-calibrate.ts
+  - 'https://github.com/ai-sdlc-framework/ai-sdlc/pull/467'
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Complete the unbuilt portion of [RFC-0031 (Calibration-Driven DID Revision Proposal Mechanism)](../../spec/rfcs/RFC-0031-calibration-driven-did-revision-proposal.md). The drift detection trigger and flywheel substrate ship today; the proposal mechanism itself does not.
+
+## What ships today (per 2026-05-13 audit)
+
+- `orchestrator/src/sa-scoring/drift-monitor.ts` — fully implements the `SoulDriftDetected` event (the RFC-0031 §2.1 trigger source) with rolling-window mean/stddev/consecutive-violation logic and structural-vs-LLM-mean disambiguation. Exported from `orchestrator/src/index.ts`
+- `orchestrator/src/sa-scoring/feedback-store.ts`, `calibration.ts`, `auto-calibrate.ts` — flywheel substrate the proposal mechanism would consume
+
+## What's missing
+
+- `DIDRevisionProposal` event itself — currently drift is detected, but nothing proposes a revision
+- Healthy / unhealthy / ambiguous drift classification per §3
+- Triad-vs-pillar-lead approval routing per §4 (Product Authority generates the proposal, Design Authority approves Design-pillar fields, etc.)
+- 14-day proposal expiry per §5
+- Operator opt-out per field via `.ai-sdlc/calibration.yaml` `field:lockNoProposal` list (OQ-12.3 — v1 must-have per author position)
+- Rejection learnings flowing back into the flywheel (OQ-12.5)
+
+## Why this matters
+
+RFC-0031 closes the calibration loop: when the framework's drift detection finds the product's Design Intent Document (DID) has drifted from operator behavior, the framework auto-proposes a revision for operator review. Without the proposal mechanism, drift is detected but never acted upon — the calibration data accumulates without producing actionable suggestions.
+
+## Pre-work required
+
+The 5 Open Questions in RFC-0031 §12.1–12.5 still need operator walkthrough before this implementation can land. Each OQ has an author "Position"; the walkthrough resolves positions into normative answers.
+
+## References
+
+- RFC-0031 body §3 (drift classification), §4 (approval routing), §5 (expiry semantics), §12 (open questions)
+- `orchestrator/src/sa-scoring/drift-monitor.ts` (existing trigger source)
+- `orchestrator/src/sa-scoring/feedback-store.ts` + `calibration.ts` + `auto-calibrate.ts` (existing flywheel substrate)
+- PR #467 — Partial implementation status annotation that surfaced this gap
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 `DIDRevisionProposal` event ships and fires from the existing `SoulDriftDetected` trigger when drift exceeds threshold per §2.1
+- [ ] #2 Drift classifier ships per §3 — healthy / unhealthy / ambiguous categories with structural-vs-LLM disambiguation already exposed in `drift-monitor.ts`
+- [ ] #3 Approval routing ships per §4 — PPA generates the proposal regardless of pillar; pillar-lead authority approves based on the drifted field's identityClass (Design lead for voiceRegister, Engineering lead for substrate fields, etc.)
+- [ ] #4 14-day proposal expiry ships per §5; expired proposals auto-archive without operator action
+- [ ] #5 `.ai-sdlc/calibration.yaml` `field:lockNoProposal` list honored per OQ-12.3 (skip proposal generation for locked fields)
+- [ ] #6 Rejection rationale captured in calibration log; future trigger evaluations weight rejection precedent into confidence per OQ-12.5
+- [ ] #7 Multi-field bundling explicitly deferred to v2 per OQ-12.2 (one-field-per-proposal in v1)
+- [ ] #8 RFC-0031 §12 OQs resolved with normative answers (operator walkthrough required first)
+- [ ] #9 RFC-0031 lifecycle flipped to Implemented; registry row + inventory entry updated
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-271 - chore-complete-RFC-0031-DIDRevisionProposal-mechanism.md
+++ b/backlog/tasks/aisdlc-271 - chore-complete-RFC-0031-DIDRevisionProposal-mechanism.md
@@ -14,29 +14,28 @@ references:
   - spec/rfcs/RFC-0008-ppa-triad-integration-final-combined.md
   - orchestrator/src/sa-scoring/drift-monitor.ts
   - orchestrator/src/sa-scoring/feedback-store.ts
-  - orchestrator/src/sa-scoring/calibration.ts
+  - orchestrator/src/calibration.ts
   - orchestrator/src/sa-scoring/auto-calibrate.ts
-  - 'https://github.com/ai-sdlc-framework/ai-sdlc/pull/467'
 priority: medium
 ---
 
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-Complete the unbuilt portion of [RFC-0031 (Calibration-Driven DID Revision Proposal Mechanism)](../../spec/rfcs/RFC-0031-calibration-driven-did-revision-proposal.md). The drift detection trigger and flywheel substrate ship today; the proposal mechanism itself does not.
+Complete the unbuilt portion of RFC-0031 (Calibration-Driven DID Revision Proposal Mechanism). The drift detection trigger and flywheel substrate ship today; the proposal mechanism itself does not.
 
 ## What ships today (per 2026-05-13 audit)
 
-- `orchestrator/src/sa-scoring/drift-monitor.ts` — fully implements the `SoulDriftDetected` event (the RFC-0031 §2.1 trigger source) with rolling-window mean/stddev/consecutive-violation logic and structural-vs-LLM-mean disambiguation. Exported from `orchestrator/src/index.ts`
-- `orchestrator/src/sa-scoring/feedback-store.ts`, `calibration.ts`, `auto-calibrate.ts` — flywheel substrate the proposal mechanism would consume
+- orchestrator/src/sa-scoring/drift-monitor.ts — fully implements the SoulDriftDetected event (the RFC-0031 §2.1 trigger source) with rolling-window mean/stddev/consecutive-violation logic and structural-vs-LLM-mean disambiguation. Exported from orchestrator/src/index.ts
+- orchestrator/src/sa-scoring/feedback-store.ts, calibration.ts, auto-calibrate.ts — flywheel substrate the proposal mechanism would consume
 
 ## What's missing
 
-- `DIDRevisionProposal` event itself — currently drift is detected, but nothing proposes a revision
+- DIDRevisionProposal event itself — currently drift is detected, but nothing proposes a revision
 - Healthy / unhealthy / ambiguous drift classification per §3
 - Triad-vs-pillar-lead approval routing per §4 (Product Authority generates the proposal, Design Authority approves Design-pillar fields, etc.)
 - 14-day proposal expiry per §5
-- Operator opt-out per field via `.ai-sdlc/calibration.yaml` `field:lockNoProposal` list (OQ-12.3 — v1 must-have per author position)
+- Operator opt-out per field via a calibration config lockNoProposal list (OQ-12.3 — v1 must-have per author position)
 - Rejection learnings flowing back into the flywheel (OQ-12.5)
 
 ## Why this matters
@@ -45,14 +44,14 @@ RFC-0031 closes the calibration loop: when the framework's drift detection finds
 
 ## Pre-work required
 
-The 5 Open Questions in RFC-0031 §12.1–12.5 still need operator walkthrough before this implementation can land. Each OQ has an author "Position"; the walkthrough resolves positions into normative answers.
+The 5 Open Questions in RFC-0031 §12.1–12.5 still need operator walkthrough before this implementation can land. Each OQ has an author Position; the walkthrough resolves positions into normative answers.
 
 ## References
 
-- RFC-0031 body §3 (drift classification), §4 (approval routing), §5 (expiry semantics), §12 (open questions)
-- `orchestrator/src/sa-scoring/drift-monitor.ts` (existing trigger source)
-- `orchestrator/src/sa-scoring/feedback-store.ts` + `calibration.ts` + `auto-calibrate.ts` (existing flywheel substrate)
-- PR #467 — Partial implementation status annotation that surfaced this gap
+- RFC-0031 §3 (drift classification), §4 (approval routing), §5 (expiry semantics), §12 (open questions)
+- orchestrator/src/sa-scoring/drift-monitor.ts (existing trigger source)
+- orchestrator/src/sa-scoring/feedback-store.ts, calibration.ts, auto-calibrate.ts (existing flywheel substrate)
+- Surfaced by the 2026-05-13 partial-implementation status retrofit pass
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -61,7 +60,7 @@ The 5 Open Questions in RFC-0031 §12.1–12.5 still need operator walkthrough b
 - [ ] #2 Drift classifier ships per §3 — healthy / unhealthy / ambiguous categories with structural-vs-LLM disambiguation already exposed in `drift-monitor.ts`
 - [ ] #3 Approval routing ships per §4 — PPA generates the proposal regardless of pillar; pillar-lead authority approves based on the drifted field's identityClass (Design lead for voiceRegister, Engineering lead for substrate fields, etc.)
 - [ ] #4 14-day proposal expiry ships per §5; expired proposals auto-archive without operator action
-- [ ] #5 `.ai-sdlc/calibration.yaml` `field:lockNoProposal` list honored per OQ-12.3 (skip proposal generation for locked fields)
+- [ ] #5 Calibration config lockNoProposal list honored per OQ-12.3 (skip proposal generation for locked fields)
 - [ ] #6 Rejection rationale captured in calibration log; future trigger evaluations weight rejection precedent into confidence per OQ-12.5
 - [ ] #7 Multi-field bundling explicitly deferred to v2 per OQ-12.2 (one-field-per-proposal in v1)
 - [ ] #8 RFC-0031 §12 OQs resolved with normative answers (operator walkthrough required first)


### PR DESCRIPTION
## Summary

Files three follow-up backlog tasks for the partial-implementation RFCs annotated in PR #467. Each tracks the unbuilt portion of an RFC whose substrate has shipped but whose main contribution has not.

| Task | RFC | What needs to ship | Critical path? |
|---|---|---|---|
| **AISDLC-269** | RFC-0024 Emergent Issue Capture + Triage | Capture authoring CLI, PR-comment marker, in-code marker, AI-agent direct-capture, triage rubric, DoR integration, lifecycle flip | **Yes** — RFC-0035 (Decision Catalog) sign-off depends on this |
| **AISDLC-270** | RFC-0025 Framework Quality Monitoring | `cli-quality-corpus aggregate`, classifier, `framework-bug` auto-routing, severity rubric, MTTR + recurrence metrics, determinism violation detection, lifecycle flip | No (depends on RFC-0024 capture flow) |
| **AISDLC-271** | RFC-0031 Calibration-Driven DID Revision | `DIDRevisionProposal` event, drift classification, triad approval routing, 14-day expiry, opt-out locks, rejection learnings, lifecycle flip | No |

## Pre-work shared by all three

Each RFC's Open Questions section already carries author "Recommendation" / "Position" text — they need an operator walkthrough to convert to normative answers before implementation can land. The walkthrough order should follow critical-path priority (RFC-0024 first, since it unblocks RFC-0035).

## Closure pattern

Each task's final AC is "RFC-XXXX lifecycle flipped to Implemented; registry row + inventory entry updated" — closing the loop that the 2026-05-13 retrofit memory (`feedback_retrofit_rfcs_after_impl.md`) describes: implementation tasks file a follow-up retrofit, then the retrofit closes the implementation.

## Test plan

- [ ] Three new task files exist under `backlog/tasks/`
- [ ] Backlog drift gate passes (no broken references)
- [ ] Filenames are ASCII (`scripts/check-backlog-ascii.sh`)
- [ ] Each task's references field resolves to a real file or PR URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)