### PR TITLE
chore: file RFC-0043 test-quality follow-ups (AISDLC-503, AISDLC-504)

### DIFF
--- a/backlog/tasks/aisdlc-503 - test-ucvg-ast-gate-stdin-spy-try-finally-isolation.md
+++ b/backlog/tasks/aisdlc-503 - test-ucvg-ast-gate-stdin-spy-try-finally-isolation.md
@@ -1,0 +1,38 @@
+---
+id: AISDLC-503
+title: 'test: isolate ucvg ast-gate stdin spies in try/finally (AISDLC-501 reviewer minor)'
+status: To Do
+assignee: []
+created_date: '2026-06-03'
+labels:
+  - rfc-0043
+  - untrusted-pr-verification
+  - test-quality
+  - follow-up
+dependencies:
+  - AISDLC-501
+references:
+  - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification.md
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Non-blocking minor raised by the code-reviewer during the AISDLC-501 (RFC-0043 Phase 5) reconcile review (PR #847). Filed for follow-up at operator request; it has no functional impact on the current passing suite.
+
+In `pipeline-cli/src/cli/ucvg.test.ts`, three `ast-gate` tests create a `stdinOnSpy` (`vi.spyOn(process.stdin, 'on')`) and a paired `process.stdin.setEncoding` spy inside the test body, then call `stdinOnSpy.mockRestore()` / `vi.mocked(process.stdin.setEncoding).mockRestore?.()` AFTER the `await runUcvgCli(...)` but BEFORE the assertions, with no `try/finally`. If `runUcvgCli` ever rejects unexpectedly, the spies leak into subsequent tests in the same describe block (fragile cross-test isolation).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
+- [ ] The three affected `ast-gate` tests in `pipeline-cli/src/cli/ucvg.test.ts` restore the `process.stdin.on` and `process.stdin.setEncoding` spies in a `finally` block (or the spies are hoisted into `beforeEach`/`afterEach`), so an unexpected rejection cannot leak them.
+- [ ] `pnpm --filter @ai-sdlc/pipeline-cli exec vitest run src/cli/ucvg.test.ts` passes (all tests).
+- [ ] No production code (`ucvg.ts`) change; test-only.
+- [ ] No shared `/tmp/.ai-sdlc/` created by the suite (isolated mkdtemp invariant preserved).
+<!-- SECTION:ACCEPTANCE_CRITERIA:END -->
+
+## Notes
+
+Source: code-reviewer finding on PR #847, `pipeline-cli/src/cli/ucvg.test.ts` ~line 425 (and the two sibling ast-gate tests). Mechanical fix; the behaviors are already correctly asserted — this only hardens isolation.

--- a/backlog/tasks/aisdlc-504 - test-ucvg-conformance-end-to-end-signer-and-resource-breach.md
+++ b/backlog/tasks/aisdlc-504 - test-ucvg-conformance-end-to-end-signer-and-resource-breach.md
@@ -1,0 +1,41 @@
+---
+id: AISDLC-504
+title: 'test: make ucvg conformance AC-3 + resource-breach checks end-to-end (AISDLC-502 reviewer minors)'
+status: To Do
+assignee: []
+created_date: '2026-06-03'
+labels:
+  - rfc-0043
+  - untrusted-pr-verification
+  - test-quality
+  - conformance
+  - follow-up
+dependencies:
+  - AISDLC-502
+references:
+  - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification.md
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Two non-blocking minors raised by the test-reviewer during the AISDLC-502 (RFC-0043 Phase 6) reconcile review (PR #848). Filed for follow-up at operator request. Both behaviors are already covered in the dedicated module tests (`clean-room-signer.test.ts`, `sandbox-runner.test.ts`); these only make the conformance suite self-contained on its own claims.
+
+In `pipeline-cli/src/pipeline/ucvg-conformance.test.ts`:
+1. The AC-3 "clean-room signer mints valid attestation only after Zod boundary validates" / signer-refusal check asserts on hand-constructed fixture data (`consensus.approved === false` on data the test itself built) rather than invoking the real `runCleanRoomSigner()`. It is effectively a data-shape assertion, not an end-to-end signer invocation.
+2. Scenario (c) "resource breach event shape for wall-clock exhaustion" constructs a plain object literal and asserts its own constants, rather than calling the exported `buildResourceBreachEvent()` factory from `sandbox-runner.ts`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- SECTION:ACCEPTANCE_CRITERIA:BEGIN -->
+- [ ] The AC-3 conformance check invokes `runCleanRoomSigner()` against an isolated `mkdtemp` work dir (no signing key present) and asserts the real refusal outcome (e.g. `result.phase === 'consensus-rejected'` / failure), exercising production code rather than a hand-built struct.
+- [ ] The resource-breach scenario constructs its event via the exported `buildResourceBreachEvent()` (or equivalent factory) from `sandbox-runner.ts` and asserts the real `type`/`limit`/`limitUnit`/`observedValue` fields, including the `not.toMatch(/AISDLC-\d+/)` adopter-facing-string check.
+- [ ] All `ucvg-conformance.test.ts` tests pass; no shared `/tmp/.ai-sdlc/` created (isolated mkdtemp invariant preserved).
+- [ ] Test-only; no production code change.
+<!-- SECTION:ACCEPTANCE_CRITERIA:END -->
+
+## Notes
+
+Source: test-reviewer findings on PR #848, `pipeline-cli/src/pipeline/ucvg-conformance.test.ts` (~line 358 signer check; ~line 765 resource-breach scenario). See also [[feedback_shared_tmp_marker_dir_pollution]] for the isolated-tmpdir requirement.


### PR DESCRIPTION
Files two **non-blocking** test-quality follow-up tasks surfaced by reviewers during the RFC-0043 Phase 5/6 reconcile reviews (PRs #847, #848). Docs-only (backlog tasks) — no code change.

- **AISDLC-503** — isolate the three `ucvg` ast-gate stdin spies in a `try/finally` (currently restored before assertions outside any guard; could leak on unexpected rejection). Mechanical, test-only.
- **AISDLC-504** — make the `ucvg-conformance` AC-3 signer-refusal check and the resource-breach scenario end-to-end (invoke `runCleanRoomSigner()` / `buildResourceBreachEvent()` instead of asserting hand-built fixtures). Behaviors already covered in the module tests; this makes the conformance suite self-contained.

Both reference RFC-0043 (now Signed Off + Implemented). Filed at operator request after the RFC-0043 drain completed (all 6 phase tasks merged).