### PR TITLE
fix(plugin): update orchestrator skill-body env gates post-AISDLC-411 default-ON

### DIFF
--- a/ai-sdlc-plugin/commands/dispatch-worker.md
+++ b/ai-sdlc-plugin/commands/dispatch-worker.md
@@ -78,10 +78,15 @@ WORKER_ID="${AI_SDLC_WORKER_ID:-worker-$$-$(date +%s)}"
 ## Step 1 — Feature-flag guard
 
 ```bash
-if [ -z "$AI_SDLC_AUTONOMOUS_ORCHESTRATOR" ]; then
-  echo "ERROR: AI_SDLC_AUTONOMOUS_ORCHESTRATOR is not set. Set it to 'experimental' to enable."
-  exit 1
-fi
+# AISDLC-411 (2026-05-23) flipped AI_SDLC_AUTONOMOUS_ORCHESTRATOR to default-ON.
+# Worker is enabled unless the operator explicitly opted out via the FALSY set.
+case "$(echo "${AI_SDLC_AUTONOMOUS_ORCHESTRATOR:-}" | tr '[:upper:]' '[:lower:]')" in
+  off|0|false|no)
+    echo "ERROR: AI_SDLC_AUTONOMOUS_ORCHESTRATOR is explicitly disabled (\"$AI_SDLC_AUTONOMOUS_ORCHESTRATOR\")."
+    echo "Unset it (or set to a non-opt-out value) to re-enable; default-ON since AISDLC-411."
+    exit 1
+    ;;
+esac
 ```
 
 ## Step 2a — Resume-signal check (Phase 1.5 / AISDLC-377.2)

--- a/ai-sdlc-plugin/commands/orchestrator-tick.md
+++ b/ai-sdlc-plugin/commands/orchestrator-tick.md
@@ -134,10 +134,15 @@ BOARD_DIR="${AI_SDLC_DISPATCH_BOARD_DIR:-$(pwd)/.ai-sdlc/dispatch}"
 ## Step 1 — Feature-flag guard
 
 ```bash
-if [ -z "$AI_SDLC_AUTONOMOUS_ORCHESTRATOR" ]; then
-  echo "ERROR: AI_SDLC_AUTONOMOUS_ORCHESTRATOR is not set. Set it to 'experimental' to enable."
-  exit 1
-fi
+# AISDLC-411 (2026-05-23) flipped AI_SDLC_AUTONOMOUS_ORCHESTRATOR to default-ON.
+# Conductor is enabled unless the operator explicitly opted out via the FALSY set.
+case "$(echo "${AI_SDLC_AUTONOMOUS_ORCHESTRATOR:-}" | tr '[:upper:]' '[:lower:]')" in
+  off|0|false|no)
+    echo "ERROR: AI_SDLC_AUTONOMOUS_ORCHESTRATOR is explicitly disabled (\"$AI_SDLC_AUTONOMOUS_ORCHESTRATOR\")."
+    echo "Unset it (or set to a non-opt-out value) to re-enable; default-ON since AISDLC-411."
+    exit 1
+    ;;
+esac
 ```
 
 ## Step 2 — Sweep stale heartbeats

