### PR TITLE
chore(backlog): triage 4 stale In-Progress tasks (file 314/367/413, revert 259)

### DIFF
--- a/backlog/completed/aisdlc-314 - feat-RFC-0009-phase-2-per-soul-dsb-and-calibration.md
+++ b/backlog/completed/aisdlc-314 - feat-RFC-0009-phase-2-per-soul-dsb-and-calibration.md
@@ -1,7 +1,7 @@
 ---
 id: AISDLC-314
 title: 'feat: RFC-0009 Phase 2.2 — Per-soul DSB authoring + Cκ per-soul calibration aggregation'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-16'
 labels:

--- a/backlog/completed/aisdlc-367 - fix-ci-detect-changes-paths-filter-race-on-merge-group.md
+++ b/backlog/completed/aisdlc-367 - fix-ci-detect-changes-paths-filter-race-on-merge-group.md
@@ -1,7 +1,7 @@
 ---
 id: AISDLC-367
 title: 'fix(ci): Detect Changes paths-filter races merge_group ephemeral branch deletion'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-05-18'
 labels:

--- a/backlog/completed/aisdlc-413 - fix-skill-body-orchestrator-flag-gates-post-411.md
+++ b/backlog/completed/aisdlc-413 - fix-skill-body-orchestrator-flag-gates-post-411.md
@@ -1,7 +1,7 @@
 ---
 id: AISDLC-413
 title: 'fix(plugin): update orchestrator-tick + dispatch-worker skill-body env gates to match AISDLC-411 default-ON polarity'
-status: In Progress
+status: Done
 labels: [plugin, rfc-0015, post-411, operator-merge]
 references:
   - ai-sdlc-plugin/commands/dispatch-worker.md

--- a/backlog/tasks/aisdlc-259 - fix-tui-panel-border-misalignment-on-critical-path-and-operator-throughput-row.md
+++ b/backlog/tasks/aisdlc-259 - fix-tui-panel-border-misalignment-on-critical-path-and-operator-throughput-row.md
@@ -1,7 +1,7 @@
 ---
 id: AISDLC-259
 title: Fix TUI panel border misalignment on CRITICAL PATH + OPERATOR THROUGHPUT row
-status: In Progress
+status: To Do
 assignee: []
 created_date: '2026-05-12 09:55'
 labels:


### PR DESCRIPTION
## Summary

Triages the 4 In-Progress backlog tasks the AISDLC-243 frontier audit surfaced.

| Task | PR | Action in this PR |
|---|---|---|
| AISDLC-314 | #562 MERGED 2026-05-19 | Move to completed/, set status Done |
| AISDLC-367 | #551 MERGED 2026-05-18 | Move to completed/, set status Done |
| AISDLC-413 | #645 MERGED | Move to completed/, set status Done |
| AISDLC-259 | No PR; 2 abandoned branches | Revert status To Do (re-enters frontier) |

## Why 314/367/413 were stuck

PRs shipped cleanly but the task file lifecycle close never landed — file stayed in `backlog/tasks/` with `status: In Progress`. The `scripts/check-task-moved.sh` pre-push hook usually catches this, but if the dev subagent exited mid-cleanup OR the PR was hand-merged outside the normal `/ai-sdlc execute` path, the move was skipped.

## Why 259 has no PR

Two abandoned branches exist, both from 2026-05-12 (14 days old):

- `fix/aisdlc-259-tui-panel-border-misalignment` — has the actual fix (`950712cc`) but main has moved significantly since; rebasing would be a major exercise
- `ai-sdlc/aisdlc-259-fix-tui-panel-border-misalignment-on-critical-path` — 30 commits of AISDLC-242 test-fixture `wip(checkpoint)` pollution (literal strings like `"word word word..."` and `"$(echo pwned)"`)

Reverting AISDLC-259 to `To Do` lets it re-enter the frontier; if the bug still exists in the current TUI code, fresh dispatch picks it up. The two stale branches are left alone for operator decision (delete vs revive).

## Test plan

- [x] Docs-only diff (`backlog/{tasks,completed}/*.md`)
- [x] Skips `verify-attestation.yml` + `ai-sdlc-review.yml` via `paths-ignore`
- [x] Auto-merges once `ai-sdlc/pr-ready` + `Backlog Drift` pass
- [ ] After merge: `cli-deps frontier` adds AISDLC-259 back; 314/367/413 absent from open backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)