### PR TITLE
docs: add AISDLC-480 + AISDLC-481 — parallel-dispatch decision-routing + IPC gaps

### DIFF
--- a/backlog/tasks/aisdlc-480 - feat-surface-dispatched-session-decisions-to-decision-catalog.md
+++ b/backlog/tasks/aisdlc-480 - feat-surface-dispatched-session-decisions-to-decision-catalog.md
@@ -1,0 +1,57 @@
+---
+id: AISDLC-480
+title: 'feat: surface dispatched-session decisions to the Decision Catalog (async escape hatch for AskUserQuestion + blocked OQs)'
+status: To Do
+assignee: []
+created_date: '2026-05-30 09:12'
+labels:
+  - dispatch
+  - decision-catalog
+  - observability
+  - parallelism
+  - rfc-0035
+dependencies: []
+references:
+  - spec/rfcs/RFC-0035-decision-catalog-operator-routing.md
+  - spec/rfcs/RFC-0041-conductor-worker-process-architecture.md
+  - spec/rfcs/RFC-0011-definition-of-ready-gate.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A 2026-05-30 code audit found the Decision Catalog (RFC-0035, cli-decisions.mjs, default-ON via AI_SDLC_DECISION_CATALOG) is NOT wired to receive decisions from dispatched Claude Code sessions. Evidence: grepping for `cli-decisions add` across ai-sdlc-plugin/commands/execute.md and pipeline-cli/src/steps/ returns zero matches. The developer subagent's escalation contract (developer.md hard rule eight) returns prUrl:null plus a notes field; that notes field is a dead-letter box — an operator must manually read it and run `cli-decisions add` by hand.
+
+Worse: a detached session (a tmux pane or a `claude -p` worker) that hits AskUserQuestion hangs indefinitely, because interactive /ask only works with an attached operator session. The Decision Catalog was the intended async escape hatch for exactly this case, and it is currently unwired. This blocks safe unattended parallel dispatch: a worker can stall silently with no operator-visible signal.
+
+Goal: when a dispatched session (native background-Agent dispatch OR a tmux/claude-p worker) encounters a decision point (a blocking open question, a scope-creep choice, or an AskUserQuestion-class question), it creates a Decision Catalog record via `cli-decisions add` instead of hanging or silently dead-lettering into a PR comment. The record routes to the operator asynchronously; the session either continues with a documented assumption or fails cleanly while emitting the catalog reference.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+
+- [ ] AC-1: The developer-subagent escalation path (prUrl:null plus notes) ALSO creates a Decision Catalog entry via `cli-decisions add` (or a library equivalent) carrying the taskId, the RFC/open-question reference, and the available options, so escalations appear in `cli-decisions list` rather than only in a PR comment.
+- [ ] AC-2: A detached or non-interactive session that would otherwise call AskUserQuestion routes the question to the Decision Catalog as an async decision record and fails cleanly (non-zero exit, with the decision id printed in its output) rather than hanging.
+- [ ] AC-3: The integration is mechanism-agnostic: it works for native background-Agent dispatch, the tmux execute-parallel path, and claude-p workers.
+- [ ] AC-4: The Decision Catalog record schema captures enough context to resume work: taskId, decision summary, options, source (which session and worktree), and a stable decision id.
+- [ ] AC-5: Hermetic tests cover three cases — escalation creates a catalog record; a non-interactive AskUserQuestion routes to the catalog and fails cleanly; no catalog write occurs when AI_SDLC_DECISION_CATALOG is off.
+- [ ] AC-6: Docs: update the relevant runbook under docs/operations/ describing how dispatched-session decisions surface and how the operator answers and resumes them.
+
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The implementation extends the existing cli-decisions.mjs entry point (pipeline-cli/src/cli/decisions.ts). Per AISDLC-298, dispatched sessions never self-resolve open questions — they route each one to the catalog for an operator decision. The orchestrator-tick.md skill body (around line 670) already describes Decision Catalog filing, but today only as a manual operator step; this task makes the dispatched session itself the producer.
+<!-- SECTION:NOTES:END -->
+
+## References
+
+- spec/rfcs/RFC-0035-decision-catalog-operator-routing.md
+- spec/rfcs/RFC-0041-conductor-worker-process-architecture.md
+- spec/rfcs/RFC-0011-definition-of-ready-gate.md
+- pipeline-cli/src/cli/decisions.ts
+- ai-sdlc-plugin/commands/execute.md
+- ai-sdlc-plugin/agents/developer.md
+- AISDLC-298

