### PR TITLE
docs(ci): require linked issue on PRs + friendly issue-first contributor flow

### DIFF
--- a/backlog/completed/aisdlc-384 - chore-audit-friction-of-remaining-non-attestation-gates.md
+++ b/backlog/completed/aisdlc-384 - chore-audit-friction-of-remaining-non-attestation-gates.md
@@ -1,7 +1,7 @@
 ---
 id: AISDLC-384
 title: 'chore(governance): audit friction of remaining ~14 non-attestation gates after RFC-0042 lands'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-05-20'
 labels:


### PR DESCRIPTION
Closes #582.

## Summary

External contributor PRs without a linked issue create disproportionate maintainer overhead. Concrete incident: PR #568 (akillies fork) took multi-step maintainer intervention to land — see issue #582 for the full backstory.

This PR adds three pieces:

1. **Friendly PR template** (`.github/PULL_REQUEST_TEMPLATE.md`) — preamble explaining the trade-off honestly + REQUIRED issue link section. Not gatekeeping — actually directs contributors to the lower-friction path.

2. **CI enforcement** (`.github/workflows/require-issue-link.yml`) — posts `ai-sdlc/issue-link` commit status. Uses `pull_request_target` so fork PRs get the status posted via elevated GITHUB_TOKEN (AISDLC-381 pattern). Maintainer bypass via `ci:no-issue-required` label.

3. **CONTRIBUTING.md update** — new "Issue-first, please" section with concrete reasons + carve-outs for when a PR is the right starting point (typos, maintainer work, security disclosures).

## Test plan

- [x] `pnpm format:check` clean
- [ ] **End-to-end**: this PR itself exercises the new check. The PR body references #582 with `Closes` keyword, so `ai-sdlc/issue-link` should report success.
- [ ] After merge: operator adds `ai-sdlc/issue-link` to required status checks via branch protection settings.

## Follow-up

- File a backlog task to monitor adoption after 2-3 weeks: if the friction message doesn't shift behavior, consider stronger gates (require issue exists at open-time, not just edit-time).