### PR TITLE
chore(RFC-0017): add blocked.reason override to phase tasks (352, 354, 355, 356)

### DIFF
--- a/backlog/tasks/aisdlc-352 - feat-RFC-0017-phase-1-soul-did-variant-schema-additions.md
+++ b/backlog/tasks/aisdlc-352 - feat-RFC-0017-phase-1-soul-did-variant-schema-additions.md
@@ -14,6 +14,8 @@ references:
   - spec/rfcs/RFC-0017-in-soul-variant-pattern.md
   - spec/rfcs/RFC-0009-tessellated-design-intent-documents.md
 priority: high
+blocked:
+  reason: "RFC-0017 v0.4 dispatched under conditional Design Authority sign-off (Morgan Hirtle, PR #709) + Engineering Authority ratification (Dominique Legault, PR #710). RFC lifecycle remains Ready for Review pending Product Authority v0.4 ratification (Alex). Mo's §11 practitioner validation condition discharges when AISDLC-355 ships. Operator-authorized dispatch override 2026-05-26."
 ---
 
 ## Description

--- a/backlog/tasks/aisdlc-354 - feat-RFC-0017-phase-3-deprecation-lifecycle-and-drift-detection.md
+++ b/backlog/tasks/aisdlc-354 - feat-RFC-0017-phase-3-deprecation-lifecycle-and-drift-detection.md
@@ -16,6 +16,8 @@ references:
   - spec/rfcs/RFC-0035-decision-catalog-operator-routing.md
   - spec/rfcs/RFC-0009-tessellated-design-intent-documents.md
 priority: high
+blocked:
+  reason: "RFC-0017 v0.4 dispatched under conditional Design Authority sign-off (Morgan Hirtle, PR #709) + Engineering Authority ratification (Dominique Legault, PR #710). RFC lifecycle remains Ready for Review pending Product Authority v0.4 ratification (Alex). Mo's §11 practitioner validation condition discharges when AISDLC-355 ships. Operator-authorized dispatch override 2026-05-26."
 ---
 
 ## Description

--- a/backlog/tasks/aisdlc-355 - feat-RFC-0017-phase-4-internaladopter-four-product-reference-impl.md
+++ b/backlog/tasks/aisdlc-355 - feat-RFC-0017-phase-4-internaladopter-four-product-reference-impl.md
@@ -16,6 +16,8 @@ dependencies:
 references:
   - spec/rfcs/RFC-0017-in-soul-variant-pattern.md
 priority: medium
+blocked:
+  reason: "RFC-0017 v0.4 dispatched under conditional Design Authority sign-off (Morgan Hirtle, PR #709) + Engineering Authority ratification (Dominique Legault, PR #710). RFC lifecycle remains Ready for Review pending Product Authority v0.4 ratification (Alex). This task IS the §11 practitioner validation pass that discharges Mo's condition #1; landing it converts Mo's sign-off from conditional to unconditional. Operator-authorized dispatch override 2026-05-26."
 ---
 
 ## Description

--- a/backlog/tasks/aisdlc-356 - docs-RFC-0017-phase-5-glossary-conformance-tests-doc-surfaces.md
+++ b/backlog/tasks/aisdlc-356 - docs-RFC-0017-phase-5-glossary-conformance-tests-doc-surfaces.md
@@ -18,6 +18,8 @@ dependencies:
 references:
   - spec/rfcs/RFC-0017-in-soul-variant-pattern.md
 priority: medium
+blocked:
+  reason: "RFC-0017 v0.4 dispatched under conditional Design Authority sign-off (Morgan Hirtle, PR #709) + Engineering Authority ratification (Dominique Legault, PR #710). RFC lifecycle remains Ready for Review pending Product Authority v0.4 ratification (Alex). Mo's §11 practitioner validation condition discharges when AISDLC-355 ships. Operator-authorized dispatch override 2026-05-26."
 ---
 
 ## Description


### PR DESCRIPTION
## Summary

Adds DoR upstream-OQ gate override (`blocked.reason`) to the 4 RFC-0017 phase tasks so the autonomous orchestrator can dispatch them while the RFC's `lifecycle:` remains `Ready for Review`.

## Sign-off state (2026-05-26)

| Pillar | Person | Status |
|---|---|---|
| Design Authority | Morgan Hirtle | ✅ conditional v0.4 (PR #709) |
| Engineering Authority | Dominique Legault | ✅ signed v0.4 (PR #710) |
| Product Authority | Alex | ⏳ v0.2 PPA-scope only — v0.4 ratification pending |

## Why override + not lifecycle promotion

- Mo's sign-off is **conditional** pending §11 practitioner validation (AISDLC-355) — full unconditional sign-off can't land until that ships
- Alex's v0.4 ratification pending (v0.4 doesn't touch PPA composability so v0.2 sign-off arguably carries through, but a fresh row is cleanest)
- Override pattern is documented in CLAUDE.md "Manual override" section; ships exactly the behavior the operator needs

## Discharge path

- **Condition #1 (§11 validation)** discharges when AISDLC-355 ships its InternalAdopter three-product reference impl
- **Condition #2 (no material spec changes)** remains a Design-Authority process gate during phase implementation
- Once AISDLC-355 lands + Alex ratifies v0.4 → lifecycle promotes `Ready for Review` → `Signed Off` → overrides can be removed

## Test plan

- [x] Docs-only diff (`backlog/tasks/*.md`)
- [x] Skips `verify-attestation.yml` + `ai-sdlc-review.yml` via `paths-ignore`
- [x] Pre-push DoR gate honors `blocked.reason` (per CLAUDE.md upstream-OQ gate spec)
- [x] Should auto-merge once `ai-sdlc/pr-ready` + `Backlog Drift` pass
- [ ] Once merged, the next `/ai-sdlc orchestrator-tick` (cron `cc90c7ea`, fires every 15 min) picks up AISDLC-352 (Phase 1, no deps) and chains the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)