--- a/backlog/tasks/aisdlc-481 - feat-dispatch-session-heartbeat-reaper-and-control-channel.md
+++ b/backlog/tasks/aisdlc-481 - feat-dispatch-session-heartbeat-reaper-and-control-channel.md
@@ -1,0 +1,57 @@
+---
+id: AISDLC-481
+title: 'feat: dispatch-session heartbeat liveness reaper + back-channel for parallel-execute sessions'
+status: To Do
+assignee: []
+created_date: '2026-05-30 09:14'
+labels:
+  - dispatch
+  - observability
+  - parallelism
+  - ipc
+  - rfc-0041
+dependencies: []
+references:
+  - spec/rfcs/RFC-0041-conductor-worker-process-architecture.md
+  - spec/rfcs/RFC-0015-autonomous-pipeline-orchestrator.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The 2026-05-30 audit found that IPC between the orchestrator and dispatched tmux/parallel sessions is one-way only. Dispatched `/ai-sdlc execute` sessions write `.ai-sdlc/dispatch/sessions/<task>.session.json` with currentStep plus lastHeartbeat (via execute.md update_session_state), and execute-parallel-status reads it for a status table. But two gaps remain.
+
+First, no reaper consumes lastHeartbeat to detect a dead session. The only stale-heartbeat sweeper operates on the separate Dispatch Board inflight/*.state.json substrate, not the tmux session files — the two substrates are unconnected, so a tmux worker can die while its session file shows it alive.
+
+Second, there is no back-channel. Nothing the orchestrator writes is read by a running session, so there is no pause, cancel, or answer capability once a session is in flight.
+
+Goal: add liveness detection for the tmux session-file substrate and a minimal control back-channel, so a running dispatched session can be cancelled and can pick up an operator answer. This pairs directly with AISDLC-480's decision routing: AISDLC-480 surfaces the question, this task carries the answer back.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+
+- [ ] AC-1: A reaper detects sessions whose lastHeartbeat is older than a configurable threshold and marks them failed in the session file; execute-parallel-status surfaces the failed state.
+- [ ] AC-2: The reaper reconciles the two substrates: a tmux session-file death and the Dispatch Board inflight state are kept consistent, with no orphan in one substrate while the other still shows the session alive.
+- [ ] AC-3: A minimal back-channel lets the orchestrator write a control signal (cancel) that a running `/ai-sdlc execute` session reads at its step boundaries and honors — performing a clean abort and marking the session file cancelled.
+- [ ] AC-4: The control channel composes with AISDLC-480: an operator decision answer can be delivered to a paused session so it resumes; if resume is out of scope for v1, the session instead fails cleanly while emitting the decision id. This task scopes the back-channel to cancel-only for v1 and defers full pause/resume to a follow-up; AC-4 is satisfied by the clean-fail-with-decision-id path under that v1 scope.
+- [ ] AC-5: Hermetic tests cover three cases — a stale heartbeat is reaped; a cancel signal is honored at the next step boundary; two-substrate consistency holds after a reap.
+- [ ] AC-6: Docs: update docs/operations/parallel-dispatch.md with the liveness and cancel semantics.
+
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Build on execute.md's update_session_state writer plus the Dispatch Board sweeper in pipeline-cli/src/dispatch/board.ts. Keep the implementation mechanism-agnostic where possible. Scope decision for v1, stated explicitly: the back-channel is cancel-only; full pause/resume of a running session is a deliberate follow-up, not part of this task. AC-4's resume path is therefore satisfied in v1 by the clean-fail-with-decision-id behavior, with true resume tracked separately.
+<!-- SECTION:NOTES:END -->
+
+## References
+
+- spec/rfcs/RFC-0041-conductor-worker-process-architecture.md (conductor/worker IPC this task makes bidirectional)
+- spec/rfcs/RFC-0015-autonomous-pipeline-orchestrator.md (autonomous-orchestrator liveness expectations)
+- pipeline-cli/src/dispatch/board.ts (Dispatch Board stale-heartbeat sweeper to reconcile against)
+- ai-sdlc-plugin/commands/execute.md (update_session_state writer + step boundaries where cancel is read)
+- .ai-sdlc/dispatch/sessions/ (the tmux session-file substrate the reaper operates on)
+- AISDLC-480 (decision routing the back-channel delivers answers for)


### PR DESCRIPTION
Two backlog tasks closing gaps found in the 2026-05-30 parallel-dispatch audit: AISDLC-480 wires dispatched-session decisions to the Decision Catalog (async escape hatch for AskUserQuestion + blocked OQs — currently unwired, detached sessions hang); AISDLC-481 adds session-heartbeat liveness reaping + a cancel back-channel (IPC is one-way today). Docs-only; auto-merges.