### PR TITLE
rfcs: 3 adopter-context extension points (RFC-0037/0038/0039) — Draft

### DIFF
--- a/spec/rfcs/RFC-0037-adopter-project-context-inheritance.md
+++ b/spec/rfcs/RFC-0037-adopter-project-context-inheritance.md
@@ -1,0 +1,149 @@
+---
+id: RFC-0037
+title: Adopter Project Context Inheritance
+status: Draft
+lifecycle: Draft
+author: alexanderkline13@gmail.com
+created: 2026-05-19
+updated: 2026-05-19
+targetSpecVersion: v1alpha1
+requires: [RFC-0010, RFC-0012, RFC-0036]
+requiresDocs: []
+---
+
+# RFC-0037: Adopter Project Context Inheritance
+
+**Status:** Draft
+**Lifecycle:** Draft
+**Author:** alexanderkline13@gmail.com (Product owner contribution)
+**Created:** 2026-05-19
+**Updated:** 2026-05-19
+**Target Spec Version:** v1alpha1
+
+---
+
+## Sign-Off
+
+- [ ] Engineering owner — dominique@reliablegenius.io
+- [ ] Product owner — Alexander Kline
+
+## 1. Summary
+
+Adopter projects accumulate domain-specific conventions (architectural primitives, doc taxonomies, failure-mode lexicons, investigation trails, linguistic norms) that the framework's dispatched developer + reviewer agents should inherit at task dispatch time. The framework currently has no clean mechanism for this. Adopters resort to either (a) inlining context in every ticket body (manual, doesn't scale), (b) forking the plugin (defeats the framework's value proposition), or (c) writing project-local `.claude/agents/*.md` overrides that may or may not be respected by the plugin's `Agent({subagent_type: "developer"})` lookup.
+
+This RFC proposes a well-known adopter-context override path (e.g., `.ai-sdlc/project-context.md`) that the plugin auto-prepends to the developer and reviewer agent system prompts when dispatching `/ai-sdlc execute`. The framework defines the path + load semantics; the adopter decides the content.
+
+## 2. Motivation
+
+### The adopter-pain pattern (production evidence)
+
+In production usage of `/ai-sdlc execute` on an adopter project carrying ~6 months of accumulated work, two recent P0 incidents both required ~90 minutes of root-cause investigation before reaching the relevant adopter-internal architectural specs that named the failure class explicitly. The dispatched developer agent had no path to those specs — they exist in the adopter's `memory/architecture/` directory (an adopter convention, not a framework convention), and the agent only finds them by accident if it greps for the right terms.
+
+### Why this isn't a one-adopter problem
+
+Every adopter project doing real work over time develops conventions specific to its domain:
+
+- A fintech adopter accumulates consistency-model specs that transaction-touching code must respect
+- A games adopter accumulates save-game compatibility rules that all serialization-touching code must respect
+- A healthcare adopter accumulates PHI-handling specs that all data-touching code must respect
+- A research adopter accumulates methodology constraints that all analysis-touching code must respect
+- An open-source library adopter accumulates API stability rules
+
+In each case, the dispatched developer agent is **structurally unaware** of conventions that are load-bearing for the adopter's domain. The agent doesn't know what it doesn't know.
+
+### Why ticket-body inlining doesn't scale
+
+Some adopters paper over the gap by inlining context in every TASK ticket body. This works for one ticket but:
+
+- Multiplies content-management overhead by N tickets
+- Drifts as conventions evolve (every ticket needs re-syncing)
+- Pollutes the ticket's own scope with framework-context
+- Doesn't help cross-project conventions like architectural patterns that span the codebase
+
+The right level for adopter-project context is **the adopter project**, not the ticket. The framework should provide the load mechanism; the adopter writes once.
+
+## 3. Goals and Non-Goals
+
+### Goals
+
+- Standard well-known path for adopter-project context that the plugin recognizes
+- Auto-prepend to developer + reviewer agent system prompts at dispatch time
+- Optional — works fine if absent (no breaking change for existing adopters)
+- Format-agnostic — the framework reads, the adopter authors freeform markdown
+- Length cap to prevent context bloat (~500 lines? configurable cap with warning above threshold)
+
+### Non-Goals
+
+- The framework prescribing WHAT adopter-context should contain
+- Multi-file context aggregation (single canonical file; adopter can reference others from it)
+- Replacing `.claude/agents/*.md` project-local overrides — this layer is additive
+- Replacing per-ticket context — high-leverage tickets may still inline ticket-specific context
+
+## 4. Proposed Mechanism
+
+### 4.1 Well-known path
+
+Plugin recognizes `<repo-root>/.ai-sdlc/project-context.md`. If present, its contents are prepended to the system prompt of every plugin-dispatched agent (developer, code-reviewer, test-reviewer, security-reviewer, and any future adopter-defined reviewers per RFC-0038).
+
+Rationale for `.ai-sdlc/` path:
+- Mirrors existing `.ai-sdlc/pipeline.yaml` and `.ai-sdlc/agent-role.yaml` adopter-configuration files
+- Distinguishable from `.claude/agents/` which is Claude-Code-general agent definitions
+- Discoverable; co-located with other adopter governance configuration
+
+### 4.2 Length cap + warning
+
+Default cap: 500 lines. Above cap: log warning during pipeline initialization. Above hard cap (configurable, default 2000 lines): refuse to load and surface error.
+
+Rationale: protects adopters from context-bloat anti-patterns. The point is to teach the agent project conventions, not to inline the entire architecture spec.
+
+### 4.3 Composition with existing layers
+
+Loading order at agent dispatch:
+1. Framework default agent system prompt (plugin-provided)
+2. Adopter `.ai-sdlc/project-context.md` (this RFC's contribution)
+3. Project-local `.claude/agents/<name>.md` override (if present, Claude Code convention)
+4. Task ticket body (per-dispatch context)
+
+Layers (2) and (3) are independent — adopters can use either, both, or neither. The proposed file is for cross-cutting context that should apply to ALL agents; `.claude/agents/<name>.md` is for per-agent customization.
+
+## 5. Schema Changes
+
+None required. The file path is convention, not schema. A future RFC could promote this to a schema field in `pipeline.yaml`'s `spec.adopter` block if more configuration becomes necessary.
+
+## 6. Backward Compatibility
+
+Fully backward-compatible. Existing adopters who don't ship `.ai-sdlc/project-context.md` see no behavior change.
+
+## 7. Composition with Other RFCs
+
+- **RFC-0010 (parallel execution / worktree pooling)**: the context file lives in the parent repo, naturally inherited by every worktree
+- **RFC-0036 (spec-kit bridge + adopter spec-authoring)**: this RFC's context file is one of the artifacts an adopter authors via the spec-kit funnel
+- **RFC-0038 (adopter-defined reviewer extension point)**: adopter-context applies to adopter-defined reviewers too
+- **RFC-0011 (definition-of-ready gate)**: DoR clarification questions can reference adopter-context, validating against the project's domain conventions
+
+## 8. Alternatives Considered
+
+### 8.1 Per-agent override via `.claude/agents/<name>.md`
+
+Already works for cases where one agent type needs full custom prompting. Doesn't address cross-cutting context that applies to ALL plugin-dispatched agents.
+
+### 8.2 Per-ticket inlining
+
+Works but doesn't scale (see §2). Manual content management overhead grows linearly with tickets.
+
+### 8.3 Framework-level "domain pack" registry
+
+Heavier proposal — framework ships pre-curated domain packs (fintech / healthcare / games / etc.) that adopters can register. Too prescriptive at this stage. RFC-0037 stays freeform.
+
+## 9. Open Questions
+
+1. **Cap value**: 500 lines default reasonable, or should it be 1000? Or token-based instead of line-based?
+2. **Path naming**: `.ai-sdlc/project-context.md` vs `.ai-sdlc/CONTEXT.md` vs `.ai-sdlc/adopter-context.md`. Bikeshed.
+3. **Per-agent vs cross-agent**: should the file have sections that target specific agent types (e.g., a `## For reviewers` section that ONLY reviewers see)? Or is the freeform "prepend to all" semantic correct?
+4. **Inheritance from parent file**: should the file support `@include` directives for composing from multiple sources? Or is single-file simplest?
+
+## 10. References
+
+- Existing plugin agent definitions: `ai-sdlc-plugin/agents/developer.md`, `code-reviewer.md`, etc.
+- Existing adopter configuration: `.ai-sdlc/pipeline.yaml`, `.ai-sdlc/agent-role.yaml`
+- Composing RFCs: RFC-0010, RFC-0011, RFC-0036

--- a/spec/rfcs/RFC-0038-adopter-defined-reviewer-extension-point.md
+++ b/spec/rfcs/RFC-0038-adopter-defined-reviewer-extension-point.md
@@ -1,0 +1,170 @@
+---
+id: RFC-0038
+title: Adopter-Defined Reviewer Extension Point
+status: Draft
+lifecycle: Draft
+author: alexanderkline13@gmail.com
+created: 2026-05-19
+updated: 2026-05-19
+targetSpecVersion: v1alpha1
+requires: [RFC-0010, RFC-0037]
+relatedRFCs: [RFC-0014]
+requiresDocs: []
+---
+
+# RFC-0038: Adopter-Defined Reviewer Extension Point
+
+**Status:** Draft
+**Lifecycle:** Draft
+**Author:** alexanderkline13@gmail.com (Product owner contribution)
+**Created:** 2026-05-19
+**Updated:** 2026-05-19
+**Target Spec Version:** v1alpha1
+
+---
+
+## Sign-Off
+
+- [ ] Engineering owner — dominique@reliablegenius.io
+- [ ] Product owner — Alexander Kline
+
+## 1. Summary
+
+The plugin currently ships three reviewer agents (code-reviewer, test-reviewer, security-reviewer) wired into `/ai-sdlc execute` Step 7 fan-out and AISDLC-141's classifier-gated subset. Adopter projects develop domain-specific quality concerns that don't map cleanly onto these three — doc-conformance, compliance, accessibility, narrative consistency, API stability, telemetry instrumentation, etc.
+
+Currently adopters' only options are (a) inline domain-specific concerns into the existing reviewer prompts via project-local `.claude/agents/<name>.md` overrides (couples concerns, hard to evolve independently), or (b) fork the plugin to add a new reviewer agent type (defeats framework value). This RFC proposes a reviewer extension contract: adopters register additional reviewer types via configuration, and the classifier + dispatch pipeline treat them as first-class.
+
+## 2. Motivation
+
+### The reviewer-quality-concern mismatch
+
+The three default reviewers cover **general-purpose software quality**:
+- code-reviewer: structural quality, conventions, anti-patterns
+- test-reviewer: test coverage, test quality
+- security-reviewer: OWASP class concerns, secrets, auth
+
+These are necessary but not sufficient for adopter projects with **domain-specific quality concerns**:
+
+- An adopter shipping architectural documentation needs a reviewer that validates doc-frontmatter, link integrity, currency dates, cross-references
+- An adopter in regulated industries needs a reviewer that scans for PHI / PII / financial-data leakage in dev artifacts
+- An adopter shipping public APIs needs a reviewer that validates breaking-change discipline + semver
+- An adopter shipping accessibility-critical UIs needs a reviewer that runs WCAG validation
+- An adopter shipping telemetry-instrumented services needs a reviewer that validates metric naming + cardinality + retention
+
+In every case, the adopter has crisp, repeatable validation criteria that don't fit the three default reviewers. Forking the plugin or wrapping every dispatch is the wrong answer; the framework should provide the extension contract.
+
+### Why this composes well with the classifier (AISDLC-141)
+
+AISDLC-141 already gates which of the three default reviewers fire based on PR content classification. Adding adopter-defined reviewers to this contract is incremental — the classifier learns to recognize new reviewer-relevant content patterns; the fan-out decision becomes a 0-to-N subset selection across the union of {default reviewers} ∪ {adopter-defined reviewers}.
+
+The classifier's fail-open property (AISDLC-141 AC-4) extends naturally: when classifier confidence falls below threshold, fire ALL reviewers including adopter-defined.
+
+## 3. Goals and Non-Goals
+
+### Goals
+
+- Adopters can register additional reviewer agent types via configuration
+- Adopter-defined reviewers participate in classifier-gated fan-out (AISDLC-141)
+- Adopter-defined reviewer verdicts integrate into existing aggregation gate (Step 8)
+- Verdict shape standardized — adopter reviewers emit the same `{approved, findings, summary}` JSON contract as default reviewers
+- Framework remains agnostic about WHAT adopter-defined reviewers check
+
+### Non-Goals
+
+- Framework prescribing specific adopter-reviewer types (no "compliance-reviewer baked in")
+- Replacing default reviewers (they remain mandatory baseline)
+- Multi-stage reviewer pipelines (each reviewer is single-stage, parallel-with-others)
+- Reviewer-against-reviewer cross-talk during single dispatch (out of scope for this RFC)
+
+## 4. Proposed Mechanism
+
+### 4.1 Adopter reviewer registration
+
+New configuration file: `.ai-sdlc/reviewers.yaml` (composes with `.ai-sdlc/pipeline.yaml`).
+
+Schema:
+
+```yaml
+adopterReviewers:
+  - id: doc-conformance-reviewer
+    agentDefinition: .claude/agents/doc-conformance-reviewer.md
+    classifierKey: docs
+    fanOutWeight: required | optional | classified-only
+    description: "Validates frontmatter standard, cross-link integrity, currency dates"
+
+  - id: accessibility-reviewer
+    agentDefinition: .claude/agents/accessibility-reviewer.md
+    classifierKey: ui
+    fanOutWeight: classified-only
+    description: "Validates WCAG 2.1 AA compliance on touched UI components"
+```
+
+### 4.2 Classifier extension
+
+`cli-classify-pr` (AISDLC-141) extended:
+- Recognizes adopter-defined `classifierKey` values
+- Returns the union subset across default + adopter-defined reviewers
+- `fanOutWeight: required` means "always fire" (overrides classifier subset)
+- `fanOutWeight: optional` means "fire if classifier confidence high"
+- `fanOutWeight: classified-only` means "fire only when classifier explicitly returns this reviewer key"
+
+### 4.3 Verdict aggregation
+
+Adopter-defined reviewer verdicts use the same JSON contract as defaults:
+
+```json
+{
+  "approved": true | false,
+  "findings": [
+    { "severity": "critical|major|minor|suggestion", "file": "...", "line": N, "message": "..." }
+  ],
+  "summary": "..."
+}
+```
+
+Step 8 aggregation in `/ai-sdlc execute` treats adopter-defined reviewer findings identically to default reviewer findings for the CHANGES_REQUESTED vs APPROVED gate decision.
+
+### 4.4 Incremental review (AISDLC-142) composition
+
+The content-hash skip + delta-only logic from AISDLC-142 applies to adopter-defined reviewers identically. Adopters get the same review-reuse savings.
+
+## 5. Backward Compatibility
+
+Fully backward-compatible. Adopters who don't ship `.ai-sdlc/reviewers.yaml` see no behavior change. Default reviewers continue to fire per existing AISDLC-141 logic.
+
+## 6. Composition with Other RFCs
+
+- **RFC-0010 (parallel execution)**: adopter-defined reviewers run in parallel with defaults during Step 7 fan-out
+- **RFC-0014 (dependency graph)**: classifier subset extension is a graph-aware decision (already handles deps); no new graph layer needed
+- **RFC-0037 (adopter project context)**: adopter-defined reviewers inherit the same `.ai-sdlc/project-context.md` prepend as defaults
+- **AISDLC-141 (classifier-gated review)**: this RFC extends the reviewer set the classifier chooses from
+- **AISDLC-142 (incremental review)**: adopter reviewers get same content-hash skip + delta-only treatment
+
+## 7. Alternatives Considered
+
+### 7.1 Per-agent prompt extension via `.claude/agents/<default-reviewer>.md` overrides
+
+Adopters can already override `.claude/agents/code-reviewer.md` etc. to add domain-specific checks. Works for small additions; couples concerns (code quality + accessibility in one reviewer) and makes the override hard to evolve.
+
+### 7.2 Adopter pre-commit / pre-PR scripts
+
+Adopters can wire domain-specific checks via husky / GitHub Actions. Works for binary pass/fail gates but doesn't participate in the classifier-gated dispatch + verdict aggregation model. Loses the reviewer agent's natural-language finding-capture capability.
+
+### 7.3 Plugin extension API
+
+A heavier proposal — register reviewers via a programmatic API rather than configuration. Higher engineering investment; configuration-file approach matches the framework's existing adopter-config conventions.
+
+## 8. Open Questions
+
+1. **Hard cap on reviewer count**: per-PR fan-out at scale (e.g., 10+ adopter-defined reviewers) — should the framework cap this for resource discipline? Or trust the classifier to subset?
+2. **Reviewer registration validation**: should `.ai-sdlc/reviewers.yaml` be schema-validated at dispatch time? Or lazy-loaded only when the agent file is referenced?
+3. **Veto semantics**: should adopter-defined reviewer findings have the same APPROVED/CHANGES_REQUESTED weight as defaults, or be advisory-only by default?
+4. **Cross-adopter reviewer sharing**: should the framework optionally support reviewer-definition sharing (e.g., npm-published reviewer packs) or stay strictly per-adopter-local?
+
+## 9. References
+
+- Existing reviewer agents: `ai-sdlc-plugin/agents/{code,test,security}-reviewer.md`
+- AISDLC-141 classifier implementation: `pipeline-cli/src/cli/classify-pr.ts`
+- AISDLC-142 incremental review: `pipeline-cli/src/cli/incremental-decide.ts`
+- Existing adopter configuration: `.ai-sdlc/pipeline.yaml`, `.ai-sdlc/agent-role.yaml`
+- Related RFCs: RFC-0037 (adopter context), RFC-0010 (parallel execution)

--- a/spec/rfcs/RFC-0039-adopter-defined-pipeline-gate-extension.md
+++ b/spec/rfcs/RFC-0039-adopter-defined-pipeline-gate-extension.md
@@ -1,0 +1,187 @@
+---
+id: RFC-0039
+title: Adopter-Defined Pipeline Gate Extension
+status: Draft
+lifecycle: Draft
+author: alexanderkline13@gmail.com
+created: 2026-05-19
+updated: 2026-05-19
+targetSpecVersion: v1alpha1
+requires: [RFC-0010, RFC-0012]
+relatedRFCs: [RFC-0037, RFC-0038, RFC-0022]
+requiresDocs: []
+---
+
+# RFC-0039: Adopter-Defined Pipeline Gate Extension
+
+**Status:** Draft
+**Lifecycle:** Draft
+**Author:** alexanderkline13@gmail.com (Product owner contribution)
+**Created:** 2026-05-19
+**Updated:** 2026-05-19
+**Target Spec Version:** v1alpha1
+
+---
+
+## Sign-Off
+
+- [ ] Engineering owner — dominique@reliablegenius.io
+- [ ] Product owner — Alexander Kline
+
+## 1. Summary
+
+The `/ai-sdlc execute` Step 0-13 pipeline currently has a fixed gate set: orchestrator state check, dependency preflight, validation, attestation verification, coverage, build, lint, format. Each gate is hardcoded in the slash command body or pipeline-cli. Adopter projects need gates the framework doesn't ship — production-consumer-trace verification, doc-frontmatter currency, CARE-domain content validation, PHI scanning, semver compliance, telemetry-instrumentation completeness.
+
+This RFC proposes a pipeline gate extension contract: adopters register additional gates via configuration, and pipeline-cli invokes them at well-defined stage hooks (post-dev / pre-review / pre-push / pre-merge-flip). The framework defines the interface + invocation timing; the adopter ships the gate logic.
+
+## 2. Motivation
+
+### The gate-discipline mismatch
+
+The framework ships gates for **universally-applicable correctness**:
+- Build / test / lint / format pass
+- Attestation signed (RFC-0010 §13)
+- Dependency preflight satisfied (AISDLC-117)
+- Definition-of-Ready satisfied (RFC-0011)
+- Skip-CI markers absent (AISDLC-88)
+
+These are necessary baseline. Adopters layer additional gates on top for **domain-specific correctness**:
+
+- An adopter committed to architect-doc currency needs a gate that verifies every commit touching a `produces:` code path also bumps the corresponding architect doc's `last_verified` date
+- An adopter in regulated industries needs a gate that scans dev artifacts for PHI / PII before push
+- An adopter shipping a multi-tenant SaaS needs a gate that verifies RLS policies cover every new table
+- An adopter with strict API stability needs a gate that enforces "no breaking changes without ADR + deprecation period"
+- An adopter committed to "no dead wires" (substrate shipped → must have non-test consumer) needs a gate that verifies `consumer: <path:line>` in commit messages
+
+Currently adopters bolt these on via husky hooks or GitHub Actions, which works but:
+- Doesn't compose with the pipeline's structured stage-hooks (gate runs in the wrong place — too early or too late)
+- Doesn't have access to pipeline-cli's stage state (e.g., the classifier decision, the reviewer verdicts)
+- Can't fail-closed with the same operator-friendly error messages the framework's gates produce
+
+### Why this is structurally framework concern
+
+Each adopter's gate logic is adopter-domain (correct). But the **gate invocation contract** is universal — when to fire, what state to expose, how to return pass/fail, how to render the operator-facing failure message. That contract belongs in the framework.
+
+## 3. Goals and Non-Goals
+
+### Goals
+
+- Adopters register additional gates via `.ai-sdlc/gates.yaml`
+- pipeline-cli invokes adopter gates at well-defined stage hooks
+- Adopter gates have read access to pipeline state (current step, classifier decision, reviewer verdicts, dev verifications)
+- Gate failure produces operator-friendly error with recovery instructions (matching framework gate style)
+- Backward-compatible (no `.ai-sdlc/gates.yaml` = no behavior change)
+
+### Non-Goals
+
+- Adopter gates writing to pipeline state (read-only access)
+- Replacing framework gates (defaults remain mandatory)
+- Multi-stage gates that run across pipeline steps (each adopter gate is single-stage)
+- Gates that modify the codebase (those are pre-commit hooks, different layer)
+
+## 4. Proposed Mechanism
+
+### 4.1 Adopter gate registration
+
+`.ai-sdlc/gates.yaml`:
+
+```yaml
+adopterGates:
+  - id: production-consumer-trace
+    stage: pre-push                          # well-known stage hook
+    command: scripts/check-consumer-trace.sh # adopter-provided executable
+    description: "Verify commit messages include 'consumer: <path:line>' for substrate additions"
+    severity: error                          # error | warning
+    skipIf: docs-only                        # optional skip condition (uses classifier output)
+
+  - id: architect-doc-currency
+    stage: post-dev
+    command: tsx scripts/check-architect-doc-currency.ts
+    description: "Bump last_verified on touched produces: paths"
+    severity: warning
+    skipIf: never
+```
+
+### 4.2 Stage hooks
+
+Well-known hooks pipeline-cli invokes adopter gates at:
+
+| Hook | Pipeline step | Pipeline state available |
+|------|---------------|----------------------------|
+| `post-orchestrator-state` | Step 0 end | nothing yet |
+| `post-validation` | Step 1 end | task validated |
+| `post-dev` | Step 6 end | dev output JSON, classifier ready to run |
+| `post-classifier` | Step 7a end | classifier decision known |
+| `post-reviewers` | Step 8 end | reviewer verdicts aggregated |
+| `pre-push` | Step 10 end | task marked Done, verdict file written |
+| `pre-ready-for-review` | Step 13 begin | draft PR open, signed envelope present |
+
+Adopter gates specify which hook to fire at. Multiple gates per hook are sequential (in `.ai-sdlc/gates.yaml` order).
+
+### 4.3 Gate invocation contract
+
+Adopter gate executable receives via environment variables:
+
+```
+AI_SDLC_GATE_STAGE        # the hook this fired at
+AI_SDLC_TASK_ID           # current task being executed
+AI_SDLC_BRANCH            # feature branch name
+AI_SDLC_WORKTREE_PATH     # absolute path to worktree
+AI_SDLC_PIPELINE_STATE    # path to a JSON file with current pipeline state
+                          # (classifier decision, dev verifications, reviewer verdicts)
+```
+
+Exit code: 0 = pass, non-zero = fail. Stderr captured for operator-facing error message.
+
+### 4.4 Failure semantics
+
+`severity: error` failure aborts the pipeline at that step, surfaces stderr to operator, preserves worktree for inspection (matching framework gate behavior).
+
+`severity: warning` failure logs but continues. Useful for soft-warning gates during bootstrap.
+
+### 4.5 Skip conditions
+
+`skipIf: docs-only` — gate skipped when classifier classified the PR as docs-only (no code paths touched).
+
+`skipIf: <classifier-key>` — gate skipped when classifier returned a specific subset.
+
+`skipIf: never` — always run.
+
+## 5. Backward Compatibility
+
+Fully backward-compatible. Adopters who don't ship `.ai-sdlc/gates.yaml` see no behavior change.
+
+## 6. Composition with Other RFCs
+
+- **RFC-0037 (adopter project context)**: adopter gates can read `.ai-sdlc/project-context.md` for context-aware checks
+- **RFC-0038 (adopter-defined reviewers)**: gates run BEFORE or AFTER reviewers depending on stage hook; reviewer findings can inform gate logic
+- **RFC-0022 (compliance posture audit surface)**: adopter compliance gates would naturally compose with the audit-surface model
+- **RFC-0012 (two-tier pipeline architecture)**: gates are second-tier — adopter-defined, optional, composable
+
+## 7. Alternatives Considered
+
+### 7.1 husky / GitHub Actions only
+
+Existing options. Doesn't compose with pipeline-cli's structured state. Wrong layer.
+
+### 7.2 Single mega-script that adopter wires into pre-push
+
+Adopter writes one orchestrating script that does all their domain-specific checks. Loses the per-gate stage-hook + skip-conditions + severity model.
+
+### 7.3 Framework ships a "gate-pack" registry
+
+Heavier proposal — framework curates gate packs adopters can register (e.g., "fintech compliance pack", "healthcare PHI pack"). Useful but premature; RFC-0039 stays adopter-local.
+
+## 8. Open Questions
+
+1. **Concurrent gate execution**: should gates at the same stage hook run in parallel or sequential? Parallel is faster but harder to debug.
+2. **State JSON schema**: what exactly should `AI_SDLC_PIPELINE_STATE` expose? Minimum useful set without over-coupling adopter gates to framework internals.
+3. **Gate timeout**: how long can an adopter gate run before pipeline-cli kills it? Default 30s? Configurable per-gate?
+4. **Gate-against-gate composition**: should adopter gates be able to skip themselves based on other gates' results? Probably no for v1; revisit if it surfaces as adopter pain.
+
+## 9. References
+
+- Existing framework gates: `scripts/check-attestation-sign.sh`, `scripts/check-skip-ci-marker.sh`, `scripts/check-task-moved.sh`
+- pipeline-cli stage structure: `pipeline-cli/src/steps/`
+- Composing RFCs: RFC-0010, RFC-0012, RFC-0037, RFC-0038
+- Related: RFC-0022 (compliance posture)


### PR DESCRIPTION
## Summary

Three Draft RFCs proposing adopter-friendly extension points for the ai-sdlc plugin. All three are framework-agnostic — they define extension contracts the framework provides, not adopter-specific implementations.

Motivated by **production adopter usage** where current framework defaults proved insufficient for domain-specific conventions. The adopter is one of many possible — every adopter project doing real work over time develops:

- Doc taxonomies + architectural primitives
- Domain-specific failure-mode lexicons
- Convention-bearing architect specifications
- Quality concerns beyond the default 3 reviewer scopes
- Pre-PR gates beyond the framework's hardcoded set

## RFCs in this PR

### RFC-0037: Adopter Project Context Inheritance

Standard well-known path (`.ai-sdlc/project-context.md`) that the plugin auto-prepends to developer + reviewer agent system prompts at dispatch time.

Adopter teaches dispatched agents project conventions WITHOUT forking the plugin or inlining context in every ticket body.

### RFC-0038: Adopter-Defined Reviewer Extension Point

Adopters register additional reviewer types via `.ai-sdlc/reviewers.yaml`. The classifier (AISDLC-141) treats adopter-defined reviewers as first-class; the gating decision becomes a subset over `{default reviewers} ∪ {adopter-defined reviewers}`.

Enables doc-conformance / compliance / accessibility / narrative-consistency / etc. reviewers as first-class participants in the dispatch + verdict aggregation pipeline.

### RFC-0039: Adopter-Defined Pipeline Gate Extension

Adopters register additional pipeline gates via `.ai-sdlc/gates.yaml`, invoked at well-defined stage hooks (post-dev / post-classifier / post-reviewers / pre-push / pre-ready-for-review). Gates have read-only access to pipeline state.

Enables adopter-specific gates (production-consumer-trace, architect-doc currency, semver compliance, multi-tenant RLS coverage, etc.) without bolting onto husky/Actions and losing structured pipeline-state access.

## Why three separate RFCs (not one)

Each addresses a distinct extension surface. They compose (e.g., adopter-defined reviewers in RFC-0038 can read context from RFC-0037), but each can ship independently — RFC-0037 alone is valuable; RFC-0038 alone is valuable; RFC-0039 alone is valuable.

## Backward compatibility

All three: fully backward-compatible. Adopters who don't ship the proposed configuration files see no behavior change.

## Composition with existing framework

- **AISDLC-141 (classifier)**: RFC-0038 extends, doesn't replace
- **AISDLC-142 (incremental review)**: RFC-0038 inherits content-hash skip + delta-only treatment
- **RFC-0010 (worktree pooling)**: adopter context inherits naturally per-worktree
- **RFC-0011 (DoR gate)**: RFC-0037 context can inform DoR clarification questions
- **RFC-0012 (two-tier pipeline)**: all three RFCs are second-tier
- **RFC-0036 (spec-kit bridge)**: RFC-0037's context file is an artifact adopters author via the spec-kit funnel

## What this PR does NOT do

- No implementation. Specs only.
- No code/agent/script changes in plugin/pipeline-cli.
- No prescription of WHAT adopters put in their override files — that's adopter scope.

## Asking for

Engineering review (dominique@reliablegenius.io) on:
1. Are these the right three extension points (vs. one, vs. five)?
2. Do the proposed configuration file paths fit the framework's `.ai-sdlc/` convention?
3. Should RFC-0037 wait for RFC-0036's spec-kit bridge to land, or can it ship independently?
4. Is the classifier integration approach in RFC-0038 the right composition pattern?

## CI bypass note

Committed with `--no-verify` because pre-commit typecheck fails on `conformance/runner/src/behavioral.ts` (missing `@ai-sdlc/orchestrator` dist — pre-existing build state, unrelated to these markdown-only RFC additions). Per the framework's CLAUDE.md docs-only exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)