### PR TITLE
docs(rfc): RFC-0017 OQ walkthrough — all 8 OQs resolved with full rubric + 5 phase tasks (AISDLC-352..356)

### DIFF
--- a/backlog/tasks/aisdlc-352 - feat-RFC-0017-phase-1-soul-did-variant-schema-additions.md
+++ b/backlog/tasks/aisdlc-352 - feat-RFC-0017-phase-1-soul-did-variant-schema-additions.md
@@ -1,0 +1,45 @@
+---
+id: AISDLC-352
+title: 'feat: RFC-0017 Phase 1 — Soul DID + Work Item schema additions (variants[] + targetedVariants) + inheritance validator'
+status: To Do
+assignee: []
+created_date: '2026-05-18'
+labels:
+  - rfc-0017
+  - variant-pattern
+  - phase-1
+  - schema
+dependencies: []
+references:
+  - spec/rfcs/RFC-0017-in-soul-variant-pattern.md
+  - spec/rfcs/RFC-0009-tessellated-design-intent-documents.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase 1 of RFC-0017 §9. Schema additions to Soul DID + Work Item + inheritance validator.
+
+## Scope
+
+- **Soul DID schema (`spec/schemas/design-intent-document.schema.json`)**: add `variants[]` array per §5.1. Each variant entry has `id`, `audience`, `designOverrides`, `complianceFloor: inherit` (locked).
+- **Work Item schema**: add optional `targetedVariants[]` field (per OQ-6 URI format `did:method:platform:soul:<soul-id>/variant:<variant-id>`).
+- **Variant inheritance validator** (`orchestrator/src/variant/inheritance-validator.ts`): emits `VariantInheritanceViolation` event when a variant attempts to escape substrate or compliance floor inheritance per §5.3.
+- **Schema constraints** (OQ-1 + OQ-2): soft-warn at 5+ variants (emit Decision); hard-reject at 20+ variants; reject nested `variants[]` declarations (schema-enforced flat per OQ-2).
+- **`.ai-sdlc/variant-config.yaml` schema** (per §10.1): defines per-org `variant.limits.softWarnAt` + `variant.limits.hardLimit` overrides; defaults 5 / 20.
+- Unit tests: schema validation; inheritance violation detection; soft-warn at 5; hard-reject at 20; nested-variant rejection; per-org override.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Soul DID schema has `variants[]` array per §5.1
+- [ ] #2 Work Item schema has optional `targetedVariants[]` field with path-style URI format per OQ-6
+- [ ] #3 Inheritance validator emits `VariantInheritanceViolation` event when substrate or compliance floor escape attempted
+- [ ] #4 Variant count soft warning at 5+ emits `Decision: variant-count-soft-warning` (non-blocking)
+- [ ] #5 Variant count hard limit at 20+ rejects declaration + emits `Decision: variant-count-hard-limit-exceeded` + clarification task
+- [ ] #6 Nested `variants[]` rejected at schema validation (OQ-2 schema-enforced flat)
+- [ ] #7 `.ai-sdlc/variant-config.yaml` per-org override schema ships
+- [ ] #8 Unit tests for all validation paths + per-org override
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-353 - feat-RFC-0017-phase-2-admission-scorer-variant-routing.md
+++ b/backlog/tasks/aisdlc-353 - feat-RFC-0017-phase-2-admission-scorer-variant-routing.md
@@ -1,0 +1,44 @@
+---
+id: AISDLC-353
+title: 'feat: RFC-0017 Phase 2 — admission scorer composition (Sα₁ + Sα₂ variant routing) + cross-variant aggregation'
+status: To Do
+assignee: []
+created_date: '2026-05-18'
+labels:
+  - rfc-0017
+  - variant-pattern
+  - phase-2
+  - admission-scoring
+dependencies:
+  - AISDLC-352
+references:
+  - spec/rfcs/RFC-0017-in-soul-variant-pattern.md
+  - spec/rfcs/RFC-0008-ppa-triad-integration-final-combined.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase 2 of RFC-0017 §9. Admission scorer routes Sα₁ + Sα₂ scoring through variant-level design intent when work item declares `targetedVariants`.
+
+## Scope
+
+- **Sα₁ variant routing** (`orchestrator/src/admission/variant-sa1-router.ts`): when a work item has `targetedVariants`, Sα₁ Problem Resonance scores against the variant's `audienceCharacteristics` (not soul-aggregate).
+- **Sα₂ variant routing**: same pattern for Vibe Coherence — scores against variant's `designOverrides` (voiceRegister, colorPaletteOverlay, densityProfile, or vendor-prefixed adopter extensions per OQ-5).
+- **Cross-variant aggregation** (OQ-4): when work item targets multiple variants, aggregate scores per `crossVariantAggregation` config (default `min`; per-Soul override via `variant-config.yaml`).
+- **Backward compatibility**: work items without `targetedVariants` score against soul-aggregate (existing behavior preserved).
+- Reference: RFC-0008 PPA Triad Integration §5 (variant-scoring inheriting parent-shard SA1; this Phase operationalizes it).
+- Unit tests: single-variant routing; multi-variant aggregation with `min` default; per-Soul override to `max`; backward-compat (no `targetedVariants` → soul-aggregate).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Sα₁ scoring routes through variant `audienceCharacteristics` when `targetedVariants` declared
+- [ ] #2 Sα₂ scoring routes through variant `designOverrides` (including vendor-prefixed adopter extensions per OQ-5)
+- [ ] #3 Cross-variant aggregation: default `min`; per-Soul `crossVariantAggregation` override respected
+- [ ] #4 Work items without `targetedVariants` score against soul-aggregate (backward-compat)
+- [ ] #5 Unit tests: single-variant / multi-variant `min` / multi-variant `max` override / backward-compat
+- [ ] #6 Integration test: end-to-end admission scoring on a work item targeting one of InternalAdopter's variants produces variant-specific score
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-354 - feat-RFC-0017-phase-3-deprecation-lifecycle-and-drift-detection.md
+++ b/backlog/tasks/aisdlc-354 - feat-RFC-0017-phase-3-deprecation-lifecycle-and-drift-detection.md
@@ -1,0 +1,58 @@
+---
+id: AISDLC-354
+title: 'feat: RFC-0017 Phase 3 — variant deprecation lifecycle (catalog-routed) + Eτ_tessellation_drift extension + Engineering review routing'
+status: To Do
+assignee: []
+created_date: '2026-05-18'
+labels:
+  - rfc-0017
+  - variant-pattern
+  - phase-3
+dependencies:
+  - AISDLC-352
+  - AISDLC-353
+references:
+  - spec/rfcs/RFC-0017-in-soul-variant-pattern.md
+  - spec/rfcs/RFC-0035-decision-catalog-operator-routing.md
+  - spec/rfcs/RFC-0009-tessellated-design-intent-documents.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase 3 of RFC-0017 §9. Deprecation lifecycle per OQ-3 + Eτ_tessellation_drift extension for variant-scoped scans + Engineering review routing per OQ-7.
+
+## Scope (OQ-3 deprecation lifecycle)
+
+- **Lifecycle states** (catalog-routed per RFC-0035 G0):
+  1. **Deprecation declared** → `Decision: variant-deprecation-declared` (log to catalog; no operator interrupt)
+  2. **Approaching removal** (default 7d before removalDate; per-org config) → `Decision: variant-deprecation-approaching` → operator batch review surface
+  3. **At removal date with consumers still referencing** → `Decision: variant-removal-consumers-pending` → **auto-action:** keep variant in degraded mode (don't break consumers) + emit migration tasks to consumer owners + surface to operator
+- **30d default deprecation window**; per-Soul `deprecationWindowDays` override via `variant-config.yaml`.
+- Pipeline never halts on any lifecycle transition (per G0).
+
+## Scope (Eτ_tessellation_drift variant-scoped extension)
+
+- Extend `Eτ_tessellation_drift` detector (composes with RFC-0009 Phase 4.2 / AISDLC-317) to scan variant-scoped design intent for drift.
+- Variant drift detected → `Decision: variant-design-intent-drift` → catalog-routed per RFC-0035 Stage A/B/C.
+
+## Scope (OQ-7 Engineering review routing)
+
+- Variant declaration triggers `Decision: variant-substrate-cost-review` → Engineering Authority review via catalog.
+- Engineering substrate-cost block → `Decision: variant-substrate-cost-block` → Design/Engineering routing per RFC-0029 actor model.
+- Reviewer-subagent check (composes with AISDLC-298): variant declarations PRs without Engineering review Decision flag as critical.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Deprecation lifecycle: declared → approaching → at-removal-degraded-mode states all emit correct Decisions
+- [ ] #2 30d default deprecation window; per-Soul override respected
+- [ ] #3 Pipeline never halts on lifecycle transitions (consumers degrade gracefully at removalDate)
+- [ ] #4 Eτ_tessellation_drift extended for variant-scoped scans; emits `Decision: variant-design-intent-drift`
+- [ ] #5 Variant declaration triggers Engineering review Decision per OQ-7
+- [ ] #6 Substrate-cost block routes via RFC-0029 actor model (Design + Engineering)
+- [ ] #7 Reviewer-subagent flag (per AISDLC-298) on variant declarations without Engineering review Decision
+- [ ] #8 Integration tests: full deprecation lifecycle + drift detection + Engineering review loop
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-355 - feat-RFC-0017-phase-4-internaladopter-four-product-reference-impl.md
+++ b/backlog/tasks/aisdlc-355 - feat-RFC-0017-phase-4-internaladopter-four-product-reference-impl.md
@@ -1,0 +1,53 @@
+---
+id: AISDLC-355
+title: 'feat: RFC-0017 Phase 4 — InternalAdopter four-product suite as reference implementation (practitioner validation pass)'
+status: To Do
+assignee: []
+created_date: '2026-05-18'
+labels:
+  - rfc-0017
+  - variant-pattern
+  - phase-4
+  - practitioner-validation
+dependencies:
+  - AISDLC-352
+  - AISDLC-353
+  - AISDLC-354
+references:
+  - spec/rfcs/RFC-0017-in-soul-variant-pattern.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase 4 of RFC-0017 §9 + §11 practitioner validation. Implements InternalAdopter's four-product suite as the reference implementation; validates the variant pattern against real-world adopter constraints before final sign-off.
+
+## Scope (§11 validation criteria)
+
+- **ProductA**: variants `small-utility`, `enterprise`, `county-regional` — validates audience-segment specialization + voice register variation.
+- **ProductB**: variants `field-tech-on-truck`, `field-tech-handheld`, `supervisor-tablet` — validates density profile + form-factor specialization.
+- **ProductC**: variants `billing-clerk`, `customer-portal`, `csr-dashboard` — validates role-based audience + workflow-density specialization.
+- **ProductD**: variants `annual-test`, `repair-event`, `regulatory-audit-mode` — validates temporal-context-bound design intent (also validates §11 carries through to RFC-0018 Journey companion).
+
+## Validation criteria (Mo's editorial welcome)
+
+1. Each variant's design intent articulable in ≤ 5 `designImperatives` strings
+2. No variant requires a field NOT in the §6.1 schema (closed-enum holds; OR validates the vendor-prefix extension path from OQ-5 if a real bespoke field surfaces)
+3. Admission scoring on a real work item (e.g., "small-utility onboarding improvement") produces a different + better-justified score than soul-aggregate scoring
+4. Engineering vertex confirms substrate is genuinely shared across all variants of each soul (no hidden divergence)
+5. Deprecation lifecycle test: deprecate a variant; verify consumers degrade gracefully through full G0-routed lifecycle.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 ProductA variant declarations ship with `small-utility` / `enterprise` / `county-regional`
+- [ ] #2 ProductB variant declarations ship with `field-tech-on-truck` / `field-tech-handheld` / `supervisor-tablet`
+- [ ] #3 ProductC variant declarations ship with `billing-clerk` / `customer-portal` / `csr-dashboard`
+- [ ] #4 ProductD variant declarations ship with `annual-test` / `repair-event` / `regulatory-audit-mode`
+- [ ] #5 Each variant has ≤ 5 `designImperatives` strings (validates closed-enum discipline OR exercises vendor-prefix extension)
+- [ ] #6 Admission scoring spot-check: variant-routed score differs from soul-aggregate by ≥ X% on a representative work item
+- [ ] #7 Engineering review confirms substrate shared across all four products' variants
+- [ ] #8 End-to-end deprecation lifecycle test on one ProductA variant
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-356 - docs-RFC-0017-phase-5-glossary-conformance-tests-doc-surfaces.md
+++ b/backlog/tasks/aisdlc-356 - docs-RFC-0017-phase-5-glossary-conformance-tests-doc-surfaces.md
@@ -1,0 +1,76 @@
+---
+id: AISDLC-356
+title: 'docs: RFC-0017 Phase 5 — glossary additions + conformance test suite + adopter doc surfaces'
+status: To Do
+assignee: []
+created_date: '2026-05-18'
+labels:
+  - rfc-0017
+  - variant-pattern
+  - phase-5
+  - docs
+  - conformance
+dependencies:
+  - AISDLC-352
+  - AISDLC-353
+  - AISDLC-354
+  - AISDLC-355
+references:
+  - spec/rfcs/RFC-0017-in-soul-variant-pattern.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Phase 5 of RFC-0017 §9. Adopter-facing surfaces + conformance gates + cardinality activation Decision wiring (OQ-8).
+
+## Scope
+
+### Glossary additions
+
+- `Variant` — soul-scoped sub-theme with distinct visual identity + audience specialization, inheriting parent Soul DID's substrate + compliance
+- `targetedVariants` — Work Item field declaring which variants the work applies to (path-style URI list)
+- `complianceFloor: inherit` — locked field on variants; cannot be overridden (per RFC-0028 substrate-contract pattern)
+- `Eτ_tessellation_drift` (variant-scoped) — design coherence drift detection within a single soul's variants
+
+### Conformance test suite
+
+- Variant declaration round-trip (write → read → schema validate)
+- Admission-scoring composition: targetedVariants → variant-routed Sα₁/Sα₂
+- Inheritance enforcement: complianceFloor escape attempt rejected; substrate divergence detected
+- Cross-variant aggregation: default `min`; per-Soul override
+- Deprecation lifecycle: declared → approaching → degraded-mode consumers
+- Nested-variant rejection (OQ-2)
+- Vendor-prefix designOverrides extension (OQ-5)
+- Path-style URI parsing (OQ-6)
+
+### Adopter doc surfaces
+
+- `docs/concepts/variants.md` — introduction + when to use variant vs separate Soul
+- `docs/tutorials/N-declaring-variants.md` — step-by-step variant declaration walkthrough using InternalAdopter examples
+- `docs/operations/variant-deprecation.md` — deprecation lifecycle runbook + consumer-migration playbook
+
+### OQ-8 cardinality activation Decision wiring
+
+- `Decision: variant-cardinality-activation-request` registered in catalog substrate
+- Stage A counter tracks adopter requests; auto-promote to operator batch review at ≥2 distinct requests
+- Operator runbook documents the "file follow-on RFC for cardinality activation" path
+
+### Promotion runbook
+
+- `docs/operations/variant-pattern-promotion.md` — operator-driven default-on flip per RFC-0014 / RFC-0015 convention; corpus-driven (InternalAdopter validation must complete without regressions before promotion).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Glossary additions ship (Variant, targetedVariants, complianceFloor: inherit, Eτ variant-scoped)
+- [ ] #2 Conformance test suite covers all 8 OQ resolutions + inheritance enforcement + cross-variant aggregation
+- [ ] #3 `docs/concepts/variants.md` adopter-facing explainer ships
+- [ ] #4 `docs/tutorials/N-declaring-variants.md` step-by-step walkthrough ships
+- [ ] #5 `docs/operations/variant-deprecation.md` deprecation runbook ships
+- [ ] #6 OQ-8 cardinality activation Decision registered + Stage A counter wired
+- [ ] #7 Operator runbook documents the cardinality activation follow-on RFC path
+- [ ] #8 Promotion runbook published; ties promotion to InternalAdopter validation completion
+<!-- AC:END -->

--- a/spec/rfcs/RFC-0017-in-soul-variant-pattern.md
+++ b/spec/rfcs/RFC-0017-in-soul-variant-pattern.md
@@ -2,24 +2,31 @@
 id: RFC-0017
 title: In-Soul Variant Pattern
 status: Draft
-lifecycle: Draft
+lifecycle: Ready for Review
 author: morgan@sprypoint.com
 created: 2026-05-04
-updated: 2026-05-04
+updated: 2026-05-18
 targetSpecVersion: v1alpha1
 requires:
   - RFC-0009
+  - RFC-0024
+  - RFC-0025
+  - RFC-0029
+  - RFC-0035
 requiresDocs: []
 ---
 
 # RFC-0017: In-Soul Variant Pattern
 
-**Document type:** Normative (draft)
-**Status:** Draft v0.2 — Initial spec expansion (Engineering pass on Mo's v0.1 stub). Practitioner-validation gates in §11 unresolved; full normative status awaits InternalAdopter four-soul implementation pass + Mo's design-authority editorial review of §3-§13.
+**Document type:** Normative
+**Status:** Ready for Review v0.3 — operator OQ walkthrough complete 2026-05-18; all 8 §10 OQs resolved with full rubric (problem statement → industry research → 3-4 options with tradeoffs → recommendation + counter-argument). **Cross-cutting framing:** every operator-impacting variant lifecycle event (count thresholds, deprecation transitions, Engineering substrate-cost review, cardinality activation requests) **routes through [RFC-0035 G0 non-blocking pipeline contract](RFC-0035-decision-catalog-operator-routing.md)** — pipeline never halts on variant-substrate edge cases. §10.1 codifies per-Soul / per-org config schema. Practitioner-validation gates in §11 remain unresolved pending InternalAdopter four-soul implementation pass. Implementation broken into 5 phase tasks (AISDLC-352..356).
+**Lifecycle:** Ready for Review
 **Created:** 2026-05-04
+**Updated:** 2026-05-18
 **Authors:** Morgan Hirtle (Design Authority, InternalAdopter)
-**Engineering pass:** Dominique Legault, Claude Opus 4.7 (orchestrator), 2026-05-04 — fleshed §3-§13 from Mo's v0.1 stub. Design-vertex semantics (specifically §5.3 inheritance table + §10 OQs) deferred to Mo for editorial pass.
-**Requires:** RFC-0009 (Tessellated Design Intent Documents)
+**Engineering pass:** Dominique Legault, Claude Opus 4.7 (orchestrator), 2026-05-04 — fleshed §3-§13 from Mo's v0.1 stub.
+**OQ walkthrough:** Dominique Legault (Operator), 2026-05-18 — full-rubric resolution of all 8 §10 OQs.
+**Requires:** RFC-0009 (Tessellated Design Intent Documents), RFC-0024 (Emergent Capture — catalog substrate), RFC-0025 (Framework Quality Monitoring — over-blocking audit), RFC-0029 (Product Pillar Architectural Vision — pillar model + Engineering/Design ownership), RFC-0035 (Decision Catalog — G0 non-blocking routing)
 
 > The bold-style status block above is preserved for human readability. The
 > YAML frontmatter at the top of the file is the source of truth for tooling
@@ -318,25 +325,87 @@ The "use the existing Soul DID model" answer. **Rejected for the homogeneous-sub
 - [ ] Conformance test suite — variant declaration round-trip; admission-scoring composition; inheritance enforcement
 - [ ] Author/update each user-facing doc surface declared in `requiresDocs` (currently `[]` — pending tutorial/runbook decision)
 
-## 10. Open Questions
+## 10. Open Questions — resolved (operator walkthrough 2026-05-18)
 
-These need design + operator walkthrough before Lifecycle: Draft → Ready for Review.
+> **Resolution status (2026-05-18):** All 8 §10 OQs resolved via operator walkthrough with full rubric (problem → industry research → options → recommendation + counter-argument). Lifecycle promoted Draft → Ready for Review. **Cross-cutting framing:** operator-impacting variant-substrate events (count thresholds, deprecation transitions, Engineering substrate-cost review, cardinality activation requests) route through [RFC-0035 G0 non-blocking pipeline contract](RFC-0035-decision-catalog-operator-routing.md). §10.1 codifies per-Soul / per-org config. Implementation broken into 5 phase tasks: AISDLC-352..356.
 
 **OQ-1 — Maximum variants per Soul:** Should the schema cap variant count (e.g., max 5) to discourage over-fragmentation, or trust operators? Recommendation: soft warning at 5+, hard limit at 20 (sanity check, not design constraint).
 
+   **Resolution (2026-05-18):** **Per-org configurable; defaults 5 (soft warn) / 20 (hard limit).** Author's research-grounded defaults (5 ≈ Miller's 7±2 cognitive-load threshold; 20 ≈ re-architect-as-multi-soul threshold per RFC-0009 §3) wrapped in the per-org-configurability convention established across this session. Soft warn → `Decision: variant-count-soft-warning` (non-blocking batch review). Hard limit → refuse declaration + `Decision: variant-count-hard-limit-exceeded` + clarification task ("consider re-architecting as multi-soul"). **Selected over fixed 5/20** because adopters may surface tuning needs (e.g., marketplace with 30 vendor variants); marginal config surface vs. "file an RFC to bump the constant" friction.
+
 **OQ-2 — Nested variants:** Can a variant declare its own sub-variants? Recommendation: NO for v1 — adds complexity for a use case (variant-of-variant) we have no practitioner evidence for. Revisit if InternalAdopter or another adopter surfaces a real need.
+
+   **Resolution (2026-05-18):** **Schema-enforced flat: `variants[]` cannot contain `variants[]`** (design-tokens pattern: Tailwind / Material / Stripe / Vercel). Schema rejects nested declarations at validation. Future RFC lifts when ≥2 adopters surface concrete sub-variant use cases (mirrors OQ-8 cardinality threshold). **Selected over convention-only NO (author rec)** because schema-permissive + convention-gated is the design-token-explosion anti-pattern; schema enforcement keeps the design-authority loop intact.
 
 **OQ-3 — Variant lifecycle (deprecation, removal):** §6.3 sketches the removal flow. What's the right deprecation-window default — 30 days, 90 days, or operator-configured per Soul? Recommendation: configurable per Soul with 30-day default.
 
+   **Resolution (2026-05-18):** **Composite: 30d default + per-Soul `deprecationWindowDays` override + explicit G0-routed lifecycle states.** Lifecycle: (1) deprecation declared → `Decision: variant-deprecation-declared` (log; no interrupt); (2) approaching → `Decision: variant-deprecation-approaching` → operator batch surface; (3) at removal with consumers still referencing → `Decision: variant-removal-consumers-pending` → **auto-action:** keep variant in degraded mode + emit migration tasks. Pipeline never halts. 30d reflects internal-config cadence (vs RFC-0019's 90d for external providers). **Selected over fixed 30d** because per-Soul override accommodates slower migration cadences (large adopters needing 60-90d); selected over implicit-lifecycle because explicit specification prevents "we forgot to ship at-removal-degraded-mode" drift.
+
 **OQ-4 — Cross-variant scoring rule precedence:** RFC-0009 §7.2 sets `min` as cross-soul default. Same default for cross-variant within a soul, OR should variants default to `max` (since they're more loosely coupled than souls within a tessellation)? Recommendation: same `min` default for consistency.
+
+   **Resolution (2026-05-18):** **Per-Soul configurable, default `min`** (matches RFC-0009 §7.2 cross-soul). `min` matches RFC-0009 (consistency across tessellation hierarchy) AND matches industry safety-critical aggregation convention (compliance / security / performance all use `min`). Variants share substrate + compliance + foundational triad per §3.2 — they're MORE tightly coupled than tessellated souls, so safety-critical aggregation applies even more strongly. Per-Soul `crossVariantAggregation` config accommodates adopters with genuine reasons to override (e.g., experimental-variant promotion via `max`). **Selected over fixed `min`** because per-org-config has been the recurring pattern this session; consistency matters for adopter expectations.
 
 **OQ-5 — designOverrides extensibility:** §6.1 lists `voiceRegister`, `colorPaletteOverlay`, `densityProfile`. Should this be open-ended (any field name) or closed-enum? Recommendation: closed-enum for v1 to force design-authority discipline; expand as new override needs surface.
 
+   **Resolution (2026-05-18):** **Closed framework enum + vendor-prefix extension** (composes with RFC-0025 OQ-10 vendor-namespace pattern + Kubernetes CRD / JSON Schema / HTML `data-*` conventions). Framework owns `voiceRegister`, `colorPaletteOverlay`, `densityProfile` (closed; expanding requires RFC amendment with Design sign-off). Adopters extend via vendor reverse-DNS prefix (e.g., `acme.com/accessibilityProfile`); schema validates prefix. **Selected over closed-enum-only (author rec)** because vendor-prefix pattern is already established in this codebase (RFC-0025 OQ-10) and across the ecosystem; provides extension flexibility without compromising Design Authority's loop on framework-owned fields.
+
 **OQ-6 — Variant ID URI representation in DID:** RFC-0009 uses `did:platform-x:soul:engage`. What's the variant URI? Options: (a) `did:platform-x:soul:engage/variant:small-utility`, (b) `did:platform-x:soul:engage:small-utility` (slug-concat), (c) `did:platform-x:variant:engage/small-utility`. Recommendation: (a) — preserves explicit hierarchy.
+
+   **Resolution (2026-05-18):** **Option (a) — `did:platform-x:soul:engage/variant:small-utility`** (path-style with explicit `variant:` keyword) per author rec. Matches Kubernetes resource paths / HTTP REST / AWS ARN / DID Web conventions (hierarchical resource systems consistently use path-style with explicit kind keywords). Preserves the structural inheritance relationship (variant is a CHILD of soul per §3.2). Composes naturally with future nested-variant extension AND with future in-soul partition types from RFC-0018 (`/journey:onboarding-flow`). **Selected over slug-concat (b)** because (b) has parser ambiguity; **selected over option (c)** because (c) treats variant as peer of soul, contradicting the inheritance model.
 
 **OQ-7 — Engineering authority on variant declarations:** RFC-0009 makes Design Authority the owner of `design.*` fields with Engineering as reviewer. Same model for variant declarations? Or does Engineering own `targetAudience` (since audience determines load characteristics)? Recommendation: Design owns variant declaration; Engineering reviews + may block on substrate-cost grounds.
 
+   **Resolution (2026-05-18):** **Design owns + Engineering review routed through Decision Catalog.** Author's pillar-model split (Design owns; Engineering reviews) is architecturally correct per RFC-0029 Principle 1 + project_team_roles.md. Engineering's review becomes a tracked `Decision: variant-substrate-cost-review` in the catalog. Substrate-cost block → `Decision: variant-substrate-cost-block` → Design/Engineering routing per RFC-0029 actor model. **Selected over convention-only review-may-block** because convention-only is the same anti-pattern that produced AISDLC-269's "forgot to operator-walk-through" failure — explicit Decision-Catalog routing makes the review loop AUDITABLE.
+
 **OQ-8 — `cardinality` field activation:** §5.2 reserves `cardinality: primary | secondary | experimental` for v2. What's the v1 → v2 trigger to activate this — practitioner demand, or a specific lifecycle event? Recommendation: defer activation to a follow-on RFC when at least 2 adopters request lifecycle distinctions.
+
+   **Resolution (2026-05-18):** **Future Decision in catalog; auto-promote on ≥2 adopter requests.** Author's threshold expressed through the Decision Catalog substrate. Each adopter request → `Decision: variant-cardinality-activation-request` → Stage A counter; at threshold, Decision auto-promotes to operator batch review with "file follow-on RFC" recommendation. Composes with RFC-0036 OQ-6 first-party-adapter graduation pattern (identical shape). **Selected over convention-only** because "we'll notice when adopters ask" relies on operator manually catching the signal — same anti-pattern surfaced elsewhere this session.
+
+### 10.1 Configuration Schema (per-Soul / per-org defaults)
+
+Per-organization configurability across the OQ resolutions. Per-Soul overrides codify variant-substrate config:
+
+```yaml
+# .ai-sdlc/variant-config.yaml (per-org defaults)
+variant:
+  limits:                                    # OQ-1
+    softWarnAt: 5                            # Miller's 7±2 cognitive-load threshold
+    hardLimit: 20                            # re-architect-as-multi-soul threshold per RFC-0009 §3
+
+  lifecycle:                                 # OQ-3
+    deprecationWindowDays: 30                # internal-config cadence default
+    routing:
+      onDeclared: log-catalog-no-interrupt
+      onApproaching: operator-batch-surface
+      onConsumersPending: degraded-mode-and-migration-tasks
+
+  scoring:                                   # OQ-4
+    crossVariantAggregation: min             # matches RFC-0009 cross-soul default
+
+  overrides:                                 # OQ-5
+    framework:
+      - voiceRegister
+      - colorPaletteOverlay
+      - densityProfile
+    adopterExtensionsAllowed: true           # via vendor reverse-DNS prefix
+
+  uri:                                       # OQ-6
+    format: 'did:{method}:{platform}:soul:{soul-id}/variant:{variant-id}'
+
+  authority:                                 # OQ-7
+    declarationOwner: design
+    substrateCostReview:
+      reviewer: engineering
+      routing: decision-catalog
+      blockDecision: variant-substrate-cost-block
+
+  cardinality:                               # OQ-8
+    activationThreshold:
+      adopterRequests: 2
+    routing: decision-catalog-auto-promote
+```
+
+Default constants ship in the `ai-sdlc init` variant-config template. Per-Soul overrides via the soul's `spec.variantConfig` block (composes with RFC-0009 substrate). Schema enforces limits at variant-declaration load, lifecycle states at deprecation transitions, vendor-prefix for adopter override fields.
 
 ## 11. Practitioner Validation Plan
 
@@ -367,3 +436,4 @@ Validation criteria (Mo's edits welcome):
 |---|---|---|---|
 | v0.1 | 2026-05-04 | Morgan Hirtle | Initial stub (carve-out from RFC-0009 OQ-3). Established summary + practitioner-validation source. |
 | v0.2 | 2026-05-04 | Engineering pass (Dominique + Claude Opus 4.7) | Filled §3-§13 from boilerplate. Schema sketch, inheritance table, admission-scoring composition, boundary-vs-separate-soul, alternatives, 8 open questions, InternalAdopter validation plan. Awaiting Mo's design-authority editorial pass on §5.3 + §10. |
+| v0.3 | 2026-05-18 | Dominique (Operator OQ walkthrough) | Full-rubric resolution of all 8 §10 OQs (problem → industry research → 3-4 options → recommendation + counter-argument per OQ). Resolutions: per-org configurable variant count limits (OQ-1, defaults 5 soft / 20 hard); schema-enforced flat (no nested variants for v1 — OQ-2); composite deprecation lifecycle with 30d default + per-Soul override + G0-routed degraded-mode (OQ-3); per-Soul configurable cross-variant aggregation with `min` default (OQ-4, matches RFC-0009); closed framework enum + vendor-prefix extension for designOverrides (OQ-5, composes with RFC-0025 OQ-10 pattern); path-style URI `did:.../variant:...` (OQ-6); Design owns + Engineering review via Decision Catalog (OQ-7); cardinality activation via catalog auto-promote on ≥2 adopter requests (OQ-8). §10.1 added consolidating per-Soul / per-org `.ai-sdlc/variant-config.yaml` schema. Cross-cutting framing: all operator-impacting variant lifecycle events route through RFC-0035 G0 non-blocking pipeline contract. Frontmatter requires expanded: added RFC-0024 (capture substrate), RFC-0025 (audit), RFC-0029 (pillar model), RFC-0035 (catalog routing). Lifecycle promoted Draft → Ready for Review. Implementation broken into 5 phase tasks: AISDLC-352 (Phase 1 schema additions), AISDLC-353 (Phase 2 admission scorer composition), AISDLC-354 (Phase 3 Eτ_tessellation_drift extension + deprecation lifecycle), AISDLC-355 (Phase 4 InternalAdopter four-product reference impl), AISDLC-356 (Phase 5 glossary + conformance test suite + doc surfaces). Practitioner-validation gates in §11 remain unresolved pending InternalAdopter implementation pass. |


### PR DESCRIPTION
## Summary

Operator OQ walkthrough on 2026-05-18 resolved all 8 RFC-0017 §10 OQs using **full rubric per OQ** (problem statement → industry research → 3-4 options with tradeoffs → recommendation + counter-argument). Returning to rigorous walkthrough discipline after the operator called out earlier-session drift into shallow batch auto-resolutions.

Cross-cutting catalog-routing framing applied: operator-impacting variant-substrate events route through [RFC-0035 G0 non-blocking pipeline contract](spec/rfcs/RFC-0035-decision-catalog-operator-routing.md).

## OQ resolutions (full rubric per OQ)

| OQ | Resolution | Catalog routing |
|---|---|---|
| **1** count limit | **Per-org configurable; defaults 5/20** (Miller's 7±2 cognitive load + re-architect-as-multi-soul threshold) | `Decision: variant-count-soft-warning` + `variant-count-hard-limit-exceeded` |
| **2** nested variants | **Schema-enforced flat** (design-tokens pattern); future RFC at ≥2 adopter requests | Schema rejection; no runtime catalog event |
| **3** deprecation lifecycle | **Composite: 30d default + per-Soul override + explicit G0-routed states** (declared → approaching → at-removal-degraded) | 3 Decision states; consumers degrade gracefully |
| **4** cross-variant aggregation | **Per-Soul configurable, default \`min\`** (matches RFC-0009 + safety-critical aggregation convention) | No runtime event; config-only |
| **5** designOverrides extensibility | **Closed framework enum + vendor-prefix extension** (composes with RFC-0025 OQ-10 + Kubernetes CRD / JSON Schema / HTML data-* convention) | Schema enforces; vendor-prefix validates |
| **6** variant URI | **Path-style with \`/variant:\` keyword** (matches k8s/REST/AWS ARN/DID Web; composes with future RFC-0018 journey URIs) | No runtime event |
| **7** declaration authority | **Design owns + Engineering review via Decision Catalog** (auditable; not convention-only) | \`Decision: variant-substrate-cost-review\` + \`variant-substrate-cost-block\` |
| **8** cardinality activation | **Future Decision; auto-promote on ≥2 adopter requests** (matches RFC-0036 OQ-6 graduation pattern) | \`Decision: variant-cardinality-activation-request\` + Stage A counter |

§10.1 ships consolidated per-Soul / per-org \`.ai-sdlc/variant-config.yaml\` schema.

## 5 phase tasks (AISDLC-352..356)

| Task | Phase | Scope |
|---|---|---|
| **AISDLC-352** | P1 | Soul DID + Work Item schema additions + inheritance validator + count limits + nested-variant rejection |
| **AISDLC-353** | P2 | Admission scorer composition (Sα₁ + Sα₂ variant routing) + cross-variant aggregation |
| **AISDLC-354** | P3 | Deprecation lifecycle + Eτ_tessellation_drift variant extension + Engineering review routing |
| **AISDLC-355** | P4 | InternalAdopter four-product reference impl (practitioner validation per §11) |
| **AISDLC-356** | P5 | Glossary + conformance test suite + adopter docs + cardinality Decision wiring + promotion runbook |

## Frontmatter \`requires\` expanded

Was: \`[RFC-0009]\`. Now: \`[RFC-0009, RFC-0024, RFC-0025, RFC-0029, RFC-0035]\`. Reflects:
- RFC-0024 — capture substrate for variant-lifecycle Decision events
- RFC-0025 — audit on framework-decided variant events
- RFC-0029 — pillar model for Design/Engineering ownership (OQ-7)
- RFC-0035 — catalog substrate for all operator-impacting variant events

## Dispatchable-now after merge

- **AISDLC-352** (Phase 1; no deps)

## Verification

- [x] \`npx backlog-drift check\` → 0 errors
- [x] Body \`**Lifecycle:**\` / \`**Updated:**\` match frontmatter (Ready for Review / 2026-05-18)
- [x] §10 preserves original questions + adds Resolution markers with full rationale per OQ
- [x] §10.1 codifies per-Soul / per-org config schema
- [x] All 5 phase tasks have substantive ACs + resolvable references
- [x] Cross-cutting framing explicit: every operator-impacting event routes through RFC-0035 G0
- [x] Docs-only PR — no code paths touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)