### PR TITLE
docs(backlog): file pipeline-friction bug roundup AISDLC-354..357

### DIFF
--- a/backlog/tasks/aisdlc-354 - fix-pipeline-error-propagation-and-pr-auto-promote.md
+++ b/backlog/tasks/aisdlc-354 - fix-pipeline-error-propagation-and-pr-auto-promote.md
@@ -1,0 +1,56 @@
+---
+id: AISDLC-354
+title: 'fix(orchestrator): pipeline error propagation + PR auto-promote-to-ready + gh PATH detection'
+status: To Do
+assignee: []
+created_date: '2026-05-17'
+labels:
+  - orchestrator
+  - pipeline-friction
+  - operator-ergonomics
+  - critical
+dependencies: []
+priority: critical
+references:
+  - pipeline-cli/src/cli/resume-from-draft.ts
+  - pipeline-cli/src/steps/03-setup-worktree.ts
+  - pipeline-cli/src/orchestrator/loop.ts
+---
+
+## Three related pipeline UX bugs hit during 282/286/323 finalization (2026-05-17)
+
+All three blocked operator from understanding pipeline state. Grouping because the fixes touch the same error-propagation + state-detection paths.
+
+## Bug 1 — `re-push failed: unknown error` swallows real stderr
+
+**Symptom**: `runResumeFromDraft` returns `{ok: false, outcome: 'failed', reason: 're-push failed: unknown error'}` when the post-review push fails. Actual stderr from the failed git/hook command is lost.
+
+**Repro**: hit on all 3 of AISDLC-282/286/323 resume runs. Operator had to manually retry the push to see the real error (which turned out to be the verdict-shape mismatch — separate bug, AISDLC-355).
+
+**Fix**: in `runResumeFromDraft`'s push step, capture stderr + tail of stdout from the runner. Include in the `reason` field. Same pattern AISDLC-327 (#500) applied to the Codex bridge ("don't silently return empty output").
+
+## Bug 2 — PR auto-promote-to-ready never fires
+
+**Symptom**: even when all 3 reviewers return `approved: true` (real verdicts, no synthetic criticals), the orchestrator opens PRs as DRAFT. Operator must manually `gh pr ready <num>` + `gh pr merge <num> --auto`.
+
+**Repro**: PR #511 #512 #514 #516 all opened as DRAFT despite final-verdict APPROVED.
+
+**Fix**: in the orchestrator's Step 11/12 (open PR + arm auto-merge), after sign+push when `aggregatedVerdict.decision === 'APPROVED'`, auto-promote ready + arm auto-merge. Already exposed as `gh pr ready` + `gh pr merge --auto` — just need the orchestrator to invoke them.
+
+## Bug 3 — `gh` PATH not propagating to Node subprocess runner
+
+**Symptom**: `detectDraftPrForBranch` shells out to `gh pr list ...` via the Node runner. When the Node process's `PATH` env doesn't include `/opt/homebrew/bin` (e.g. when invoked from a Claude Code Bash tool subshell that inherited a minimal env), `gh` is not found → runner returns `code !== 0` → function returns `null` → resume-from-draft reports `hasDraftPr: false` even though the PR exists.
+
+**Repro**: ran `node pipeline-cli/bin/ai-sdlc-pipeline.mjs execute AISDLC-286 --resume-from-draft --spawner claude --run` from Claude Code Bash → `hasDraftPr=false` despite PR #512 being open. Workaround: `PATH="/opt/homebrew/bin:$PATH" node ...`.
+
+**Fix**: in `pipeline-cli/src/runtime/exec.ts` (or wherever the runner lives), augment the spawned PATH with common locations (`/opt/homebrew/bin`, `/usr/local/bin`, `~/.local/bin`) automatically. Or accept `GH_BIN` env override that the runner uses directly.
+
+## Acceptance criteria
+
+- [ ] **Bug 1**: `runResumeFromDraft` includes actual stderr from failed push in `reason`. Test: simulate a push that fails with a known error string; assert the error string appears in the returned envelope.
+- [ ] **Bug 2**: orchestrator auto-promotes PR to ready + arms auto-merge when `aggregatedVerdict.decision === 'APPROVED'`. Test: dispatch a task with mock approving reviewers; assert PR ends in `ready=true, autoMerge=enabled` state.
+- [ ] **Bug 3**: runner augments PATH with `/opt/homebrew/bin` + `/usr/local/bin` automatically. Test: spawn a child with a minimal env; confirm `gh` resolves via the augmented PATH. Alternative: add `GH_BIN` env override + use it in `detectDraftPrForBranch`.
+
+## Source
+
+Operator session 2026-05-17 finalizing AISDLC-282/286/323 via `--resume-from-draft --spawner claude` after the AISDLC-351 parser fix landed.

