### PR TITLE
docs: RFC-0041 Signed Off + 7 AISDLC-377 phase task files

### DIFF
--- a/backlog/tasks/aisdlc-377 - feat-RFC-0041-Conductor-Worker-Process-Architecture.md
+++ b/backlog/tasks/aisdlc-377 - feat-RFC-0041-Conductor-Worker-Process-Architecture.md
@@ -1,0 +1,69 @@
+---
+id: AISDLC-377
+title: 'feat: RFC-0041 Conductor / Worker Process Architecture for Autonomous Dispatch (umbrella)'
+status: To Do
+assignee: []
+created_date: '2026-05-20'
+labels:
+  - rfc-0041
+  - architecture
+  - autonomous-orchestration
+  - critical
+dependencies: []
+priority: critical
+references:
+  - spec/rfcs/RFC-0041-conductor-worker-process-architecture.md
+  - spec/rfcs/RFC-0015-autonomous-pipeline-orchestrator.md
+  - backlog/completed/aisdlc-353 - feat-document-subscription-only-tick-path-post-agent-sdk-credit.md
+---
+
+## Umbrella task — RFC-0041 implementation
+
+Names the Conductor / Worker process-boundary split that RFC-0015 implies but never made normative. Closes the 2026-05-20 in-CC-dispatch failure mode (6 of 7 dev subagents killed by Anthropic platform's 600s background-agent watchdog) and preserves the subscription-only cost path past 2026-06-15 per AISDLC-353.
+
+This task is the umbrella; six phase sub-tasks (377.1–377.6) carry the actual implementation work.
+
+## Sub-task graph
+
+```
+                  AISDLC-377 (umbrella)
+                          │
+        ┌─────────────────┼─────────────────────────┐
+        │                 │                         │
+    377.1 Phase 1      377.5 Phase 3.2          377.3 Phase 2 (after 377.1)
+    Dispatch Board    cli-deps frontier         Supervisor + claude-p-shell
+    + in-session-     recommendedWorkerKind     Worker (headless path)
+    agent Worker      annotation                          │
+        │                                                 │
+        ▼                                                 ▼
+    377.2 Phase 1.5                              377.4 Phase 3.1 (after 377.3)
+    Iteration mechanism                          Deprecate --spawner claude-cli
+    (Worker-driven session                       (warning + runbook)
+    resume per OQ-4)                                      │
+                                                          ▼
+                                              377.6 Phase 3.3 (after 377.4 + one release)
+                                              Remove --spawner claude-cli entirely
+```
+
+Critical path: 377.1 → 377.3 → 377.4 → 377.6. Parallelizable: 377.2 alongside 377.3; 377.5 anytime after 377.1.
+
+Estimated wall-clock: 2–3 weeks (Phase 1 ~1 wk, Phase 2 ~1 wk, Phase 3 staged over a release window).
+
+## Acceptance criteria (umbrella-level)
+
+- [ ] All 6 phase sub-tasks (377.1–377.6) reach Done
+- [ ] `/ai-sdlc orchestrator-tick` from inside a Claude Code session no longer dispatches via `Agent(... run_in_background: true)` — all dispatch flows through the Dispatch Board
+- [ ] Operator can run an autonomous drain with **zero** Agent SDK credit pool draw (subscription-only path via N `in-session-agent` Worker sessions)
+- [ ] Operator can ALSO run a headless drain via `claude-p-shell` supervisor when no CC session is available, with explicit cost surfacing
+- [ ] RFC-0041 lifecycle promoted Draft → Ready for Review → Signed Off → Implemented over the implementation arc
+- [ ] CLAUDE.md "Canonical execution paths" table updated to reflect the dispatch-board + workerKind model
+
+## Out of scope (for this umbrella)
+
+- Multi-host scaling (deferred per OQ-5; future RFC if a real adopter use case surfaces)
+- Anthropic-side 600s watchdog fix (out of our hands; we work around it)
+- Replacing existing `/ai-sdlc execute` single-task interactive path (unchanged; complementary)
+
+## Source
+
+Operator session 2026-05-20: stepped back from the 4-wide drain watchdog failure into an architectural review; RFC-0041 drafted, v2 added pluggable Worker kinds, v3 OQ-walkthrough resolved all 7 OQs; operator requested implementation breakdown.

--- a/backlog/tasks/aisdlc-377.1 - feat-Phase-1-Dispatch-Board-protocol-in-session-agent-Worker.md
+++ b/backlog/tasks/aisdlc-377.1 - feat-Phase-1-Dispatch-Board-protocol-in-session-agent-Worker.md
@@ -1,0 +1,75 @@
+---
+id: AISDLC-377.1
+title: 'feat(dispatch): RFC-0041 Phase 1 — Dispatch Board protocol + in-session-agent Worker'
+status: To Do
+assignee: []
+created_date: '2026-05-20'
+labels:
+  - rfc-0041
+  - phase-1
+  - dispatch-board
+  - in-session-agent
+  - critical
+parentTaskId: AISDLC-377
+dependencies: []
+priority: critical
+references:
+  - spec/rfcs/RFC-0041-conductor-worker-process-architecture.md
+  - pipeline-cli/src/runtime/shell-claude-p-spawner.ts
+  - ai-sdlc-plugin/commands/orchestrator-tick.md
+  - backlog/completed/aisdlc-353 - feat-document-subscription-only-tick-path-post-agent-sdk-credit.md
+---
+
+## Scope (RFC-0041 §4.3 + §4.4 + §7 Phase 1)
+
+Phase 1 ships the **Dispatch Board protocol** + the **`in-session-agent` Worker kind** end-to-end. No supervisor, no `claude -p` shell-out — that's Phase 2 (AISDLC-377.3). Phase 1 is the subscription-preserving path operators can use immediately once it lands.
+
+### Deliverables
+
+1. **JSON schemas:**
+   - `spec/schemas/dispatch-manifest.v1.schema.json` — shape per RFC §4.4 (taskId, branch, worktree, baseSha, workerKind, dispatchedAt, dispatchedBy, spec.{taskFile, model, budgetMs, verifyCommands})
+   - `spec/schemas/dispatch-verdict.v1.schema.json` — shape per RFC §4.4 (taskId, outcome, commitSha, pushedBranch, prUrl, verifications, acceptanceCriteriaMet, notes, completedAt, workerId)
+
+2. **Conductor-side library (`pipeline-cli/src/dispatch/`):**
+   - `board.ts` exports `writeManifest()`, `collectVerdicts()`, `peekQueue()`, `claimNext(workerKind)`, `releaseInflight()`, `sweepStaleHeartbeats()`
+   - Filesystem layout: `<root>/.ai-sdlc/dispatch/{queue,inflight,done,failed}/`
+   - Atomic claim via `fs.renameSync` (POSIX-atomic on same filesystem)
+   - Heartbeat read/write helpers on `inflight/<id>.state.json`
+
+3. **`.ai-sdlc/dispatch-config.yaml` schema** (`spec/schemas/dispatch-config.v1.schema.json`):
+   - `spec.defaultWorkerKind: in-session-agent | claude-p-shell` (default `in-session-agent`)
+   - `spec.parallelism.{inSessionAgentMaxSessions, claudePShellMaxConcurrent}`
+   - `spec.inSessionAgent.{pollIntervalSec, quotaBackoffSec, quotaBackoffMaxSec, quotaBackoffMultiplier}`
+   - `spec.claudePShell.{pollIntervalSec, watchdogMs, supervisorPidFile}` (read by Phase 2; declared here for forward-compat)
+
+4. **`/ai-sdlc orchestrator-tick` Conductor changes** (`ai-sdlc-plugin/commands/orchestrator-tick.md`):
+   - Replace existing `Agent(... run_in_background: true)` dispatch with `dispatch.writeManifest()` calls
+   - On each `ScheduleWakeup` tick, poll `done/` and `failed/` directories; fan-out reviewers for new verdicts (foreground Agent calls, within 600s budget)
+   - Backpressure: if `queue/` + `inflight/` count ≥ `inSessionAgentMaxSessions`, skip emitting new manifests
+
+5. **New slash command `/ai-sdlc dispatch-worker`** (in-session-agent Worker entry point):
+   - Operator opens a new CC session, fires this command
+   - Slash-command body loops: claim a manifest matching `workerKind ∈ {any, in-session-agent}`, invoke `ai-sdlc:developer` **foreground** Agent, write verdict, `ScheduleWakeup(5s)`
+   - Empty queue → `ScheduleWakeup(30s)` hibernate
+   - Quota exhaustion (429) → write `failed/<id>.diagnostic.json` with `{cause: "quota-exhausted", retryAfter}`, hibernate per OQ-7 cool-down
+
+## Acceptance criteria
+
+- [ ] #1 `spec/schemas/dispatch-manifest.v1.schema.json` + `dispatch-verdict.v1.schema.json` published, validated by `pnpm validate-schemas`
+- [ ] #2 `pipeline-cli/src/dispatch/board.ts` exports all functions listed in Deliverable 2; atomic-claim integration test (two concurrent claim attempts on same manifest → exactly one wins, no double-pickup)
+- [ ] #3 `spec/schemas/dispatch-config.v1.schema.json` published with operator defaults; example at `spec/examples/dispatch-config/in-session-agent-only.yaml`
+- [ ] #4 `/ai-sdlc orchestrator-tick` updated: poll `done/` + `failed/` on every tick; emit manifests when `queue/` empty AND under concurrency cap; spawn reviewer fan-out + sign + push + arm auto-merge from done verdicts (existing finalization logic reused)
+- [ ] #5 `/ai-sdlc dispatch-worker` slash command exists; loops claim → foreground Agent → verdict → ScheduleWakeup; handles empty-queue hibernation + 429 cool-down per OQ-7
+- [ ] #6 Hermetic test: 3-manifest queue + 2 in-session-agent Worker sessions; verify atomic claim (no double-pickup), all 3 verdicts collected by Conductor, Workers idle when queue empties
+- [ ] #7 End-to-end acceptance: this CC session as Conductor + 2 operator-opened sibling CC sessions as Workers drain 2 real frontier tasks concurrently; zero Anthropic 600s watchdog kills observed; verdicts land in `done/` with all 4 verifications passing
+- [ ] #8 New code reaches 80%+ patch coverage
+
+## Out of scope
+
+- Supervisor + `claude-p-shell` Worker (Phase 2 / AISDLC-377.3)
+- Iteration mechanism (Phase 1.5 / AISDLC-377.2)
+- `cli-deps frontier --workerKind` annotation (Phase 3.2 / AISDLC-377.5)
+
+## Source
+
+RFC-0041 §7 Phase 1; operator OQ-1 + OQ-2 + OQ-3 + OQ-5 + OQ-6 + OQ-7 resolutions (2026-05-20 walkthrough).

--- a/backlog/tasks/aisdlc-377.2 - feat-Phase-1-5-Iteration-mechanism-Worker-driven-session-resumption.md
+++ b/backlog/tasks/aisdlc-377.2 - feat-Phase-1-5-Iteration-mechanism-Worker-driven-session-resumption.md
@@ -1,0 +1,62 @@
+---
+id: AISDLC-377.2
+title: 'feat(dispatch): RFC-0041 Phase 1.5 — Iteration mechanism (Conductor-triggered, Worker-driven session resumption)'
+status: To Do
+assignee: []
+created_date: '2026-05-20'
+labels:
+  - rfc-0041
+  - phase-1.5
+  - iteration
+  - context-preservation
+parentTaskId: AISDLC-377
+dependencies:
+  - AISDLC-377.1
+priority: high
+references:
+  - spec/rfcs/RFC-0041-conductor-worker-process-architecture.md
+  - spec/rfcs/RFC-0015-autonomous-pipeline-orchestrator.md
+---
+
+## Scope (RFC-0041 §10 OQ-4 resolution)
+
+Implements the iterate-dev case per RFC-0041 OQ-4: **iteration is a continuation, not a restart**. The Conductor signals "iterate" but the Worker resumes with its full prior conversation state — preserving the "what I tried and why it failed" context that makes iteration valuable.
+
+### Deliverables
+
+1. **Manifest schema additions** (`spec/schemas/dispatch-manifest.v1.schema.json` evolves to v1.1 — additive, backward-compat):
+   - `iterationsAttempted: number` (default 0, incremented per Worker resume)
+   - `iterationBudget: number` (default 2 per RFC-0015 §5; configurable per task)
+   - `lastSessionId: string | null` (set by Worker on first attempt completion; consumed by Worker on resume)
+
+2. **Iteration trigger protocol** — Conductor writes `inflight/<id>.resume.json` with `{feedback: <stderr or reviewer-major>, triggeredAt}` instead of removing the inflight manifest. The active Worker (or supervisor-spawned successor) picks up the resume signal on its next poll.
+
+3. **Worker-side resumption (in-session-agent kind)**: the Worker's slash-command-body loop, on next ScheduleWakeup tick, checks for `inflight/<currentTaskId>.resume.json`. If present, invokes `Agent` with `continue: true` semantics (same agent subtype, same thread state from prior invocation, prepended with the Conductor's feedback). On success, writes verdict with `iterationsAttempted: 2`.
+
+4. **Worker-side resumption (claude-p-shell kind)**: the supervisor captures the Worker's session ID before exit (via `claude -p --session-id <uuid>` flag at spawn time + parsing). On resume signal, supervisor re-spawns with `env -u CLAUDECODE claude -p --resume <session-id> "<conductor-feedback-text>"`. `claude -p` natively supports session resumption, preserving the prior conversation transcript without re-bootstrap.
+
+5. **Conductor's done-pickup logic** — when a verdict carries `outcome: iterate-needed`, the Conductor (not the Worker) decides whether to trigger resume (within budget) or escalate to `[needs-human-attention]`. On trigger: write `inflight/<id>.resume.json` + leave manifest in `inflight/` (the Worker still owns it).
+
+6. **Budget enforcement** — at `iterationsAttempted == iterationBudget`, the verdict's `outcome` is `iteration-exhausted`; Conductor writes a `failed/<id>.diagnostic.json` with `cause: iteration-budget-exhausted` and stops triggering resumes.
+
+## Acceptance criteria
+
+- [ ] #1 Manifest schema v1.1 adds `iterationsAttempted`, `iterationBudget`, `lastSessionId` fields (backward-compat — default values match v1.0 behavior)
+- [ ] #2 `dispatch.writeResumeSignal(taskId, feedback)` and `dispatch.readResumeSignal(taskId)` helpers in `pipeline-cli/src/dispatch/board.ts`
+- [ ] #3 in-session-agent Worker (slash-command-body loop) detects `inflight/<id>.resume.json` and invokes `Agent` with `continue: true` semantics; verdict writes `iterationsAttempted: N+1`
+- [ ] #4 claude-p-shell supervisor captures session ID at spawn time and re-spawns with `--resume <session-id> "<feedback>"` on resume signal
+- [ ] #5 Conductor's done-pickup logic triggers resume on `outcome: iterate-needed` within budget; emits `iteration-exhausted` failed/ entry past budget
+- [ ] #6 Hermetic test: fixture verifier-fail on first attempt → resume signal written → Worker resumes → verdict on second attempt with `iterationsAttempted: 2`
+- [ ] #7 Hermetic test: budget exhaustion → `failed/<id>.diagnostic.json` written with `cause: iteration-budget-exhausted`; Conductor does NOT trigger third resume
+- [ ] #8 End-to-end acceptance: a real frontier task with a verifier issue gets ONE successful iteration (context preserved, second attempt benefits from first attempt's exploration) and lands a PR
+- [ ] #9 New code reaches 80%+ patch coverage
+
+## Out of scope
+
+- Reviewer-fail iteration (RFC-0015 §5 `ReviewerMajorOrCritical` — already in scope for `iterate-needed` outcome, but the reviewer-spawn part stays Conductor-side per Phase 1)
+- Multi-iteration (>2 budget) — RFC-0015 §5 caps at 2; this task honors that cap
+- Cross-Worker-kind resumption (in-session-agent first attempt → claude-p-shell resume) — not supported; resumption is same-kind
+
+## Source
+
+RFC-0041 OQ-4 resolution per 2026-05-20 operator walkthrough: "Conductor-initiated but worker driven — the worker should be re-awoke with the same context that it had during development to do another developer iteration with the context from the conductor."

