### PR TITLE
docs: add AISDLC-482 (rm-guard) + AISDLC-483 (codex/sonnet dispatch defaults)

### DIFF
--- a/backlog/tasks/aisdlc-482 - fix-guard-rm-on-possibly-empty-path-vars-in-cleanup-worktree-code.md
+++ b/backlog/tasks/aisdlc-482 - fix-guard-rm-on-possibly-empty-path-vars-in-cleanup-worktree-code.md
@@ -1,0 +1,42 @@
+---
+id: AISDLC-482
+title: >-
+  fix: guard rm -rf "$VAR/$x" on possibly-empty path vars so autonomous runs
+  aren't blocked by the rm-safety prompt
+status: To Do
+assignee: []
+created_date: '2026-05-30 20:30'
+labels:
+  - bug
+  - autonomy
+  - safety
+  - cleanup
+  - worktree
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+During autonomous/--dangerously-skip-permissions operation, Claude Code's built-in safety guard still interrupts with prompts like `Dangerous rm operation on possibly-empty variable path: "$WT/$p"` whenever a script constructs `rm -rf "$SOMEVAR/$x"` where `$SOMEVAR` could be empty (which would expand to `rm -rf /$x` — a root-relative path wipeout). This blocks unattended operation even when permissions are otherwise skipped.
+
+The framework's own cleanup and worktree code emits such patterns. Known sites include `ai-sdlc-plugin/commands/cleanup.md`, `ai-sdlc-plugin/commands/execute-parallel-cleanup.md`, and any `.worktrees/` removal logic or sign/reconcile temp-dir cleanup that constructs paths via variable concatenation. Each such site must be hardened: either guard the variable for non-emptiness before the `rm`, use an absolute-path assertion, or — where the target is a worktree — prefer `git worktree remove` over raw `rm -rf`.
+
+The fix must also prevent regressions: a shellcheck rule or hermetic test should fail when a new `rm -rf "$VAR/` pattern is added without a preceding non-empty guard, and the pattern must be documented in CONTRIBUTING or a scripts/ README note so future contributors follow it automatically.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] AC-1: Audit all `rm -rf`/`rm -f "$VAR/..."` sites in `ai-sdlc-plugin/` scripts and command bodies and `scripts/`; produce an enumerated list of every site found.
+- [ ] AC-2: Each identified site guards the variable before the `rm` — for example `[ -n "$VAR" ] || { echo "refusing rm: VAR empty" >&2; exit 1; }` immediately before the `rm` line — so the command can never expand to a root-relative path even if the variable is unset or empty.
+- [ ] AC-3: Where the path is a worktree under `.worktrees/`, the removal uses `git worktree remove --force` instead of raw `rm -rf`; fall back to guarded `rm -rf` only when `git worktree remove` is not applicable (e.g. temp dirs outside the worktree list).
+- [ ] AC-4: A hermetic test (e.g. a `scripts/check-rm-guard.test.mjs` shellcheck-style scan or a grep-based assertion) fails CI when a new `rm -rf "$` pattern is introduced without a preceding non-empty guard on the same variable in the same script block.
+- [ ] AC-5: The guard pattern is documented in `CONTRIBUTING.md` or a `scripts/README.md` note (whichever already exists) so future contributors know the rule before writing new cleanup scripts.
+<!-- AC:END -->
+
+## References
+
+- ai-sdlc-plugin/commands/cleanup.md
+- ai-sdlc-plugin/commands/execute-parallel-cleanup.md
+- ai-sdlc-plugin/commands/execute-parallel.md

