### PR TITLE
fix(ci): broaden v6 envelope filter to surface descendant-relaxation candidates (AISDLC-419 follow-up)

### DIFF
--- a/scripts/verify-attestation.mjs
+++ b/scripts/verify-attestation.mjs
@@ -1773,14 +1773,40 @@ export function runVerifier({ headSha, baseSha, repoRoot = process.cwd() }) {
   const all = loadAllAttestations(repoRoot);
 
   // AISDLC-398: check patch-id-named v6 envelope first, then SHA-named.
+  // AISDLC-419 (follow-up): also accept envelopes whose subject.sha1 is an
+  // attestation-only ancestor of HEAD. The signer's patch-id and the
+  // verifier's patch-id can diverge when the merge-base they each pick
+  // differs (signer uses origin/main at sign-time, verifier uses the PR's
+  // baseSha). When that happens, the patch-id-named envelope is not
+  // findable by name even though its subject.sha1 cryptographically
+  // commits to a valid ancestor of HEAD. The descendant relaxation
+  // (added by AISDLC-419 inside verifyV6Envelope) defends the binding;
+  // this widens the candidate set so that defense actually runs.
   const v6PatchIdFilename = contentPatchId ? `${contentPatchId}.v6.dsse.json` : null;
   const v6Envelopes = all.filter((entry) => {
     if (!entry.isV6) return false;
     const lowerName = entry.fileName.toLowerCase();
     // Patch-id filename (AISDLC-398 preferred)
     if (v6PatchIdFilename && lowerName === v6PatchIdFilename) return true;
-    // Legacy per-SHA filename (pre-AISDLC-398 compat)
+    // Legacy per-SHA filename (pre-AISDLC-398 compat) — current HEAD
     if (lowerName === `${lowerHead}.v6.dsse.json`) return true;
+    // AISDLC-419 follow-up: surface envelopes whose internal
+    // `subject.digest.sha1` is an attestation-only ancestor of HEAD,
+    // regardless of filename. The filename can be ANY 40-hex string
+    // (patch-id, sign-time HEAD bridge, etc) — what matters for
+    // structural validity is the cryptographic subject binding inside
+    // the envelope, and the inner descendant-relaxation in
+    // verifyV6Envelope. Doing the check here surfaces the envelope to
+    // the candidate set; verifyV6Envelope's signature + Merkle defenses
+    // still gate acceptance.
+    const subjectSha = entry.envelope?.subject?.digest?.sha1;
+    if (
+      typeof subjectSha === 'string' &&
+      /^[0-9a-f]{40}$/i.test(subjectSha) &&
+      isAttestationOnlyDescendant(subjectSha, lowerHead, repoRoot)
+    ) {
+      return true;
+    }
     return false;
   });
   if (v6Envelopes.length > 0) {

--- a/scripts/verify-attestation.test.mjs
+++ b/scripts/verify-attestation.test.mjs
@@ -3981,6 +3981,125 @@ describe('runVerifier — v6 integration', () => {
 // from the CURRENT HEAD's files rather than comparing the stored hash against
 // itself. A force-push that changes blob SHAs (but preserves the unified diff
 // structure) MUST be rejected.
+describe('runVerifier (AISDLC-419 follow-up — broaden v6 envelope filter)', () => {
+  // Reproduces the production failure mode: a v6 envelope sits on disk
+  // named for the parent-of-HEAD (the "signed commit"). The chore commit
+  // on top only adds attestation files. The verifier's strict
+  // patch-id-or-HEAD-sha filter would skip the envelope entirely; with
+  // the broadened filter (AISDLC-419 follow-up) the envelope surfaces
+  // and the inner descendant-relaxation accepts it.
+  let fixture;
+  let v6Keys;
+
+  beforeEach(() => {
+    fixture = setupFixture();
+    v6Keys = genV6KeyPair();
+    writeTrustedReviewersYaml(fixture.root, v6Keys.publicKeyPem);
+  });
+
+  afterEach(() => {
+    rmSync(fixture.root, { recursive: true, force: true });
+  });
+
+  it('accepts a v6 envelope whose subject.sha1 is an attestation-only ancestor of HEAD (post-rebase shape)', () => {
+    // Write a v6 envelope binding to fixture.headSha (the work commit).
+    const leaves = [
+      makeLeaf(0, 'code-reviewer'),
+      makeLeaf(1, 'test-reviewer'),
+      makeLeaf(2, 'security-reviewer'),
+    ];
+    writeV6Fixture(fixture.root, fixture.headSha, leaves, v6Keys.privateKeyPem);
+
+    // Now add an attestation-only chore commit on top. Use a fake patch-id
+    // filename to mirror the production shape (the file is named for an
+    // arbitrary 40-hex that is NEITHER the chore HEAD nor the verifier's
+    // computed patch-id). This is the case the original AISDLC-419 fix
+    // failed to surface because the filter ignored the envelope.
+    const FAKE_PATCH_ID = 'a'.repeat(40);
+    writeFileSync(
+      join(fixture.root, '.ai-sdlc', 'attestations', `${FAKE_PATCH_ID}.v6.dsse.json`),
+      readFileSync(
+        join(fixture.root, '.ai-sdlc', 'attestations', `${fixture.headSha}.v6.dsse.json`),
+        'utf-8',
+      ),
+    );
+    // Remove the per-HEAD bridge so the only matchable envelope is the
+    // fake-patch-id one (forces the broadened filter to be exercised).
+    rmSync(join(fixture.root, '.ai-sdlc', 'attestations', `${fixture.headSha}.v6.dsse.json`));
+
+    // Create the chore commit. Re-stash transcript-leaves first because
+    // the chore commit only adds attestation files.
+    execFileSync('git', ['add', '.ai-sdlc/attestations/', '.ai-sdlc/transcript-leaves.jsonl'], {
+      cwd: fixture.root,
+    });
+    execFileSync('git', ['commit', '-q', '-m', 'chore: sign v6 attestation'], {
+      cwd: fixture.root,
+    });
+    const choreHead = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: fixture.root,
+      encoding: 'utf-8',
+    }).trim();
+
+    // Run verifier with the chore commit as HEAD — this is what CI sees
+    // after the pre-push attestation-sign hook adds the chore commit.
+    const out = runVerifier({
+      headSha: choreHead,
+      baseSha: fixture.baseSha,
+      repoRoot: fixture.root,
+    });
+    assert.equal(
+      out.status,
+      'valid',
+      `expected valid (envelope surfaced via broadened filter), got: ${out.reason}`,
+    );
+  });
+
+  it('STILL rejects when the descendant chore commit ALSO changes source files', () => {
+    // Same setup as above but smuggle a source-file change into the
+    // descendant chore commit. The broadened filter still surfaces the
+    // envelope (subject.sha1 is an ancestor), but the inner
+    // isAttestationOnlyDescendant check rejects because the diff isn't
+    // attestation-only.
+    const leaves = [
+      makeLeaf(0, 'code-reviewer'),
+      makeLeaf(1, 'test-reviewer'),
+      makeLeaf(2, 'security-reviewer'),
+    ];
+    writeV6Fixture(fixture.root, fixture.headSha, leaves, v6Keys.privateKeyPem);
+    const FAKE_PATCH_ID = 'b'.repeat(40);
+    writeFileSync(
+      join(fixture.root, '.ai-sdlc', 'attestations', `${FAKE_PATCH_ID}.v6.dsse.json`),
+      readFileSync(
+        join(fixture.root, '.ai-sdlc', 'attestations', `${fixture.headSha}.v6.dsse.json`),
+        'utf-8',
+      ),
+    );
+    rmSync(join(fixture.root, '.ai-sdlc', 'attestations', `${fixture.headSha}.v6.dsse.json`));
+    // Tamper a source file in the chore commit.
+    writeFileSync(join(fixture.root, 'feature.txt'), 'feature\nTAMPERED\n');
+    execFileSync(
+      'git',
+      ['add', '.ai-sdlc/attestations/', '.ai-sdlc/transcript-leaves.jsonl', 'feature.txt'],
+      { cwd: fixture.root },
+    );
+    execFileSync('git', ['commit', '-q', '-m', 'chore: sign + tamper'], { cwd: fixture.root });
+    const tamperedHead = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: fixture.root,
+      encoding: 'utf-8',
+    }).trim();
+    const out = runVerifier({
+      headSha: tamperedHead,
+      baseSha: fixture.baseSha,
+      repoRoot: fixture.root,
+    });
+    assert.equal(
+      out.status,
+      'invalid',
+      `expected invalid (source code tampered between sign and push), got: ${out.reason}`,
+    );
+  });
+});
+
 describe('runVerifier (AISDLC-398 fix #3 — v5 fast-path content-hash recompute)', () => {
   let fixture;
   let keys;


### PR DESCRIPTION
## Summary

Follow-up to #657. The initial AISDLC-419 fix added the descendant relaxation **inside** `verifyV6Envelope` but never engaged in production — the candidate v6 envelope filter (in `runVerifier`) only accepted filenames matching either the verifier's computed patch-id OR the current HEAD SHA, neither of which matches in the chore-stack pattern.

Production failure mode (observed when verifying #654 force-push):
- Signer patch-id `c17617...` (merge-base = `origin/main` at sign-time)
- Verifier patch-id `e7abd97...` (merge-base = PR `baseSha`)
- Per-HEAD bridge file named for sign-time HEAD `4e7a5dd0`, but current HEAD is `aa946f0a` (after pre-push chore commit)
- Result: filter returns empty, v6 path skipped, verifier falls through to v3/v5 → reports `contentHashV4 mismatch` against an irrelevant historical envelope

## Fix

Surface a v6 envelope to the candidate set whenever its **internal `subject.digest.sha1`** is an attestation-only ancestor of HEAD, regardless of filename. The inner relaxation + signature/Merkle verification then cryptographically gate acceptance.

## Security

The broadening only widens the candidate pool — the trust boundary is unchanged. Acceptance still requires:
1. `subject.sha1` is an ancestor of HEAD (no cross-PR replay)
2. No source diff between subject and HEAD outside `.ai-sdlc/attestations/` + `.ai-sdlc/transcript-leaves.jsonl` (no tampering)
3. Signature verifies against trusted reviewer pubkey
4. Merkle root recomputes from on-disk transcript leaves

## Tests

- New `runVerifier (AISDLC-419 follow-up)` describe block, 2 hermetic integration tests:
  - Accepts envelope with non-matching filename when subject is attestation-only ancestor
  - Still rejects when descendant chore also tampers a source file
- All 113 prior verifier tests continue to pass

## Chicken-and-egg

Same as #657 — this PR's own CI runs main's old verifier, which has #657's helper but not this broadened filter. Admin-merge required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)