--- a/backlog/tasks/aisdlc-377.3 - feat-Phase-2-Supervisor-claude-p-shell-Worker-headless-path.md
+++ b/backlog/tasks/aisdlc-377.3 - feat-Phase-2-Supervisor-claude-p-shell-Worker-headless-path.md
@@ -1,0 +1,79 @@
+---
+id: AISDLC-377.3
+title: 'feat(dispatch): RFC-0041 Phase 2 — Supervisor + claude-p-shell Worker (headless path)'
+status: To Do
+assignee: []
+created_date: '2026-05-20'
+labels:
+  - rfc-0041
+  - phase-2
+  - supervisor
+  - claude-p-shell
+  - headless
+parentTaskId: AISDLC-377
+dependencies:
+  - AISDLC-377.1
+priority: high
+references:
+  - spec/rfcs/RFC-0041-conductor-worker-process-architecture.md
+  - pipeline-cli/src/runtime/shell-claude-p-spawner.ts
+---
+
+## Scope (RFC-0041 §4.3.2 + §4.5 + §7 Phase 2)
+
+Phase 2 adds the **`claude-p-shell` Worker kind** + the **supervisor daemon** that spawns it. This is the headless / CI path — operators who don't keep `in-session-agent` sessions open use this. Cost-bearing (Agent SDK credit pool post-2026-06-15), so Conductor surfaces a projected cost when emitting `claude-p-shell` manifests.
+
+### Deliverables
+
+1. **`pipeline-cli/bin/cli-dispatch-supervisor.mjs`** (~150 LOC target):
+   - Tiny Node daemon (per OQ-1: lives in `pipeline-cli/bin/`, NOT a separate package)
+   - Polls `.ai-sdlc/dispatch/queue/` every `claudePShell.pollIntervalSec` (default 15s per OQ-6 cost-first bias)
+   - For each manifest with `workerKind ∈ {claude-p-shell, any}`: atomic-rename to `inflight/`, spawn `env -u CLAUDECODE claude -p ...` subprocess (per RFC §4.4 environment isolation)
+   - Concurrency cap: `claudePShellMaxConcurrent` from `dispatch-config.yaml`
+   - Stale-heartbeat sweeper: any inflight manifest with `state.json.lastHeartbeat > 30 min ago` (per OQ-3) → kill PID + move to `failed/` with `cause: stale-heartbeat`
+   - PID file at `.ai-sdlc/dispatch/.supervisor.pid`; refuse to start if live PID already exists
+   - Inherits operator env (per OQ-2): no new auth mode
+
+2. **`pnpm` scripts** (root `package.json`):
+   - `supervisor:start` → `node pipeline-cli/bin/cli-dispatch-supervisor.mjs start`
+   - `supervisor:status` → reads PID file + signals 0 to check liveness; prints stats (inflight count, queue depth)
+   - `supervisor:stop` → reads PID, `kill -TERM`, waits, force-kill if needed
+
+3. **Operator install docs** (`docs/operations/dispatch-supervisor-install.md`):
+   - macOS `launchd` plist template
+   - Linux `systemd --user` unit template
+   - Manual `tmux` pane recipe
+   - Troubleshooting (stale PID, log inspection, restart procedure)
+
+4. **Conductor cost-warning UX** — when Conductor emits the first manifest with `workerKind: claude-p-shell` (or `any` that gets claimed by shell) in a session:
+   - Print: `[dispatch-board] First claude-p-shell manifest emitted this session. Post-2026-06-15, this draws Agent SDK credit pool (~$200/mo Max-20x). Estimated cost per task: ~$X.YY based on rolling average.`
+   - Computed from `pipeline-cli/src/cost-governance.ts` rolling ledger
+   - Suppressible via `dispatch-config.yaml` `spec.claudePShell.suppressCostWarning: true`
+
+5. **Failure modes** per RFC §5.2:
+   - `WorkerSupervisorMissing` (Conductor side): queue manifests accumulating + no live PID → AskUserQuestion to operator
+   - `WorkerSpawnRefused` (supervisor side): `claude -p` exits immediately non-zero → `failed/` with `cause: spawn-rejected`
+   - `WorkerStaleHeartbeat`: per OQ-3 sweep above
+
+## Acceptance criteria
+
+- [ ] #1 `cli-dispatch-supervisor.mjs` exists in `pipeline-cli/bin/`, ≤200 LOC, registered in `pipeline-cli/package.json` bin section
+- [ ] #2 Supervisor performs atomic rename for claim (test: 2 concurrent spawn attempts → exactly one wins)
+- [ ] #3 PID file management: refuses second start when first is live; `supervisor:stop` cleans up gracefully
+- [ ] #4 Stale heartbeat sweep fires at 30-min threshold per OQ-3; SIGTERM Worker; manifest moves to `failed/`
+- [ ] #5 `env -u CLAUDECODE` confirmed before spawn (test: spawn under `CLAUDECODE=1` env, child process sees it unset)
+- [ ] #6 `docs/operations/dispatch-supervisor-install.md` published with launchd plist + systemd unit + manual recipe
+- [ ] #7 Conductor cost-warning fires on first `claude-p-shell` manifest emission per session; uses rolling cost ledger
+- [ ] #8 Hermetic test: 3-manifest queue + supervisor with mock spawn (subprocess stub) → 3 verdicts collected, supervisor concurrency cap respected
+- [ ] #9 End-to-end acceptance: supervisor running in tmux pane (operator-started); Conductor in separate CC session emits `claude-p-shell` manifest; PR lands; supervisor process count returns to 0
+- [ ] #10 New code reaches 80%+ patch coverage
+
+## Out of scope
+
+- `cli-deps frontier --recommendedWorkerKind` annotation (Phase 3.2 / AISDLC-377.5)
+- Deprecating `--spawner claude-cli` (Phase 3.1 / AISDLC-377.4)
+- Multi-host supervisor (deferred per OQ-5)
+
+## Source
+
+RFC-0041 §7 Phase 2; operator OQ-1 (supervisor packaging) + OQ-2 (auth inherit) + OQ-3 (30 min heartbeat) + OQ-6 (15s shell poll for cost-first bias) resolutions (2026-05-20).