--- a/backlog/tasks/aisdlc-483 - feat-default-dispatch-reviewers-to-codex-and-subagents-to-sonnet.md
+++ b/backlog/tasks/aisdlc-483 - feat-default-dispatch-reviewers-to-codex-and-subagents-to-sonnet.md
@@ -1,0 +1,55 @@
+---
+id: AISDLC-483
+title: >-
+  feat: default code/test review dispatch to the Codex harness and dev/subagent
+  dispatch to Sonnet (cost control)
+status: To Do
+assignee: []
+created_date: '2026-05-30 20:30'
+labels:
+  - feature
+  - cost
+  - dispatch
+  - codex
+  - subagent
+dependencies: []
+references:
+  - spec/rfcs/RFC-0010-parallel-execution-worktree-pooling.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A 2026-05-30 cost incident (26% of weekly usage in a single session) traced to subagents inheriting Opus 4.8 because agent frontmatter was `model: inherit` and dispatch paths did not pin per-role models or harnesses. A companion task (AISDLC-482-sibling, shipped in PR #777) pinned the frontmatter defaults (developer/code-reviewer/test-reviewer = sonnet; security-reviewer = opus), but the DISPATCH paths themselves still route all reviewer calls to the Claude-native agents by default.
+
+The dispatch paths — `/ai-sdlc execute` (Step 7 reviewer fan-out in `ai-sdlc-plugin/commands/execute.md`), `/ai-sdlc orchestrator-tick` (Step 2.5 Phase B reviewer dispatch), and any manual `Agent(code-reviewer)` call in slash-command bodies — should ALSO:
+
+(a) Route code-review and test-review to `code-reviewer-codex` / `test-reviewer-codex` by default. Codex CLI is installed at `/opt/homebrew/bin/codex` (v0.128.0 confirmed 2026-05-30); Codex plan billing = zero Claude usage, making it cost-free for the bulk of review work.
+
+(b) Keep security-review on the Claude-native `security-reviewer` agent at opus — reasoning-heavy work that Codex does not handle reliably.
+
+(c) Keep developer dispatch on sonnet (already pinned in frontmatter; dispatch layer should not override this downward or upward).
+
+(d) Expose a documented override (env var or per-command flag) for cases where a Claude-native reviewer is explicitly wanted (e.g. when Codex is not installed or a team disables it).
+
+This makes the cheap path the default everywhere, not just in agent frontmatter, and closes the gap where ad-hoc `Agent(...)` calls or manual execute invocations silently pick the expensive model.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] AC-1: The canonical reviewer fan-out in `/ai-sdlc execute` (Step 7) selects `code-reviewer-codex` and `test-reviewer-codex` by default; security-reviewer stays on the Claude-native agent at opus. A documented env var (e.g. `AI_SDLC_REVIEWER_HARNESS=claude`) overrides to the Claude-native reviewer for all three review roles.
+- [ ] AC-2: The orchestrator-tick reviewer fan-out (Step 2.5 Phase B) applies the same default selection and honors the same override env var.
+- [ ] AC-3: Developer dispatch explicitly pins sonnet (consistent with the frontmatter default); security-review dispatches the Claude-native `security-reviewer` at opus by default. Both have a documented per-invocation override.
+- [ ] AC-4: Docs under `docs/operations/` (or the relevant command README) describe the default harness and model per role, how to override each, and the cost rationale (Codex plan = zero Claude tokens for code/test review; opus on security = one high-value role).
+- [ ] AC-5: A hermetic test asserts that, with no override env vars set, the reviewer selection logic resolves code-reviewer to `code-reviewer-codex`, test-reviewer to `test-reviewer-codex`, security-reviewer to the Claude-native agent, and developer to sonnet.
+<!-- AC:END -->
+
+## References
+
+- spec/rfcs/RFC-0010-parallel-execution-worktree-pooling.md
+- ai-sdlc-plugin/commands/execute.md
+- ai-sdlc-plugin/agents/code-reviewer-codex.md
+- ai-sdlc-plugin/agents/test-reviewer-codex.md
+- ai-sdlc-plugin/agents/security-reviewer.md
+- ai-sdlc-plugin/agents/developer.md


### PR DESCRIPTION
## Summary

- Adds AISDLC-482: guard `rm -rf "$VAR/$x"` on possibly-empty path vars in cleanup/worktree code, so Claude Code's built-in safety prompt no longer blocks autonomous/unattended runs.
- Adds AISDLC-483: default code/test reviewer dispatch to the Codex harness and developer dispatch to Sonnet — closes the dispatch-path cost gap left after the agent frontmatter pins in PR #777 (AISDLC-482-sibling).

Both tasks are DoR-clean (verified via `cli-dor-check --task`, exit 0, no violations). No TBD/XXX/TODO/FIXME markers. References verified on disk.

## Reference path corrections

- AISDLC-483 references `spec/rfcs/RFC-0010-parallel-execution-worktree-pooling.md` (confirmed on disk; the task brief listed `RFC-0010-cross-harness-review.md` which does not exist — actual RFC-0010 covers parallel execution / worktree pooling, which is the right context for dispatch routing).

## Test plan

- [ ] `backlog/tasks/aisdlc-482 - fix-guard-rm-on-possibly-empty-path-vars-in-cleanup-worktree-code.md` present with correct id, labels, priority, no TBD markers
- [ ] `backlog/tasks/aisdlc-483 - feat-default-dispatch-reviewers-to-codex-and-subagents-to-sonnet.md` present with correct id, labels, priority, no TBD markers
- [ ] Backlog Drift CI check passes (all references resolve)
- [ ] DoR ingress CI check passes

Docs-only PR — no attestation required (paths-ignore covers `backlog/tasks/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)