### PR TITLE
docs: add AISDLC-486 + AISDLC-487 — parallel-dispatch test findings

### DIFF
--- a/backlog/tasks/aisdlc-486 - fix-rename-tasks-must-update-inbound-references-to-avoid-backlog-drift-failure.md
+++ b/backlog/tasks/aisdlc-486 - fix-rename-tasks-must-update-inbound-references-to-avoid-backlog-drift-failure.md
@@ -1,0 +1,47 @@
+---
+id: AISDLC-486
+title: >-
+  fix: dev subagent must update inbound references when renaming/moving a
+  referenced file (avoid Backlog Drift gate failure)
+status: To Do
+assignee: []
+created_date: '2026-05-31 00:00'
+labels:
+  - bug
+  - dispatch
+  - developer-subagent
+  - backlog-drift
+  - ci
+dependencies: []
+references: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+## Context
+
+On 2026-05-31, PR #789 (AISDLC-474) renamed `ai-sdlc-plugin/commands/review.md` to `ai-sdlc-plugin/commands/review-pr.md`. The rename was correct, but the completed backlog task AISDLC-71 ("Replace orchestrator-driven dogfood pipeline with /ai-sdlc execute plugin command") had a frontmatter/body reference to the old path `ai-sdlc-plugin/commands/review.md`. After the rename that referenced file no longer existed, so `backlog-drift check` flagged it as an error-severity issue (`✗ Referenced file no longer exists: ai-sdlc-plugin/commands/review.md`). Backlog Drift is a REQUIRED merge check (promoted from advisory in AISDLC-125), so this blocked PR #789 from merging until the stale reference was manually corrected to `review-pr.md`. The developer subagent that performed the rename did not search for or update inbound references to the file it moved.
+
+## Impact
+
+Any dispatch task that renames or moves a file referenced by another backlog task (or any drift-tracked artifact) will fail the required Backlog Drift gate and stall the PR, requiring manual operator intervention mid-flight. This directly undermines unattended/parallel dispatch — it cost a manual fix in the first real execute-parallel run. The class is general: renames, deletions, and moves of any drift-referenced path.
+
+## Proposed Fix
+
+When a developer subagent renames/moves/deletes a file, it should (a) `grep` the repo (especially `backlog/`) for references to the old path and update them in the same commit, OR (b) run `npx backlog-drift check` (or `backlog-drift fix --task <id>`) as part of its Definition-of-Done verification before opening the PR and repair any error-severity drift it introduced. Wire this into the developer subagent's contract / the Step 0-13 verification so the drift gate is satisfied locally before push, not discovered in CI.
+
+## Acceptance Criteria
+
+- [ ] #1 The developer subagent's workflow detects when its changes rename/move/delete a file and updates inbound references (at minimum in `backlog/`) in the same PR.
+- [ ] #2 A developer-subagent verification step runs `backlog-drift check` (error-severity) before opening the PR and fails locally (with a clear message) if the change introduced new error-severity drift, so it is fixed pre-push.
+- [ ] #3 A regression test/fixture proves a rename that orphans a backlog reference is caught and repaired (or blocked) before PR open.
+- [ ] #4 The developer-subagent contract / runbook documents the rename-updates-references requirement.
+
+## Notes
+
+Surfaced by the 2026-05-31 live `/ai-sdlc execute-parallel` test (PR #789, AISDLC-474). Related to the autonomy-gap family AISDLC-480/481/485.
+
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/aisdlc-487 - fix-strict-up-to-date-merge-starvation-without-merge-queue.md
+++ b/backlog/tasks/aisdlc-487 - fix-strict-up-to-date-merge-starvation-without-merge-queue.md
@@ -1,0 +1,53 @@
+---
+id: AISDLC-487
+title: >-
+  fix: strict up-to-date branch protection causes merge starvation for
+  slow-CI PRs when main is active (no-queue race)
+status: To Do
+assignee: []
+created_date: '2026-05-31 00:00'
+labels:
+  - bug
+  - ci
+  - merge
+  - branch-protection
+  - dispatch
+dependencies: []
+references: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+
+## Context
+
+On 2026-05-31, PR #789 (AISDLC-474) had all required checks green (Backlog Drift, ai-sdlc/pr-ready, attestation) but kept showing `mergeStateStatus=BLOCKED` because branch protection on `main` is configured `strict: true` (require branches up-to-date before merging) while there is NO merge queue (the queue was dropped in AISDLC-400). With several PRs merging in parallel, main advanced under #789 faster than its ~5-6 minute CI matrix could complete, so each time #789 finished CI it was already 1 commit behind and had to be rebased and re-signed again. It took multiple rebase/re-sign cycles before it landed during a brief lull. This is a starvation race: strict-up-to-date + slow per-PR CI + an active main with no serialization means a PR can be perpetually one-behind.
+
+## Impact
+
+Slow-CI PRs (especially code PRs needing the full build/test/coverage matrix + attestation) can stall indefinitely when main is busy, each rebase invalidating up-to-date-ness again. For autonomous/parallel dispatch this is acute: multiple sessions landing PRs concurrently is exactly the condition that triggers the race. Wastes CI minutes (re-runs the full matrix every rebase) and demands repeated operator/agent intervention to push through.
+
+## Proposed Fix
+
+Evaluate and choose (this is an architectural decision to route to the operator / Decision Catalog):
+
+- **(a) Re-introduce a GitHub merge queue** so PRs serialize and auto-rebase without the up-to-date race.
+- **(b) Relax `strict` to false on `main`** and rely on the post-merge `main-health-monitor` (AISDLC-406) to catch cross-PR skew reactively (the original AISDLC-400 trade-off — document the risk).
+- **(c) Keep strict but add an auto-rebase-on-behind automation** that rebases and re-signs a PR the moment it falls behind, bounded to avoid infinite loops.
+
+Capture the decision and rationale in the Decision Catalog.
+
+## Acceptance Criteria
+
+- [ ] #1 The branch-protection posture for `main` is decided (merge-queue vs strict=false vs auto-rebase automation) and documented with the trade-off rationale, routed through the operator/Decision Catalog since it is an architectural/security-posture choice.
+- [ ] #2 The chosen mechanism is implemented so a slow-CI PR with all required checks green does not starve when main is active.
+- [ ] #3 A runbook entry in docs/operations explains the merge model and how to land a PR caught in the race (e.g. admin-merge criteria) until/unless the automation handles it.
+- [ ] #4 The fix composes with parallel dispatch (multiple concurrent execute-parallel PRs can all land without manual rebase chasing).
+
+## Notes
+
+Surfaced live by PR #789 during the 2026-05-31 execute-parallel test. Relates to AISDLC-400 (merge-queue drop) and AISDLC-406 (main-health-monitor).
+
+<!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
Two findings from the 2026-05-31 live `/ai-sdlc execute-parallel` test:

- **AISDLC-486** — dev subagent must update inbound references when renaming/moving a referenced file (avoid Backlog Drift gate failure). PR #789 renamed `review.md` → `review-pr.md` but AISDLC-71 still referenced the old path; the required Backlog Drift check blocked merge until manually corrected.
- **AISDLC-487** — strict up-to-date branch protection + slow CI + active main = merge starvation (no-queue race). PR #789 stalled in multiple rebase/re-sign cycles because `strict: true` with no merge queue (AISDLC-400) meant every new commit to main invalidated its up-to-date status before CI finished.

Docs-only. Both tasks are DoR-clean (cli-dor-check passes).