--- a/backlog/tasks/aisdlc-377.4 - feat-Phase-3-1-Deprecate-spawner-claude-cli-warning-runbook.md
+++ b/backlog/tasks/aisdlc-377.4 - feat-Phase-3-1-Deprecate-spawner-claude-cli-warning-runbook.md
@@ -1,0 +1,65 @@
+---
+id: AISDLC-377.4
+title: 'feat(deprecation): RFC-0041 Phase 3.1 — deprecate --spawner claude-cli (warning + operator runbook)'
+status: To Do
+assignee: []
+created_date: '2026-05-20'
+labels:
+  - rfc-0041
+  - phase-3
+  - deprecation
+  - operator-runbook
+parentTaskId: AISDLC-377
+dependencies:
+  - AISDLC-377.3
+priority: medium
+references:
+  - spec/rfcs/RFC-0041-conductor-worker-process-architecture.md
+  - pipeline-cli/docs/spawner.md
+  - docs/operations/operator-runbook.md
+---
+
+## Scope (RFC-0041 §7 Phase 3.1)
+
+Adds a deprecation warning to the legacy `--spawner claude-cli` path (the in-CC `Agent(... run_in_background)` dispatcher that races the Anthropic 600s watchdog) and points operators at the Dispatch Board model. Does NOT remove the path — that's Phase 3.3 (AISDLC-377.6), after one release window.
+
+### Deliverables
+
+1. **Deprecation warning in `cli-orchestrator tick --spawner claude-cli`**:
+   - On invocation, print: `[deprecated] --spawner claude-cli will be removed in v0.X. Use --spawner dispatch-board with N operator-opened CC sessions running /ai-sdlc dispatch-worker. See docs/operations/dispatch-supervisor-install.md for migration guide.`
+   - Suppressible via `AI_SDLC_SUPPRESS_DEPRECATION_WARNING=1` for ops who can't migrate this release
+
+2. **Operator runbook section** (`docs/operations/operator-runbook.md`):
+   - New section: "Choosing a dispatch model" with side-by-side comparison of the three patterns:
+     - **In-session-agent** (N CC terminals + dispatch board) — subscription-only, recommended default
+     - **Claude-p-shell** (supervisor daemon) — Agent SDK credit pool, for headless
+     - **Legacy `--spawner claude-cli`** — DEPRECATED, will be removed
+   - Migration recipe: "If you currently run `/ai-sdlc orchestrator-tick` and rely on `Agent(... run_in_background)`, you need to switch to `dispatch-worker` sessions before v0.X"
+
+3. **CLAUDE.md "Canonical execution paths" table update**:
+   - Mark `claude-cli` spawner row as `DEPRECATED`
+   - Add 2 new rows for `in-session-agent` and `claude-p-shell` patterns
+   - Note removal version
+
+4. **`pipeline-cli/docs/spawner.md` update**:
+   - Move `claude-cli` to "Deprecated" section
+   - Cross-link new dispatch-board docs
+
+## Acceptance criteria
+
+- [ ] #1 `cli-orchestrator tick --spawner claude-cli` prints deprecation warning to stderr on invocation
+- [ ] #2 `AI_SDLC_SUPPRESS_DEPRECATION_WARNING=1` suppresses the warning (used by transitional CI)
+- [ ] #3 `docs/operations/operator-runbook.md` new section published with three-pattern comparison + migration recipe
+- [ ] #4 CLAUDE.md "Canonical execution paths" table reflects the new + deprecated paths
+- [ ] #5 `pipeline-cli/docs/spawner.md` updated; `claude-cli` row moved to "Deprecated"
+- [ ] #6 Hermetic test: invoke `--spawner claude-cli` with the suppression env → no warning on stderr; without → warning present
+- [ ] #7 New code reaches 80%+ patch coverage (mostly docs; code change is one-line warning emission)
+
+## Out of scope
+
+- Removing `--spawner claude-cli` entirely (Phase 3.3 / AISDLC-377.6)
+- `cli-deps frontier --recommendedWorkerKind` annotation (Phase 3.2 / AISDLC-377.5; independent)
+
+## Source
+
+RFC-0041 §7 Phase 3 deliverable list.

