### PR TITLE
chore(backlog): sync RFC-0017 phase tasks to v0.4 editorial pass

### DIFF
--- a/backlog/tasks/aisdlc-352 - feat-RFC-0017-phase-1-soul-did-variant-schema-additions.md
+++ b/backlog/tasks/aisdlc-352 - feat-RFC-0017-phase-1-soul-did-variant-schema-additions.md
@@ -24,6 +24,7 @@ Phase 1 of RFC-0017 §9. Schema additions to Soul DID + Work Item + inheritance 
 ## Scope
 
 - **Soul DID schema (`spec/schemas/design-intent-document.schema.json`)**: add `variants[]` array per §5.1. Each variant entry has `id`, `audience`, `designOverrides`, `complianceFloor: inherit` (locked).
+- **`designOverrides` closed framework enum (v0.4 / OQ-5 revisit 2026-05-26)**: schema MUST accept ONLY `colorPaletteOverlay` (string), `densityProfile` (enum `compact`/`comfortable`/`spacious`), `typographyScale` (enum `default`/`large-print`/`data-dense`), `motionProfile` (enum `full`/`reduced`/`none`), `radiusProfile` (enum `sharp`/`default`/`rounded`). `voiceRegister` is **NOT** in the enum (cut in v0.4 per Mo's Design-Authority editorial pass — content register lives outside the visual token surface per 6/6 leading design systems). Adopter extensions via vendor reverse-DNS prefix (e.g. `acme.com/accessibilityProfile`) accepted; non-prefixed unknown keys rejected with `additionalProperties: false`.
 - **Work Item schema**: add optional `targetedVariants[]` field (per OQ-6 URI format `did:method:platform:soul:<soul-id>/variant:<variant-id>`).
 - **Variant inheritance validator** (`orchestrator/src/variant/inheritance-validator.ts`): emits `VariantInheritanceViolation` event when a variant attempts to escape substrate or compliance floor inheritance per §5.3.
 - **Schema constraints** (OQ-1 + OQ-2): soft-warn at 5+ variants (emit Decision); hard-reject at 20+ variants; reject nested `variants[]` declarations (schema-enforced flat per OQ-2).
@@ -35,6 +36,7 @@ Phase 1 of RFC-0017 §9. Schema additions to Soul DID + Work Item + inheritance 
 
 <!-- AC:BEGIN -->
 - [ ] #1 Soul DID schema has `variants[]` array per §5.1
+- [ ] #1a `designOverrides` closed enum accepts ONLY the v0.4 field set: `colorPaletteOverlay`, `densityProfile`, `typographyScale`, `motionProfile`, `radiusProfile` (each with the value-enum per §6.1). `voiceRegister` rejected. Vendor-prefixed keys (`<reverse-dns>/<field>`) accepted via `patternProperties`; non-prefixed unknown keys rejected.
 - [ ] #2 Work Item schema has optional `targetedVariants[]` field with path-style URI format per OQ-6
 - [ ] #3 Inheritance validator emits `VariantInheritanceViolation` event when substrate or compliance floor escape attempted
 - [ ] #4 Variant count soft warning at 5+ emits `Decision: variant-count-soft-warning` (non-blocking)

--- a/backlog/tasks/aisdlc-355 - feat-RFC-0017-phase-4-internaladopter-four-product-reference-impl.md
+++ b/backlog/tasks/aisdlc-355 - feat-RFC-0017-phase-4-internaladopter-four-product-reference-impl.md
@@ -1,6 +1,6 @@
 ---
 id: AISDLC-355
-title: 'feat: RFC-0017 Phase 4 — InternalAdopter four-product suite as reference implementation (practitioner validation pass)'
+title: 'feat: RFC-0017 Phase 4 — InternalAdopter three-product suite (ProductA/B/C) as reference implementation; ProductD deferred to RFC-0018 per v0.4 (practitioner validation pass)'
 status: To Do
 assignee: []
 created_date: '2026-05-18'
@@ -25,10 +25,10 @@ Phase 4 of RFC-0017 §9 + §11 practitioner validation. Implements InternalAdopt
 
 ## Scope (§11 validation criteria)
 
-- **ProductA**: variants `small-utility`, `enterprise`, `county-regional` — validates audience-segment specialization + voice register variation.
+- **ProductA**: variants `small-utility`, `enterprise`, `county-regional` — validates audience-segment specialization across the v0.4 visual-token surface (color/density/typography/motion/radius).
 - **ProductB**: variants `field-tech-on-truck`, `field-tech-handheld`, `supervisor-tablet` — validates density profile + form-factor specialization.
 - **ProductC**: variants `billing-clerk`, `customer-portal`, `csr-dashboard` — validates role-based audience + workflow-density specialization.
-- **ProductD**: variants `annual-test`, `repair-event`, `regulatory-audit-mode` — validates temporal-context-bound design intent (also validates §11 carries through to RFC-0018 Journey companion).
+- **ProductD**: **DEFERRED to RFC-0018 §11** per v0.4 Design Authority editorial pass. Proposed variants (`annual-test`, `repair-event`, `regulatory-audit-mode`) are temporal-context-bound operational modes activated by *when* and *why* a user is in the system — same user, different operational moment = Journey shape (RFC-0018), not Variant shape. ProductD validates the Variant/Journey boundary as a validation case for the companion RFC, not this one. **Scope of this task is now three products (A, B, C), not four.**
 
 ## Validation criteria (Mo's editorial welcome)
 
@@ -45,7 +45,7 @@ Phase 4 of RFC-0017 §9 + §11 practitioner validation. Implements InternalAdopt
 - [ ] #1 ProductA variant declarations ship with `small-utility` / `enterprise` / `county-regional`
 - [ ] #2 ProductB variant declarations ship with `field-tech-on-truck` / `field-tech-handheld` / `supervisor-tablet`
 - [ ] #3 ProductC variant declarations ship with `billing-clerk` / `customer-portal` / `csr-dashboard`
-- [ ] #4 ProductD variant declarations ship with `annual-test` / `repair-event` / `regulatory-audit-mode`
+- [ ] #4 ProductD scope removed from this task per v0.4 (deferred to RFC-0018 §11 — temporal-context-bound modes are Journey shape, not Variant). File follow-up task against RFC-0018 once that RFC's implementation plan is broken down.
 - [ ] #5 Each variant has ≤ 5 `designImperatives` strings (validates closed-enum discipline OR exercises vendor-prefix extension)
 - [ ] #6 Admission scoring spot-check: variant-routed score differs from soul-aggregate by ≥ X% on a representative work item
 - [ ] #7 Engineering review confirms substrate shared across all four products' variants


### PR DESCRIPTION
Updates 2 phase tasks to reflect Mo's RFC-0017 v0.4 editorial pass (PR #707, merged).

## AISDLC-352 (Phase 1 — schema additions)

Added explicit `designOverrides` closed enum to scope + new AC #1a:
- v0.4 enum: `colorPaletteOverlay`, `densityProfile`, `typographyScale`, `motionProfile`, `radiusProfile` (each with value-enum per §6.1)
- `voiceRegister` excluded (cut in v0.4 OQ-5 revisit 2026-05-26)
- Vendor-prefix extension (`<reverse-dns>/<field>`) accepted via patternProperties

## AISDLC-355 (Phase 4 — InternalAdopter reference impl)

ProductD scope removed:
- Per v0.4 §11, ProductD's proposed variants (annual-test, repair-event, regulatory-audit-mode) are temporal-context-bound operational modes (Journey shape per RFC-0018), not Variant shape
- Task now scopes 3 products (A/B/C), not 4
- Title updated to reflect 3-product scope + deferral
- AC #4 rewritten to file follow-up against RFC-0018 once that RFC's implementation plan is broken down

## Not affected

- AISDLC-353 (Phase 2 — admission scorer) — already merged, doesn't reference v0.3 enum specifics
- AISDLC-354 (Phase 3 — deprecation lifecycle) — doesn't reference v0.3 enum specifics
- AISDLC-356 (Phase 5 — glossary/tests/docs) — only mentions vendor-prefix designOverrides (still valid)

2 files changed, 6 insertions, 4 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>