### PR TITLE
docs(rfc): operator sign-off on RFC-0031 (calibration-driven DID revision)

### DIFF
--- a/spec/rfcs/RFC-0031-calibration-driven-did-revision-proposal.md
+++ b/spec/rfcs/RFC-0031-calibration-driven-did-revision-proposal.md
@@ -46,7 +46,7 @@ This RFC defines a **PPA mechanism** (the proposal-generation path), not a **DID
 | Person | Role | Status | Date |
 |--------|------|--------|------|
 | Alexander Kline | Head of Product Strategy / Product Authority | ✍️ Authored v1 | 2026-05-04 |
-| Dominique Legault | CTO / Engineering Authority | ⏸ Pending | — |
+| Dominique Legault | CTO / Engineering Authority + AI-SDLC Operator | ✅ Signed (all 5 OQs resolved per audit-affirmed walkthrough 2026-05-16; lifecycle Implemented via AISDLC-271) | 2026-05-27 |
 | Morgan Hirtle | Chief of Design / Design Authority | ⏸ Pending | — |
 
 ## Revision History


### PR DESCRIPTION
## Summary

One-line operator sign-off on RFC-0031.

Operator authorization: *"Add my sign off to any of the RFC's that I resolve the open questions for."*

## Change

RFC-0031 §Sign-Off table:
- **Dominique Legault** (CTO / Engineering Authority + AI-SDLC Operator): ⏸ Pending → ✅ Signed 2026-05-27
- All 5 OQs resolved per audit-affirmed walkthrough 2026-05-16
- Lifecycle Implemented via AISDLC-271; resolutions shipped normatively in §12
- Role label promoted Engineering Authority → Engineering Authority + AI-SDLC Operator (per \`project_team_roles\` convention: dominique covers both pillars)

Alex (Product) row unchanged (✍️ Authored v1 2026-05-04). Morgan (Design) row unchanged (⏸ Pending — not auto-filled).

## Sibling sign-off PRs (current batch)

| PR | Coverage |
|---|---|
| **#742** | RFC-0019, RFC-0022, RFC-0030, RFC-0035 sign-offs |
| **#743** | RFC-0028 sign-off (this session's walkthrough) |
| **#739** | RFC-0024 sign-off (Refit Phase 6) |
| **#744** (this PR) | RFC-0031 sign-off |
| — | RFC-0036 sign-off blocked on stray \`## Open Questions\` template placeholder at line 298 (operator triage required first; punted) |

## Verification

- [x] Single 1-line edit; docs-only PR
- [x] Drift gate: 0 errors
- [x] No reference / lifecycle / OQ-count changes — purely a sign-off-status update

🤖 Generated with [Claude Code](https://claude.com/claude-code)