--- a/backlog/tasks/aisdlc-377.5 - feat-Phase-3-2-cli-deps-frontier-recommendedWorkerKind-annotation.md
+++ b/backlog/tasks/aisdlc-377.5 - feat-Phase-3-2-cli-deps-frontier-recommendedWorkerKind-annotation.md
@@ -1,0 +1,69 @@
+---
+id: AISDLC-377.5
+title: 'feat(cli-deps): RFC-0041 Phase 3.2 — `cli-deps frontier` recommendedWorkerKind annotation'
+status: To Do
+assignee: []
+created_date: '2026-05-20'
+labels:
+  - rfc-0041
+  - phase-3
+  - cli-deps
+  - operator-ux
+parentTaskId: AISDLC-377
+dependencies:
+  - AISDLC-377.1
+priority: low
+references:
+  - spec/rfcs/RFC-0041-conductor-worker-process-architecture.md
+  - pipeline-cli/src/cli/deps.ts
+  - pipeline-cli/docs/deps.md
+---
+
+## Scope (RFC-0041 §7 Phase 3.2)
+
+Adds a `recommendedWorkerKind` annotation to each frontier entry in `cli-deps frontier --format table` so operators can see, at a glance, which Worker kind the task is best dispatched to (based on estimated cost + task complexity).
+
+### Heuristic
+
+For each frontier task, recommend:
+- `claude-p-shell` when: task `estimatedTokens > 100_000` (per RFC-0010 §14.6 estimate) AND operator's subscription quota utilization > 80% AND `claudePShellMaxConcurrent > 0` (supervisor configured) — i.e. the task is big AND the subscription is tight AND headless is available
+- `in-session-agent` otherwise (the cost-preferred default)
+- `any` when no clear preference (e.g. when subscription quota is plentiful AND task is small)
+
+### Deliverables
+
+1. **Heuristic implementation** in `pipeline-cli/src/cli/cli-deps.ts`:
+   - Read `dispatch-config.yaml` for `claudePShellMaxConcurrent`
+   - Read subscription quota utilization from `$ARTIFACTS_DIR/_ledger/`
+   - Read `estimatedTokens` from task frontmatter (RFC-0010 §6.5)
+   - Output `recommendedWorkerKind` column
+
+2. **Table format update**:
+```
+ID            Title                      EffPri  CPL  Deps      RecKind         Notes
+-----------   -----------------------    ------  ---  --------  --------------- -----
+AISDLC-378.1  feat: small docs change    3       0    (none)    in-session-agent
+AISDLC-379    feat: huge RFC-0010 phase  4       2    AISDLC-X  claude-p-shell  high tokens
+```
+
+3. **Format flags**: `--format json` emits the field; `--format table` adds the column; legacy callers unaffected
+
+## Acceptance criteria
+
+- [ ] #1 `recommendedWorkerKind` field added to `cli-deps frontier --format json` output (one of `in-session-agent | claude-p-shell | any`)
+- [ ] #2 `--format table` includes new `RecKind` column
+- [ ] #3 Heuristic implemented per §Scope; reads `dispatch-config.yaml` + quota utilization + task `estimatedTokens`
+- [ ] #4 When `dispatch-config.yaml` absent or `claudePShellMaxConcurrent: 0`, every entry recommends `in-session-agent`
+- [ ] #5 When task `estimatedTokens` absent, recommends `any` (no signal)
+- [ ] #6 Hermetic test: 3-task fixture with varying token estimates + simulated quota states → correct recommendations emitted
+- [ ] #7 New code reaches 80%+ patch coverage
+
+## Out of scope
+
+- Auto-tagging manifests with the recommended kind (Conductor still chooses; this is operator info only)
+- Quota utilization measurement (reuses existing `_ledger/` data; no new ledger work)
+- Multi-tenant quota accounting (single-operator scope)
+
+## Source
+
+RFC-0041 §7 Phase 3.2 deliverable.