--- a/backlog/tasks/aisdlc-355 - fix-resume-from-draft-stale-verdicts-and-degenerate-reviewer.md
+++ b/backlog/tasks/aisdlc-355 - fix-resume-from-draft-stale-verdicts-and-degenerate-reviewer.md
@@ -1,0 +1,83 @@
+---
+id: AISDLC-355
+title: 'fix(orchestrator): resume-from-draft stale verdict reuse + verdict-shape mismatch + degenerate-reviewer retry'
+status: To Do
+assignee: []
+created_date: '2026-05-17'
+labels:
+  - orchestrator
+  - pipeline-friction
+  - resume-from-draft
+  - critical
+dependencies: []
+priority: critical
+references:
+  - pipeline-cli/src/cli/resume-from-draft.ts
+  - ai-sdlc-plugin/scripts/sign-attestation.mjs
+  - pipeline-cli/src/steps/09-iterate.ts
+---
+
+## Three related resume-from-draft bugs hit during 282/286/323 finalization
+
+All three centre on the verdict-file lifecycle. Grouping because the fixes touch the same file (`pipeline-cli/src/cli/resume-from-draft.ts`).
+
+## Bug 1 — Stale verdict file blocks reviewer re-run
+
+**Symptom**: `runResumeFromDraft` checks `hasVerdictFile`. When the verdict file exists (even if it's a broken synthetic-critical placeholder from a prior failed run), the resume skips the reviewer phase and tries to push the stale verdict. No `--force-reviewers` flag exists.
+
+**Repro**: hit on AISDLC-282 and AISDLC-286. Prior pipeline run (pre-AISDLC-351 parser fix) wrote `.ai-sdlc/verdicts/<task-id>.json` with `decision: CHANGES_REQUESTED, counts.critical: 3, verdicts: [{approved: false, findings: [{severity: critical, message: "<role> returned no parseable verdict (status=success)"}]}]`. Workaround: manually `rm .ai-sdlc/verdicts/<task-id>.json` before each retry.
+
+**Fix**: 
+- (a) Add `--force-reviewers` flag that deletes the existing verdict file before re-running, OR
+- (b) Auto-detect synthetic-critical placeholders (`message.includes("returned no parseable verdict")`) and treat them as "verdict file effectively absent — re-run reviewers."
+
+Option (b) is more operator-friendly (no manual cleanup needed).
+
+## Bug 2 — Verdict file shape mismatch (nested vs flat array)
+
+**Symptom**: `runResumeFromDraft`'s post-review output writes the `AggregatedVerdict` shape to disk:
+```json
+{
+  "taskId": "AISDLC-282",
+  "decision": "APPROVED",
+  "counts": {"critical": 0, "major": 0, "minor": 4, "suggestion": 2},
+  "verdicts": [{"agentId": "code-reviewer", "approved": true, "findings": [...]}]
+}
+```
+
+`ai-sdlc-plugin/scripts/sign-attestation.mjs` expects the FLAT shape:
+```json
+[
+  {"agentId": "code-reviewer", "harness": "claude-code", "approved": true, "findings": {"critical": 0, "major": 0, "minor": 3, "suggestion": 2}}
+]
+```
+
+Sign fails silently with `ERROR: .ai-sdlc/verdicts/<task-id>.json must contain a JSON array of reviewer verdicts`. The orchestrator surfaces this as the unhelpful `re-push failed: unknown error` (covered by AISDLC-354 Bug 1).
+
+**Workaround**: manual python flatten before push (did this 3× on 282/286/323).
+
+**Fix**:
+- (a) Standardize on ONE shape (flat array) and have `runResumeFromDraft` write the flat shape, OR
+- (b) `sign-attestation.mjs` accepts BOTH shapes — if it gets the nested AggregatedVerdict, flattens internally before signing.
+
+Option (a) is cleaner; option (b) is more backward-compatible.
+
+## Bug 3 — Code-reviewer occasionally returns degenerate parsed output
+
+**Symptom**: for AISDLC-282 the first via-pipeline code-reviewer returned `{approved: false, findings: [], summary: ""}`. The reviewer subagent's output parsed fine (no markdown-fence issue), but the LLM produced effectively empty content. Pipeline shipped it as CHANGES_REQUESTED → blocked the PR.
+
+**Repro**: AISDLC-282 only; AISDLC-286 + AISDLC-323 didn't hit this. Operator-requested manual re-run via `Agent` tool produced a substantive APPROVED verdict (3 minor + 2 suggestions).
+
+**Fix**: in `coerceReviewerVerdict`, detect "suspicious" output and retry once:
+- `approved === false` AND `findings.length === 0` AND `(summary === undefined || summary.trim() === '')` → emit `WARNING: reviewer returned approved=false with no findings/summary; retrying once` + invoke spawner.spawn again with the same args.
+- After retry, accept whatever comes back. If still degenerate, escalate as CHANGES_REQUESTED with a `pipeline-degenerate-reviewer` finding (clearly distinguishable from a real reviewer rejection).
+
+## Acceptance criteria
+
+- [ ] **Bug 1**: `runResumeFromDraft` auto-skips stale verdict files when the file contains synthetic-critical placeholders. Test: pre-populate verdicts file with `[{approved: false, findings: [{severity: critical, message: "code-reviewer returned no parseable verdict (status=success)"}]}]`; assert resume re-runs reviewers.
+- [ ] **Bug 2**: verdicts file shape is unified — either always flat OR signer accepts both. Test: write nested AggregatedVerdict shape; assert sign succeeds. Write flat shape; assert sign succeeds.
+- [ ] **Bug 3**: `coerceReviewerVerdict` retries once on degenerate output. Test: inject a spawner returning `approved=false, findings=[], summary=""` on first call + substantive verdict on second; assert the second is used + warning is logged.
+
+## Source
+
+Operator session 2026-05-17. Bug 1+2 hit on all 3 of AISDLC-282/286/323; Bug 3 hit on AISDLC-282 specifically (operator manually re-ran code-reviewer via Agent).

--- a/backlog/tasks/aisdlc-356 - fix-orchestrator-force-push-rearm-and-branch-slug-consistency.md
+++ b/backlog/tasks/aisdlc-356 - fix-orchestrator-force-push-rearm-and-branch-slug-consistency.md
@@ -1,0 +1,58 @@
+---
+id: AISDLC-356
+title: 'fix(orchestrator): auto-rearm auto-merge after force-push + canonical branch-slug doc/guard'
+status: To Do
+assignee: []
+created_date: '2026-05-17'
+labels:
+  - orchestrator
+  - pipeline-friction
+  - operator-ergonomics
+dependencies: []
+priority: high
+references:
+  - pipeline-cli/src/cli/resume-from-draft.ts
+  - pipeline-cli/src/steps/02-compute-branch.ts
+  - ai-sdlc-plugin/commands/execute.md
+  - ai-sdlc-plugin/agents/rebase-resolver.md
+---
+
+## Two pipeline-UX bugs
+
+## Bug 1 — Force-push clears `autoMergeRequest`; operator must manually re-arm
+
+**Symptom**: every time the operator force-pushes (rebase, re-sign attestation after stale-envelope cleanup, AISDLC-351 parser fix re-run), GitHub silently clears the `autoMergeRequest` state on the PR. Operator must remember to run `gh pr merge <num> --auto` again.
+
+**Repro**: hit on AISDLC-498, AISDLC-282, AISDLC-322 — every PR that needed a re-sign after rebase.
+
+**Fix**: in `runResumeFromDraft` AND `ai-sdlc:rebase-resolver` subagent, after a successful `git push --force-with-lease`, auto-arm `gh pr merge <num> --auto` again. Idempotent: if it's already armed, GitHub returns "already queued" — no-op.
+
+## Bug 2 — Branch slug mismatch when manually creating worktree
+
+**Symptom**: `git worktree add -b <slug>` with operator-picked slug ≠ orchestrator's canonical slug. The orchestrator's slug formula (`pipeline-cli/src/steps/02-compute-branch.ts`):
+- Lowercase title
+- Replace non-alphanumeric runs with `-`
+- Trim leading/trailing `-`
+- Truncate to 50 chars
+- Prefix with `ai-sdlc/<task-id-lower>-`
+
+For task title "feat: RFC-0016 Phase 4 — Stage B LLM tie-breaker + Q5 ensemble", the canonical slug is `ai-sdlc/aisdlc-282-feat-rfc-0016-phase-4-stage-b-llm-tie-breaker-q5-e` (truncated mid-word). My manual `git worktree add -b ai-sdlc/aisdlc-282-feat-rfc-0016-phase-4-stage-b-llm-tiebreaker` (sans `q5-e` and with concatenated "tiebreaker") didn't match. `--resume-from-draft` looked up the canonical branch on remote, didn't find it (because my manual one was named differently), failed with `no-draft-pr`.
+
+This bit me during 282 finalization — caused duplicate PRs #513 / #514. Operator had to grant a one-time exception to `gh pr close #513`.
+
+**Fix**:
+- (a) Document the canonical slug formula prominently in `ai-sdlc-plugin/commands/execute.md` + a `cli-deps print-canonical-branch <task-id>` helper for ad-hoc operators
+- (b) In `runResumeFromDraft`, fall back to `gh pr list --search "AISDLC-<id> in:title"` when the canonical-branch lookup fails — find the PR by task ID in title, not branch name
+- (c) In the `ai-sdlc:rebase-resolver` agent, refuse to operate on branches that don't match the canonical slug + emit a clear message pointing at the helper
+
+Pick (a)+(b) for backwards compatibility; (c) for new-PR strictness.
+
+## Acceptance criteria
+
+- [ ] **Bug 1**: post-force-push auto-rearm in `runResumeFromDraft` + `rebase-resolver`. Test: simulate a force-push then verify the spawned `gh pr merge --auto` call is made.
+- [ ] **Bug 2a**: canonical-slug helper `cli-deps print-canonical-branch <task-id>` ships. Test: known task title → expected slug.
+- [ ] **Bug 2b**: `runResumeFromDraft` falls back to title-search when branch-lookup fails. Test: PR exists with task ID in title but non-canonical branch name; assert resume finds it.
+
+## Source
+
+Operator session 2026-05-17. Bug 1 was a chronic friction across the AISDLC-498/282/322 finalization push cycles. Bug 2 caused the #513/#514 duplicate-PR incident.

--- a/backlog/tasks/aisdlc-357 - fix-build-infra-mcp-server-bundle-and-coverage-flake-and-envelope-deletion.md
+++ b/backlog/tasks/aisdlc-357 - fix-build-infra-mcp-server-bundle-and-coverage-flake-and-envelope-deletion.md
@@ -1,0 +1,58 @@
+---
+id: AISDLC-357
+title: 'fix(infra): mcp-server stale-bundle auto-rebuild + coverage-gate flake + envelope-deletion safety'
+status: To Do
+assignee: []
+created_date: '2026-05-17'
+labels:
+  - infra
+  - pipeline-friction
+  - build-system
+dependencies: []
+priority: medium
+references:
+  - .husky/pre-push
+  - ai-sdlc-plugin/mcp-server/scripts/verify-bundle.mjs
+  - scripts/check-coverage.sh
+  - docs/operations/merge-queue-rebase-recovery.md
+---
+
+## Three build/test infrastructure friction items hit during the 282/286/323 finalization
+
+Grouping because they're all infra-level (no orchestrator-logic changes), small individually, hit operator UX during pre-push hooks.
+
+## Bug 1 — `mcp-server/dist/bin.js` stale-bundle blocks merge after rebase
+
+**Symptom**: the `Verify dist/bin.js` CI check (`ai-sdlc-plugin/mcp-server/scripts/verify-bundle.mjs`) compares the committed bundle SHA to a clean-rebuild SHA. After any rebase that touches `pipeline-cli/` source (which is a workspace dep of mcp-server), the committed bundle goes stale → CI fails.
+
+**Repro**: hit on AISDLC-285 finalization after rebase onto post-AISDLC-280 main. Workaround: `pnpm --filter @ai-sdlc/plugin-mcp-server build` then amend commit. Required operator-amend cycle.
+
+**Fix**: in `.husky/pre-push`, after `check-task-moved.sh` and BEFORE `check-attestation-sign.sh`, detect when the staged commits touch `pipeline-cli/src/**` AND the mcp-server bundle didn't get rebuilt → auto-rebuild + auto-amend (or fail with a clear "run `pnpm --filter @ai-sdlc/plugin-mcp-server build` then re-push" message). Same pattern as the auto-task-move hook.
+
+## Bug 2 — `pnpm test:coverage` flaky exit during pre-push coverage gate
+
+**Symptom**: `scripts/check-coverage.sh` runs `pnpm test:coverage` per package. Observed once on AISDLC-351 finalization: `vitest run --coverage` exited code 1 with NO failing tests + all coverage above 80%. Retry on the next push succeeded. Suspected cause: `Error: process.exit(N)` lines from intentional-exit tests (e.g. CLI exit-code tests) confusing vitest's parent process accounting.
+
+**Repro**: rare; once during AISDLC-351 push. Operator workaround: re-run push.
+
+**Fix**: investigate the vitest run for spurious failure modes. If the issue is intentional-exit tests, isolate them in a separate vitest project that doesn't fail the parent on exit codes. If unreproducible, leave as-is + document the "if test:coverage fails with no actual test failures, just re-run" pattern.
+
+## Bug 3 — Stale envelope deletion footgun
+
+**Symptom**: when an operator runs `rm -f .ai-sdlc/attestations/*.dsse.json` (intending to drop ONE stale envelope from a re-sign cycle), the glob expansion deletes 200+ pre-existing envelopes from main. Recoverable via `git checkout HEAD -- .ai-sdlc/attestations/` but bites operators who don't realize the glob was greedy.
+
+**Repro**: hit during AISDLC-322 finalization 2026-05-17.
+
+**Fix**: 
+- (a) Add a helper script `scripts/drop-stale-attestation-envelope.mjs <head-sha>` that deletes ONLY the specific envelope for the given SHA + warns if the SHA isn't reachable from current HEAD.
+- (b) Document in `docs/operations/merge-queue-rebase-recovery.md` under "Re-signing after a rebase" — never `rm *.dsse.json`, always target the specific SHA.
+
+## Acceptance criteria
+
+- [ ] **Bug 1**: pre-push hook auto-rebuilds mcp-server bundle when `pipeline-cli/src/**` is in the push range. Test: stage a pipeline-cli change without rebuilding bundle; assert hook auto-rebuilds + amends.
+- [ ] **Bug 2**: investigate flake root cause. Either fix (isolate intentional-exit tests) or document (retry pattern in `docs/operations/merge-queue-rebase-recovery.md`).
+- [ ] **Bug 3**: helper script `scripts/drop-stale-attestation-envelope.mjs` ships + is referenced from the recovery runbook.
+
+## Source
+
+Operator session 2026-05-17 finalizing AISDLC-282/286/323. Bug 1 hit on AISDLC-285 (an earlier 504 finalization). Bug 2 hit once on AISDLC-351 push. Bug 3 hit once on AISDLC-322 re-sign.


### PR DESCRIPTION
## Summary

Files 11 pipeline UX/robustness bugs discovered during AISDLC-282/286/323 finalization via the FIXED autonomous pipeline (post-AISDLC-349 dispatcher + AISDLC-351 parser fix). Grouped into 4 tasks by surface:

| Task | Severity | Surface | Bugs |
|---|---|---|---|
| **AISDLC-354** | critical | error propagation + state detection | re-push error swallow, PR auto-promote, gh PATH |
| **AISDLC-355** | critical | resume-from-draft verdict lifecycle | stale verdict reuse, shape mismatch, degenerate reviewer retry |
| **AISDLC-356** | high | force-push + branch-slug UX | auto-rearm after force-push, canonical slug doc/guard |
| **AISDLC-357** | medium | build/test infra | mcp-server stale bundle, coverage flake, envelope deletion |

Each task carries concrete repros from the 2026-05-17 finalization session + actionable fix recipes.

## Why grouped this way

- 354 + 355 are the operator-visible blockers: every resume-from-draft run today requires 2-3 manual workarounds. Grouping makes the fix PR-sized but not overwhelming.
- 356 is force-push + slug — 2 distinct fixes that both touch the rebase-resolver agent. Same scope.
- 357 is infra-level (no orchestrator-logic changes) — small individually, hit pre-push hooks.

## Docs-only path

This PR is docs-only (`backlog/tasks/**` only) so it bypasses the full review+attestation pipeline per CLAUDE.md.