### PR TITLE
fix(ci): exclude bin/*.mjs CLI shims from patch-coverage gate (AISDLC-403)

### DIFF
--- a/backlog/tasks/aisdlc-403 - fix-patch-coverage-gate-exclude-bin-shims.md
+++ b/backlog/tasks/aisdlc-403 - fix-patch-coverage-gate-exclude-bin-shims.md
@@ -1,0 +1,38 @@
+---
+id: AISDLC-403
+title: 'fix(ci): patch-coverage gate excludes bin/*.mjs CLI shims (AISDLC-376 follow-up)'
+status: To Do
+labels: [ci, coverage-gate, operator-merge]
+references:
+  - scripts/check-pr-patch-coverage.mjs
+priority: high
+permittedExternalPaths: []
+---
+
+## Description
+
+AISDLC-376 (PR #627) shipped the server-side patch-coverage gate but its `NON_INSTRUMENTED_PATTERNS` list excludes `src/cli-*.ts` shims but NOT `bin/*.mjs` shims. PR #524 (AISDLC-284) hit this on 2026-05-23: a new bin file `pipeline-cli/bin/cli-estimate-classes.mjs` has 12 changed lines, no coverage data (correctly — bin shims just delegate to library code), gate reports MISSING + fails with exit 1. Same gap will hit every future PR that adds a new bin shim.
+
+The fix: extend `NON_INSTRUMENTED_PATTERNS` to also exclude `bin/.+\.mjs`. Bin shims are entrypoint thunks that parse argv and call into libraries; the libraries are unit-tested directly, the shim is exercised end-to-end via subprocess invocation which istanbul can't see.
+
+## Acceptance criteria
+
+- [ ] AC-1: `scripts/check-pr-patch-coverage.mjs` `NON_INSTRUMENTED_PATTERNS` includes a pattern matching `bin/<anything>.mjs` (e.g. `/(^|\/)bin\/.+\.mjs$/`).
+- [ ] AC-2: `scripts/check-pr-patch-coverage.test.mjs` adds a test case: a changed file at `pkg/bin/cli-foo.mjs` is correctly identified as non-instrumentable and skipped from enforcement.
+- [ ] AC-3: Inline comment on the new pattern entry explains the rationale (bin shims are subprocess-tested, istanbul can't see them) — mirrors existing pattern comments.
+- [ ] AC-4: Run the existing hermetic tests to confirm no regression (`node --test scripts/check-pr-patch-coverage.test.mjs`).
+- [ ] AC-5: Document in PR body that PR #524 (AISDLC-284) is the immediate beneficiary — its Coverage check will pass on rebase once this lands.
+
+## Out of scope
+
+- Adding `bin/*.cjs` or `bin/*.js` (only `.mjs` is currently used; can extend if/when needed).
+- Rewriting the bin shims to be testable (they're intentionally thin).
+
+## References
+
+- AISDLC-376 (PR #627) — original patch-coverage gate
+- PR #524 (AISDLC-284) — first PR to hit the gap
+
+## Estimated effort
+
+15-30 min.

--- a/scripts/check-pr-patch-coverage.mjs
+++ b/scripts/check-pr-patch-coverage.mjs
@@ -119,6 +119,11 @@ const NON_INSTRUMENTED_PATTERNS = [
   /(^|\/)src\/.*\/index\.ts$/,
   // Generated schemas — sanctioned exclusion per CLAUDE.md.
   /(^|\/)generated-schemas\.ts$/,
+  // bin/*.mjs CLI entrypoint shims — these are thin argv-parse thunks that
+  // delegate to library code; the libraries are unit-tested directly, and the
+  // shims themselves are exercised via subprocess invocation which istanbul
+  // can't instrument. Same rationale as `src/cli-*.ts` above.
+  /(^|\/)bin\/.+\.mjs$/,
 ];
 
 // ── Argv parsing ─────────────────────────────────────────────────────────────

--- a/scripts/check-pr-patch-coverage.test.mjs
+++ b/scripts/check-pr-patch-coverage.test.mjs
@@ -335,6 +335,33 @@ describe('check-pr-patch-coverage — skip on 0 changed code files', () => {
     const parsed = JSON.parse(r.stdout);
     assert.equal(parsed.reason, 'no-instrumentable-changes');
   });
+
+  it('exits 0 when only bin/*.mjs shim changed (AISDLC-403)', () => {
+    // bin/*.mjs entrypoints are subprocess-tested; istanbul can't instrument
+    // them. They must be excluded from the enforcement denominator, regardless
+    // of whether coverage data exists for them.
+    const base = commitFile(repo, 'README.md', '# x\n', 'init');
+    const head = commitFile(
+      repo,
+      'pkg/bin/cli-foo.mjs',
+      [
+        '#!/usr/bin/env node',
+        "import { run } from '../src/foo.js';",
+        'run(process.argv.slice(2));',
+      ].join('\n') + '\n',
+      'feat: add cli-foo bin shim',
+    );
+    // No coverage file written — the gate must skip, not fail, for bin shims.
+    const r = runGate(repo, { base, head, json: true });
+    assert.equal(
+      r.status,
+      0,
+      `expected exit 0 for bin shim, got ${r.status}\nstdout: ${r.stdout}\nstderr: ${r.stderr}`,
+    );
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(parsed.reason, 'no-instrumentable-changes');
+    assert.deepEqual(parsed.changedCodeFiles, []);
+  });
 });
 
 // ── AC 4: failure with diagnostic when coverage data missing ─────────────────


### PR DESCRIPTION
## Summary

AISDLC-376 (PR #627) shipped the server-side patch-coverage gate with `NON_INSTRUMENTED_PATTERNS` that excluded `src/cli-*.ts` shims but NOT `bin/*.mjs` shims. PR #524 (AISDLC-284) hit this gap on 2026-05-23: `pipeline-cli/bin/cli-estimate-classes.mjs` has 12 changed lines with no coverage data (correctly — bin shims just delegate to library code), but the gate reported MISSING and failed with exit 1.

## Changes

- `scripts/check-pr-patch-coverage.mjs`: added `/(^|\/)bin\/.+\.mjs$/` to `NON_INSTRUMENTED_PATTERNS` with an inline comment explaining the rationale (bin shims are subprocess-tested; istanbul can't instrument them) — mirrors the existing `src/cli-*.ts` entry.
- `scripts/check-pr-patch-coverage.test.mjs`: added a new test case in the "skip on 0 changed code files" suite: a changed file at `pkg/bin/cli-foo.mjs` is correctly identified as non-instrumentable and skipped from enforcement, with no coverage file required.
- `backlog/tasks/aisdlc-403 - fix-patch-coverage-gate-exclude-bin-shims.md`: task file.

## Acceptance criteria verification

- [x] AC-1: `NON_INSTRUMENTED_PATTERNS` now includes `/(^|\/)bin\/.+\.mjs$/`
- [x] AC-2: Test case for `pkg/bin/cli-foo.mjs` asserts `reason: 'no-instrumentable-changes'` and `changedCodeFiles: []`
- [x] AC-3: Inline comment on the new pattern explains the subprocess-testing rationale
- [x] AC-4: All 20 hermetic tests pass (`node --test scripts/check-pr-patch-coverage.test.mjs`)
- [x] AC-5: PR #524 (AISDLC-284) is the immediate beneficiary — its Coverage check will pass on rebase once this lands

## Beneficiary

PR #524 (AISDLC-284) will pass the `Coverage` check once it rebases onto a main that includes this fix.

## Test plan

- [x] Run `node --test scripts/check-pr-patch-coverage.test.mjs` — 20/20 pass
- [ ] Merge this PR first, then rebase PR #524 — Coverage check should pass