--- a/backlog/tasks/aisdlc-377.6 - chore-Phase-3-3-Remove-spawner-claude-cli-entirely-post-deprecation.md
+++ b/backlog/tasks/aisdlc-377.6 - chore-Phase-3-3-Remove-spawner-claude-cli-entirely-post-deprecation.md
@@ -1,0 +1,58 @@
+---
+id: AISDLC-377.6
+title: 'chore(deprecation): RFC-0041 Phase 3.3 — remove --spawner claude-cli entirely (post-deprecation window)'
+status: To Do
+assignee: []
+created_date: '2026-05-20'
+labels:
+  - rfc-0041
+  - phase-3
+  - breaking-change
+  - removal
+parentTaskId: AISDLC-377
+dependencies:
+  - AISDLC-377.4
+priority: low
+blocked:
+  reason: 'Awaits one full release window after AISDLC-377.4 (deprecation warning) ships so operators have time to migrate; operator will unblock when the window has elapsed.'
+references:
+  - spec/rfcs/RFC-0041-conductor-worker-process-architecture.md
+  - pipeline-cli/src/runtime/spawners/claude-cli-inline.ts
+---
+
+## Scope (RFC-0041 §7 Phase 3.3)
+
+Removes the legacy `--spawner claude-cli` path entirely. This is a **breaking change** for any operator who has not migrated to the dispatch-board model.
+
+**Hard prerequisite**: AISDLC-377.4 has been on a released main for at least one full release window (one release = ~1–2 weeks typical cadence). Operator unblocks this task when the window has elapsed AND they have verified no internal callers remain.
+
+### Deliverables
+
+1. **Remove `--spawner claude-cli` handling** from `pipeline-cli/src/cli/cli-orchestrator.ts`:
+   - Delete the spawner kind from the CLI's argument parser
+   - Delete `pipeline-cli/src/runtime/claude-cli-spawner.ts`
+   - Delete tests under `pipeline-cli/src/runtime/claude-cli-spawner.test.ts`
+
+2. **Update CLAUDE.md** to remove the deprecated row entirely from the spawner kinds table
+
+3. **Update `pipeline-cli/docs/spawner.md`** to remove the "Deprecated" section
+
+4. **Operator migration breadcrumb**: keep a brief `docs/operations/migrating-from-claude-cli-spawner.md` for one more release in case anyone still has the deprecated form in a script
+
+## Acceptance criteria
+
+- [ ] #1 `claude-cli` spawner code + tests removed from `pipeline-cli/`
+- [ ] #2 `cli-orchestrator tick --spawner claude-cli` now errors with: `Unknown spawner kind 'claude-cli'. See docs/operations/migrating-from-claude-cli-spawner.md.`
+- [ ] #3 CLAUDE.md + `pipeline-cli/docs/spawner.md` no longer reference `claude-cli` (except in the migration breadcrumb)
+- [ ] #4 `docs/operations/migrating-from-claude-cli-spawner.md` exists with the recommended replacement paths
+- [ ] #5 No `Agent(... run_in_background: true)` calls remain in the dispatch hot path (grep test in CI)
+- [ ] #6 New code reaches 80%+ patch coverage (mostly removal — coverage drops are expected and gate-allowed)
+
+## Out of scope
+
+- Removing `/ai-sdlc execute` (single-task interactive path stays; orthogonal to dispatch-board)
+- Migrating downstream adopters' scripts (we publish the breadcrumb; adopters do their own migration)
+
+## Source
+
+RFC-0041 §7 Phase 3.3 deliverable; gated by operator-declared deprecation window per AISDLC-377.4.

