### PR TITLE
docs(backlog): AISDLC-491 root-cause addendum (whole-tree head-binding)

### DIFF
--- a/backlog/tasks/aisdlc-491 - attestation-rebase-invariance-stop-resign-on-every-main-landing.md
+++ b/backlog/tasks/aisdlc-491 - attestation-rebase-invariance-stop-resign-on-every-main-landing.md
@@ -54,3 +54,22 @@ This touches the attestation trust chain + merge policy. Recommend an operator w
 ## References
 - AISDLC-475 (per-SHA bridge removal), AISDLC-490 (cut chore commit), AISDLC-487 (merge-race), AISDLC-398 (content-addressed patch-id), AISDLC-448 (tree-equivalent relaxation), AISDLC-460 (auto-rebase watcher), DEC-0008
 - scripts/verify-attestation.mjs, pipeline-cli/src/attestation/patch-id.ts
+
+## Root cause (confirmed 2026-05-31 via code investigation)
+
+Two independent traces of `scripts/verify-attestation.mjs` confirmed the exact mechanism. AISDLC-398 made the envelope FILENAME content-addressed (`<patch-id>.v6.dsse.json`) but the patch-id is **only a lookup key — it is never used as a validity gate** (used at ~lines 2100/2165 for filename lookup only). Validity still hinges on whole-tree head-binding:
+
+1. PR-B signed at dev commit `S`. PR-A merges → auto-rebase watcher rebases PR-B → `S` orphaned (new HEAD `C`).
+2. `isAttestationOnlyDescendant` (~line 182): `git merge-base --is-ancestor S C` exits 1 (rebase orphaned `S`) → fails.
+3. `isTreeEquivalentModuloAttestation` (~line 298) runs `git diff <S> <C> -- ':!.ai-sdlc/attestations/' ...` — a **WHOLE-TREE** diff, not scoped to PR-B's own patch. `C` contains PR-A's merged (disjoint) files; `S` does not → diff non-empty → returns false.
+4. Both relaxations fail → falls to legacy contentHashV4 → mismatch → `ai-sdlc/attestation` FAILURE → forced re-sign.
+
+So even fully-disjoint PRs invalidate each other on every main landing, exactly as the operator observed.
+
+## The fix (decide in walkthrough; recommended option A)
+
+- **Option A (surgical):** make `isTreeEquivalentModuloAttestation` (verify-attestation.mjs ~line 298) **patch-scoped** — scope the `git diff <S> <C>` to ONLY the files the envelope's own patch touched (derivable from `git diff-tree <subject-merge-base>..<S>` with PATCH_ID_EXCLUSIONS), instead of the whole tree. The check becomes "do PR-B's own files have identical blobs at S and C?" — preserved by any disjoint rebase. Add a `changedPaths` param; fall back to whole-tree (conservative) only when the subject merge-base is unreachable. Regression guard: a rebase that DOES change PR-B's own files still fails (replay protection preserved).
+- **Option B (deeper, base-independent validity):** embed the patch-id INSIDE the v6 envelope (schema change) and gate validity on "recomputed patch-id of HEAD's diff == envelope patch-id" + Merkle-root signature, dropping whole-tree head-binding entirely. This is what AISDLC-398 intended architecturally.
+- **Option C:** reinstate a merge queue (serializes merges so PRs never rebase-thrash) — resolves AISDLC-487 but adds queue latency and doesn't fix the underlying verifier asymmetry.
+
+Recommend A now (unblocks concurrent disjoint merges with minimal trust-chain change), B as the long-term architecture. Source: `scripts/verify-attestation.mjs` `isTreeEquivalentModuloAttestation` (~line 278-313), `isAttestationOnlyDescendant` (~line 173-218); `pipeline-cli/src/attestation/patch-id.ts`.


### PR DESCRIPTION
Adds the confirmed root cause + fix options to AISDLC-491. References AISDLC-398, AISDLC-448, AISDLC-487. Docs-only.

## Summary
- Code-traced `isTreeEquivalentModuloAttestation` (~L298) and `isAttestationOnlyDescendant` (~L182) in `scripts/verify-attestation.mjs`
- Confirmed: patch-id is a lookup key only, never a validity gate; the relaxation does a **whole-tree** diff that fails for any disjoint rebase landing
- Documented three fix options (A: patch-scoped diff, B: embed patch-id in envelope, C: merge queue) with recommendation A now + B long-term

## Test plan
- [ ] Docs-only changeset — `paths-ignore` skips `verify-attestation.yml` and `ai-sdlc-review.yml`; no attestation needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)