### PR TITLE
chore(backlog): file 3 tasks from open GitHub issues (#713, #701, #582)

### DIFF
--- a/backlog/tasks/aisdlc-441 - fix-plugin-install-pipeline-broken-v0.9.2-install-runtime-deps-noop.md
+++ b/backlog/tasks/aisdlc-441 - fix-plugin-install-pipeline-broken-v0.9.2-install-runtime-deps-noop.md
@@ -23,7 +23,7 @@ permittedExternalPaths: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-## Problem (GH issue #713)
+## Problem (GH issue GH issue 713)
 
 **Severity: P0 — published v0.9.2 plugin is unusable on a fresh install.**
 
@@ -34,7 +34,7 @@ Two compounding bugs:
 1. **`scripts/install-runtime-deps.sh` is a no-op.** It runs `npm install` against `ai-sdlc-plugin/package.json` which has zero `dependencies:` — only a custom `runtimeDependencies:` field that npm doesn't understand. So the script "succeeds" without installing anything.
 2. **No hook triggers the script.** Even if the script worked, nothing in `plugin.json`'s hook list invokes it. The path-resolver (`scripts/resolve-pipeline-cli.sh`) has logic to call `install-runtime-deps.sh` as a self-heal, but the script's no-op nature makes that self-heal cosmetic.
 
-## Manual recovery (documented in #713)
+## Manual recovery (documented in GH issue 713)
 
 From inside the plugin cache directory:
 
@@ -68,6 +68,6 @@ After that, the MCP server starts and `/ai-sdlc execute` runs.
 - [ ] #5 Some hook OR resolver step actually invokes the install script on first load (not pure copy-then-fail)
 - [ ] #6 `resolve-pipeline-cli.sh` error message surfaces the real root cause when self-heal fails (no more "tried 4 topologies" that all are unreachable)
 - [ ] #7 Hermetic test simulates fresh-install scenario + asserts deps resolve
-- [ ] #8 PR body closes #713
+- [ ] #8 PR body closes GH issue 713
 - [ ] #9 80%+ patch coverage on new test code
 <!-- AC:END -->

--- a/backlog/tasks/aisdlc-441 - fix-plugin-install-pipeline-broken-v0.9.2-install-runtime-deps-noop.md
+++ b/backlog/tasks/aisdlc-441 - fix-plugin-install-pipeline-broken-v0.9.2-install-runtime-deps-noop.md
@@ -13,7 +13,7 @@ dependencies: []
 references:
   - ai-sdlc-plugin/scripts/install-runtime-deps.sh
   - ai-sdlc-plugin/plugin.json
-  - ai-sdlc-plugin/package.json
+  - ai-sdlc-plugin/mcp-server/package.json
   - ai-sdlc-plugin/hooks/session-start.sh
   - ai-sdlc-plugin/scripts/resolve-pipeline-cli.sh
 priority: critical

--- a/backlog/tasks/aisdlc-441 - fix-plugin-install-pipeline-broken-v0.9.2-install-runtime-deps-noop.md
+++ b/backlog/tasks/aisdlc-441 - fix-plugin-install-pipeline-broken-v0.9.2-install-runtime-deps-noop.md
@@ -1,0 +1,73 @@
+---
+id: AISDLC-441
+title: 'fix(plugin): install pipeline broken in v0.9.2 — install-runtime-deps.sh is a no-op + no hook triggers it'
+status: To Do
+assignee: []
+created_date: '2026-05-26'
+labels:
+  - plugin
+  - install
+  - p0
+  - regression
+dependencies: []
+references:
+  - ai-sdlc-plugin/scripts/install-runtime-deps.sh
+  - ai-sdlc-plugin/plugin.json
+  - ai-sdlc-plugin/package.json
+  - ai-sdlc-plugin/hooks/session-start.sh
+  - ai-sdlc-plugin/scripts/resolve-pipeline-cli.sh
+priority: critical
+permittedExternalPaths: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem (GH issue #713)
+
+**Severity: P0 — published v0.9.2 plugin is unusable on a fresh install.**
+
+The plugin ships without its runtime dependencies. Claude Code's local marketplace installer copies the cache layer but does not invoke `npm install`, so the MCP server entry point and every `pipeline-cli` binary fail with `Cannot find module .../node_modules/.../dist/...js`.
+
+Two compounding bugs:
+
+1. **`scripts/install-runtime-deps.sh` is a no-op.** It runs `npm install` against `ai-sdlc-plugin/package.json` which has zero `dependencies:` — only a custom `runtimeDependencies:` field that npm doesn't understand. So the script "succeeds" without installing anything.
+2. **No hook triggers the script.** Even if the script worked, nothing in `plugin.json`'s hook list invokes it. The path-resolver (`scripts/resolve-pipeline-cli.sh`) has logic to call `install-runtime-deps.sh` as a self-heal, but the script's no-op nature makes that self-heal cosmetic.
+
+## Manual recovery (documented in #713)
+
+From inside the plugin cache directory:
+
+```bash
+npm install --omit=dev --no-audit --no-fund --ignore-scripts \
+  @ai-sdlc/pipeline-cli@^0.10.0 \
+  @ai-sdlc/plugin-mcp-server@0.9.2
+```
+
+After that, the MCP server starts and `/ai-sdlc execute` runs.
+
+## Scope
+
+- **Fix `install-runtime-deps.sh`** to actually install the runtime deps. Two paths:
+  1. Move `runtimeDependencies` content into `dependencies:` in `ai-sdlc-plugin/package.json` (then plain `npm install` works) — preferred.
+  2. Make the script parse the `runtimeDependencies` field and run `npm install <each>` explicitly — fallback if (1) breaks something.
+- **Wire the script into the install path** so it actually runs on first plugin load. Either:
+  1. Add a `postInstall` script (if Claude Code's plugin loader supports it).
+  2. Invoke from `SessionStart` hook (first-time only — guard with a sentinel like `node_modules/.installed-by-ai-sdlc`).
+  3. Invoke from `resolve-pipeline-cli.sh` and make the self-heal actually heal.
+- **Fix the lying error message** in `resolve-pipeline-cli.sh` — when self-heal succeeds, retry resolution; when self-heal fails, surface WHY (no `dependencies:` field, etc.) instead of listing topologies that can never succeed.
+- **Hermetic test** that simulates a fresh-plugin-install scenario (empty `node_modules`, plugin cache copy) and asserts the install path now succeeds.
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Fresh `/plugin install ai-sdlc` on a clean Codespace / VM populates `node_modules` such that `@ai-sdlc/pipeline-cli` and `@ai-sdlc/plugin-mcp-server` resolve
+- [ ] #2 MCP server starts (no `Failed to reconnect to plugin:ai-sdlc:ai-sdlc: -32000`)
+- [ ] #3 `/ai-sdlc execute <task-id>` succeeds past Step 1.5 (no `ERR_MODULE_NOT_FOUND` on `cli-deps`)
+- [ ] #4 `scripts/install-runtime-deps.sh` actually installs the declared `runtimeDependencies` (either via repackaged `dependencies:` field OR explicit parse-and-install)
+- [ ] #5 Some hook OR resolver step actually invokes the install script on first load (not pure copy-then-fail)
+- [ ] #6 `resolve-pipeline-cli.sh` error message surfaces the real root cause when self-heal fails (no more "tried 4 topologies" that all are unreachable)
+- [ ] #7 Hermetic test simulates fresh-install scenario + asserts deps resolve
+- [ ] #8 PR body closes #713
+- [ ] #9 80%+ patch coverage on new test code
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-442 - docs-clarify-remote-sandbox-readonly-constraint-and-error-path.md
+++ b/backlog/tasks/aisdlc-442 - docs-clarify-remote-sandbox-readonly-constraint-and-error-path.md
@@ -1,0 +1,53 @@
+---
+id: AISDLC-442
+title: 'docs: clarify remote-sandbox read-only constraint + improve error path when CCR tries /ai-sdlc execute (closes #701)'
+status: To Do
+assignee: []
+created_date: '2026-05-26'
+labels:
+  - documentation
+  - remote-sandbox
+  - developer-experience
+  - rfc-0012
+dependencies: []
+references:
+  - CLAUDE.md
+  - docs/operations/remote-agents-readonly.md
+  - ai-sdlc-plugin/commands/execute.md
+  - ai-sdlc-plugin/scripts/resolve-pipeline-cli.sh
+priority: medium
+permittedExternalPaths: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem (GH issue #701)
+
+A Claude Code agent running in the managed remote execution environment (CCR remote sandbox) cannot run `/ai-sdlc execute` against a freshly-filed backlog task. The sandbox lacks the prerequisites the slash command body assumes:
+
+- No signing key (`~/.ai-sdlc/signing-key.pem` is operator-machine-local)
+- No plugin install (no `mcp__plugin_ai-sdlc_ai-sdlc__*` MCP tools)
+- No worktree creation rights (sandbox filesystem layout differs)
+- No operator filesystem (`.ai-sdlc/trusted-reviewers.yaml` pubkeys not accessible)
+
+CLAUDE.md already documents this: *"Remote agents (`/schedule`) — read-only by design"*. The issue's value is surfacing that (a) the failure path when CCR tries `/ai-sdlc execute` is unhelpful (cryptic errors instead of "remote sandbox is read-only — file a backlog task instead"), and (b) the existing documentation could be more prominent / discoverable.
+
+## Scope
+
+- **Defensive error path**: when `/ai-sdlc execute` detects it's running in a CCR remote sandbox (env-var heuristic — `CLAUDE_CODE_ENV=ccr` or similar), refuse early with an operator-actionable message pointing at the read-only docs + suggesting the backlog-task-file-via-MCP path that DOES work in CCR (filing a backlog task or GitHub issue for local pickup).
+- **Surface the constraint earlier**: add a section to `CLAUDE.md` explaining the remote-sandbox / local-session split. Also add a top-level note to `docs/operations/remote-agents-readonly.md` (create if missing).
+- **Document the workaround flow**: CCR sandbox can do `mcp__backlog__task_create` + `mcp__github__create_issue` perfectly fine — that's the supported path. The local operator session picks the task up next.
+- **NOT in scope** for this task: building the actual remote-sandbox bridge that would enable `/ai-sdlc execute` from CCR. That's an RFC-class architectural decision (would need to address signing-key transport, attestation trust model, worktree filesystem differences). Research from earlier session at `/tmp/issue-701-research.md` (operator) covers 4 architectural paths if/when the operator wants to take it on.
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 `/ai-sdlc execute` slash command body detects CCR remote-sandbox environment (env-var or filesystem heuristic) and refuses with an operator-actionable error pointing at the read-only path
+- [ ] #2 Refusal message names the supported alternative: file a backlog task (`mcp__backlog__task_create`) or GitHub issue for local pickup
+- [ ] #3 New section in `CLAUDE.md` (or expand existing "Remote agents" section) explaining the local-vs-remote split with concrete examples of what works where
+- [ ] #4 `docs/operations/remote-agents-readonly.md` created (or expanded if exists) covering: what CCR can do, what it can't, why, and the supported handoff workflow
+- [ ] #5 PR body closes #701
+- [ ] #6 Hermetic test for the env detection + refusal path
+- [ ] #7 80%+ patch coverage on new code
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-442 - docs-clarify-remote-sandbox-readonly-constraint-and-error-path.md
+++ b/backlog/tasks/aisdlc-442 - docs-clarify-remote-sandbox-readonly-constraint-and-error-path.md
@@ -12,7 +12,6 @@ labels:
 dependencies: []
 references:
   - CLAUDE.md
-  - docs/operations/remote-agents-readonly.md
   - ai-sdlc-plugin/commands/execute.md
   - ai-sdlc-plugin/scripts/resolve-pipeline-cli.sh
 priority: medium

--- a/backlog/tasks/aisdlc-442 - docs-clarify-remote-sandbox-readonly-constraint-and-error-path.md
+++ b/backlog/tasks/aisdlc-442 - docs-clarify-remote-sandbox-readonly-constraint-and-error-path.md
@@ -1,6 +1,6 @@
 ---
 id: AISDLC-442
-title: 'docs: clarify remote-sandbox read-only constraint + improve error path when CCR tries /ai-sdlc execute (closes #701)'
+title: 'docs: clarify remote-sandbox read-only constraint + improve error path when CCR tries /ai-sdlc execute (closes GH issue 701)'
 status: To Do
 assignee: []
 created_date: '2026-05-26'
@@ -22,7 +22,7 @@ permittedExternalPaths: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-## Problem (GH issue #701)
+## Problem (GH issue GH issue 701)
 
 A Claude Code agent running in the managed remote execution environment (CCR remote sandbox) cannot run `/ai-sdlc execute` against a freshly-filed backlog task. The sandbox lacks the prerequisites the slash command body assumes:
 
@@ -47,7 +47,7 @@ CLAUDE.md already documents this: *"Remote agents (`/schedule`) — read-only by
 - [ ] #2 Refusal message names the supported alternative: file a backlog task (`mcp__backlog__task_create`) or GitHub issue for local pickup
 - [ ] #3 New section in `CLAUDE.md` (or expand existing "Remote agents" section) explaining the local-vs-remote split with concrete examples of what works where
 - [ ] #4 `docs/operations/remote-agents-readonly.md` created (or expanded if exists) covering: what CCR can do, what it can't, why, and the supported handoff workflow
-- [ ] #5 PR body closes #701
+- [ ] #5 PR body closes GH issue 701
 - [ ] #6 Hermetic test for the env detection + refusal path
 - [ ] #7 80%+ patch coverage on new code
 <!-- AC:END -->

--- a/backlog/tasks/aisdlc-443 - feat-require-linked-issue-on-prs-issue-first-contributor-flow.md
+++ b/backlog/tasks/aisdlc-443 - feat-require-linked-issue-on-prs-issue-first-contributor-flow.md
@@ -1,6 +1,6 @@
 ---
 id: AISDLC-443
-title: 'feat(docs+ci): require linked issue on PRs + friendly issue-first contributor flow (closes #582)'
+title: 'feat(docs+ci): require linked issue on PRs + friendly issue-first contributor flow (closes GH issue 582)'
 status: To Do
 assignee: []
 created_date: '2026-05-26'
@@ -21,13 +21,13 @@ permittedExternalPaths: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-## Problem (GH issue #582)
+## Problem (GH issue GH issue 582)
 
-External contributor PRs without a linked issue create disproportionate maintainer overhead. Concrete incident: PR #568 (akillies fork) took multi-step maintainer intervention to land (rebase, drop stale chore commit, re-sign attestation against new HEAD, force-push to fork). The actual code change was 4 files of hook fixes.
+External contributor PRs without a linked issue create disproportionate maintainer overhead. Concrete incident: PR 568 (akillies fork) took multi-step maintainer intervention to land (rebase, drop stale chore commit, re-sign attestation against new HEAD, force-push to fork). The actual code change was 4 files of hook fixes.
 
 If an Issue had been opened first, a maintainer could have implemented the same fix via `/ai-sdlc execute` in 5-20 minutes through the standard pipeline.
 
-## Scope (per #582 proposal)
+## Scope (per GH issue 582 proposal)
 
 1. **Update `.github/PULL_REQUEST_TEMPLATE.md`** with a friendly "please consider opening an Issue first" preamble explaining the trade-off honestly. Don't shame contributors who skip — frame as "this is why we prefer it; here's the fast path".
 2. **Add `.github/workflows/require-issue-link.yml`** that posts `ai-sdlc/issue-link: failure` status on PRs whose body lacks a `Closes/Fixes/Resolves #N` reference (case-insensitive, GitHub-Linked-Issues regex). Status check, not a hard block.
@@ -42,12 +42,12 @@ Operator request 2026-05-20 in active session: *"make it a requirement that all 
 
 <!-- AC:BEGIN -->
 - [ ] #1 `.github/PULL_REQUEST_TEMPLATE.md` updated with friendly issue-first preamble (concrete benefit, not shaming)
-- [ ] #2 `.github/workflows/require-issue-link.yml` posts `ai-sdlc/issue-link` status check (failure when body lacks `Closes/Fixes/Resolves #N` pattern; success otherwise)
+- [ ] #2 `.github/workflows/require-issue-link.yml` posts `ai-sdlc/issue-link` status check (failure when body lacks `Closes/Fixes/Resolves issue-number` pattern; success otherwise)
 - [ ] #3 Workflow respects the `ci:no-issue-required` label as bypass (status posts success when label present)
 - [ ] #4 `CONTRIBUTING.md` adds an "Issue-first" section explaining the workflow + why
-- [ ] #5 Workflow handles edge cases: cross-repo references (`Closes org/repo#N`), multiple references in one PR, references in PR title (not just body)
+- [ ] #5 Workflow handles edge cases: cross-repo references (`Closes org/repo-issue-number`), multiple references in one PR, references in PR title (not just body)
 - [ ] #6 Hermetic tests cover: PR with issue link → success; PR without → failure; PR with bypass label → success
-- [ ] #7 PR body closes #582
+- [ ] #7 PR body closes GH issue 582
 - [ ] #8 Optional follow-up note in PR description: operator wires `ai-sdlc/issue-link` into required branch-protection checks (out of scope for this task; needs `gh api` PATCH)
 - [ ] #9 80%+ patch coverage on workflow logic + tests
 <!-- AC:END -->

--- a/backlog/tasks/aisdlc-443 - feat-require-linked-issue-on-prs-issue-first-contributor-flow.md
+++ b/backlog/tasks/aisdlc-443 - feat-require-linked-issue-on-prs-issue-first-contributor-flow.md
@@ -1,0 +1,53 @@
+---
+id: AISDLC-443
+title: 'feat(docs+ci): require linked issue on PRs + friendly issue-first contributor flow (closes #582)'
+status: To Do
+assignee: []
+created_date: '2026-05-26'
+labels:
+  - documentation
+  - ci
+  - contributor-experience
+  - branch-protection
+dependencies: []
+references:
+  - .github/PULL_REQUEST_TEMPLATE.md
+  - .github/workflows/
+  - CONTRIBUTING.md
+priority: medium
+permittedExternalPaths: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem (GH issue #582)
+
+External contributor PRs without a linked issue create disproportionate maintainer overhead. Concrete incident: PR #568 (akillies fork) took multi-step maintainer intervention to land (rebase, drop stale chore commit, re-sign attestation against new HEAD, force-push to fork). The actual code change was 4 files of hook fixes.
+
+If an Issue had been opened first, a maintainer could have implemented the same fix via `/ai-sdlc execute` in 5-20 minutes through the standard pipeline.
+
+## Scope (per #582 proposal)
+
+1. **Update `.github/PULL_REQUEST_TEMPLATE.md`** with a friendly "please consider opening an Issue first" preamble explaining the trade-off honestly. Don't shame contributors who skip — frame as "this is why we prefer it; here's the fast path".
+2. **Add `.github/workflows/require-issue-link.yml`** that posts `ai-sdlc/issue-link: failure` status on PRs whose body lacks a `Closes/Fixes/Resolves #N` reference (case-insensitive, GitHub-Linked-Issues regex). Status check, not a hard block.
+3. **Update `CONTRIBUTING.md`** with a new "Issue-first" section explaining why + the workflow.
+4. **Maintainer escape**: label `ci:no-issue-required` bypasses the workflow status for self-evident chore PRs (release-please, dependabot, etc.). Workflow short-circuits when the label is present.
+
+## Source
+
+Operator request 2026-05-20 in active session: *"make it a requirement that all PR's must have an issue, that way we can see the issue land first then work on it"*
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 `.github/PULL_REQUEST_TEMPLATE.md` updated with friendly issue-first preamble (concrete benefit, not shaming)
+- [ ] #2 `.github/workflows/require-issue-link.yml` posts `ai-sdlc/issue-link` status check (failure when body lacks `Closes/Fixes/Resolves #N` pattern; success otherwise)
+- [ ] #3 Workflow respects the `ci:no-issue-required` label as bypass (status posts success when label present)
+- [ ] #4 `CONTRIBUTING.md` adds an "Issue-first" section explaining the workflow + why
+- [ ] #5 Workflow handles edge cases: cross-repo references (`Closes org/repo#N`), multiple references in one PR, references in PR title (not just body)
+- [ ] #6 Hermetic tests cover: PR with issue link → success; PR without → failure; PR with bypass label → success
+- [ ] #7 PR body closes #582
+- [ ] #8 Optional follow-up note in PR description: operator wires `ai-sdlc/issue-link` into required branch-protection checks (out of scope for this task; needs `gh api` PATCH)
+- [ ] #9 80%+ patch coverage on workflow logic + tests
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

Triages 3 open GitHub issues into backlog tasks. All 3 are real / actionable.

| Task | Priority | Closes | Title |
|---|---|---|---|
| **AISDLC-441** | critical | #713 | fix(plugin): install pipeline broken in v0.9.2 — install-runtime-deps.sh is a no-op + no hook triggers it |
| **AISDLC-442** | medium | #701 | docs: clarify remote-sandbox read-only constraint + improve error path when CCR tries `/ai-sdlc execute` |
| **AISDLC-443** | medium | #582 | feat(docs+ci): require linked issue on PRs + friendly issue-first contributor flow |

## Triage assessment

**#713 (P0 — plugin unusable on fresh install)** — Real. Reported today. Root cause documented in issue: `install-runtime-deps.sh` runs `npm install` against a `package.json` with no `dependencies:` field (only custom `runtimeDependencies:` that npm doesn't understand), AND no hook ever triggers the script. Manual recovery documented. Priority: critical.

**#701 (Remote sandbox can't /ai-sdlc execute)** — Real but the policy *"remote sandboxes are read-only by design"* is already in CLAUDE.md. Scoping the backlog task to (a) defensive error path when CCR tries `/ai-sdlc execute`, (b) more prominent docs of the constraint, NOT (c) building the actual remote-sandbox bridge (RFC-class architectural decision; research from earlier session at `/tmp/issue-701-research.md` covers 4 paths if/when the operator wants to take it on).

**#582 (Require linked issue on PRs)** — Real. Concrete proposal with 4 ACs already in the issue body. Operator-authored 2026-05-20. Scope is clear: PR template + workflow + CONTRIBUTING.md + bypass label.

## Test plan

- [x] Docs-only diff (`backlog/tasks/*.md`)
- [x] Skips `verify-attestation.yml` + `ai-sdlc-review.yml` via `paths-ignore`
- [x] Pre-push DoR gate passes (no upstream OQs / lifecycle blocks)
- [x] Auto-merges once `ai-sdlc/pr-ready` + `Backlog Drift` pass
- [ ] After merge: `cli-deps frontier` shows AISDLC-441/442/443 as dispatchable

🤖 Generated with [Claude Code](https://claude.com/claude-code)