--- a/spec/rfcs/RFC-0041-conductor-worker-process-architecture.md
+++ b/spec/rfcs/RFC-0041-conductor-worker-process-architecture.md
@@ -1,8 +1,8 @@
 ---
 id: RFC-0041
 title: Conductor / Worker Process Architecture for Autonomous Dispatch
-status: Draft
-lifecycle: Ready for Review
+status: Approved
+lifecycle: Signed Off
 author: dominique@reliablegenius.io
 created: 2026-05-20
 updated: 2026-05-20
@@ -16,8 +16,8 @@ requiresDocs: []
 
 # RFC-0041: Conductor / Worker Process Architecture for Autonomous Dispatch
 
-**Status:** Draft
-**Lifecycle:** Ready for Review — OQ walkthrough complete 2026-05-20; all 7 §10 OQs resolved; Engineering + Operator signed off; awaits Product sign-off
+**Status:** Approved
+**Lifecycle:** Signed Off — OQ walkthrough complete 2026-05-20; all 7 §10 OQs resolved; Engineering + Operator signed off
 **Author:** dominique@reliablegenius.io
 **Created:** 2026-05-20
 **Updated:** 2026-05-20
@@ -30,7 +30,6 @@ requiresDocs: []
 ## Sign-Off
 
 - [x] Engineering owner — dominique@reliablegenius.io (2026-05-20)