--- a/backlog/tasks/aisdlc-413 - fix-skill-body-orchestrator-flag-gates-post-411.md
+++ b/backlog/tasks/aisdlc-413 - fix-skill-body-orchestrator-flag-gates-post-411.md
@@ -1,0 +1,39 @@
+---
+id: AISDLC-413
+title: 'fix(plugin): update orchestrator-tick + dispatch-worker skill-body env gates to match AISDLC-411 default-ON polarity'
+status: In Progress
+labels: [plugin, rfc-0015, post-411, operator-merge]
+references:
+  - ai-sdlc-plugin/commands/dispatch-worker.md
+  - ai-sdlc-plugin/commands/orchestrator-tick.md
+  - pipeline-cli/src/orchestrator/feature-flag.ts
+priority: high
+permittedExternalPaths: []
+---
+
+## Description
+
+AISDLC-411 (PR #644, 2026-05-23) flipped `AI_SDLC_AUTONOMOUS_ORCHESTRATOR` to default-ON via the TypeScript `isOrchestratorEnabled()` parser. The promotion missed two shell-script Step 1 gates embedded directly in plugin skill bodies:
+
+- `ai-sdlc-plugin/commands/dispatch-worker.md` line 81: `if [ -z "$AI_SDLC_AUTONOMOUS_ORCHESTRATOR" ]; then exit 1; fi`
+- `ai-sdlc-plugin/commands/orchestrator-tick.md` line 137: same pattern
+
+These gates still require the env var to be SET, contradicting the new default-ON convention. Operators who try `/ai-sdlc:dispatch-worker` or `/ai-sdlc:orchestrator-tick` post-cutover see "ERROR: AI_SDLC_AUTONOMOUS_ORCHESTRATOR is not set" even though the parser would say "enabled" for an unset env.
+
+Symptom (observed 2026-05-23 immediately after AISDLC-411 merge): the operator's worker session refused to start with the stale message; manifest AISDLC-412 queued but no Worker could claim it.
+
+## Acceptance criteria
+
+- [x] AC-1: Update both skill-body Step 1 gates to mirror the FALSY-set opt-out polarity (off / 0 / false / no, case-insensitive). Default-ON when env is unset.
+- [x] AC-2: Updated error message names the new semantic ("explicitly disabled" + "default-ON since AISDLC-411").
+- [ ] AC-3: Hermetic test (deferred — skill bodies are markdown executed inline by Claude Code; no test framework hooks them. The TypeScript parser already has 5-case-group coverage from AISDLC-411).
+- [x] AC-4: Operator unblock path: `unset AI_SDLC_AUTONOMOUS_ORCHESTRATOR && /ai-sdlc:dispatch-worker` works post-merge.
+
+## Out of scope
+
+- Restructuring the skill bodies to invoke `isOrchestratorEnabled()` via the CLI (cleaner but bigger change; the shell-case approach is minimal-diff + matches the parser's semantic exactly).
+- Sweeping other skill bodies for similar env-gate patterns (none found in `/ai-sdlc execute`, etc — those don't gate on this flag).
+
+## Estimated effort
+
+15-30 min.


### PR DESCRIPTION
## Summary

AISDLC-411 (PR #644) flipped \`AI_SDLC_AUTONOMOUS_ORCHESTRATOR\` to default-ON via the TypeScript \`isOrchestratorEnabled()\` parser. The promotion missed two shell-script Step 1 gates embedded directly in plugin skill bodies — operators trying \`/ai-sdlc:dispatch-worker\` or \`/ai-sdlc:orchestrator-tick\` post-cutover still saw the old "ERROR: AI_SDLC_AUTONOMOUS_ORCHESTRATOR is not set" message.

**Observed live**: operator's worker session refused at Step 1 immediately after AISDLC-411 merged; manifest AISDLC-412 queued with no Worker able to claim it.

## Changes

- \`ai-sdlc-plugin/commands/dispatch-worker.md\`: Step 1 gate flipped to FALSY-set opt-out (\`off\`/\`0\`/\`false\`/\`no\`, case-insensitive). Unset env = ON (default-ON).
- \`ai-sdlc-plugin/commands/orchestrator-tick.md\`: same gate flip.
- Updated error message names the new "default-ON since AISDLC-411" semantic.
- Task file: \`backlog/tasks/aisdlc-413\`.

## Out of scope

- Restructuring skill bodies to invoke \`isOrchestratorEnabled()\` via the CLI (bigger change; inline shell-case matches parser semantic exactly with minimum diff).
- Hermetic test (skill bodies are markdown executed inline by Claude Code; no test framework. The TypeScript parser already has 5-case-group coverage from AISDLC-411).

🤖 Generated with [Claude Code](https://claude.com/claude-code)