-- [ ] Product owner — Alexander Kline
 - [x] Operator owner — dominique@reliablegenius.io (2026-05-20)
 
 ## Revision History


### PR DESCRIPTION
## Summary

Two changes in one PR (both docs-only):

1. **RFC-0041 → Signed Off** — removes Product owner from sign-off block (operator decision 2026-05-20: not required for this RFC), promotes lifecycle Draft → Signed Off, marks status Approved. Engineering + Operator already signed in #572.

2. **7 backlog task files** breaking down the implementation per RFC §7 + OQ resolutions:

| Task | Phase | Scope |
|---|---|---|
| AISDLC-377 | Umbrella | Parent task with sub-task graph + acceptance criteria |
| AISDLC-377.1 | Phase 1 | Dispatch Board protocol + in-session-agent Worker (subscription path) |
| AISDLC-377.2 | Phase 1.5 | Iteration mechanism — Worker-driven session resumption per OQ-4 |
| AISDLC-377.3 | Phase 2 | Supervisor + `claude-p-shell` Worker (headless path) |
| AISDLC-377.4 | Phase 3.1 | Deprecate `--spawner claude-cli` (warning + runbook) |
| AISDLC-377.5 | Phase 3.2 | `cli-deps frontier` recommendedWorkerKind annotation |
| AISDLC-377.6 | Phase 3.3 | Remove `--spawner claude-cli` entirely (`blocked.reason` set per operator — awaits release window after 377.4) |

Critical path: 377.1 → 377.3 → 377.4 → 377.6. Parallelizable: 377.2 alongside 377.3; 377.5 anytime after 377.1.

## Test plan
- [x] `pnpm rfc:check` clean
- [x] `pnpm rfc:lifecycle-check` clean (Ready for Review → Signed Off)
- [x] `npx backlog-drift check` clean (no error-severity drift on new task files)
- [x] All task references point at real paths (cli-deps source moved to deps.ts in this repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)