### PR TITLE
chore: RFC-0043 Phase 7 — integration & end-to-end task breakdown (AISDLC-507..515)

### DIFF
--- a/backlog/tasks/aisdlc-507 - docs-RFC-0043-phase-7-amendment-docker-v1-runtime-and-in-sandbox-reviewer-architecture.md
+++ b/backlog/tasks/aisdlc-507 - docs-RFC-0043-phase-7-amendment-docker-v1-runtime-and-in-sandbox-reviewer-architecture.md
@@ -1,0 +1,40 @@
+---
+id: AISDLC-507
+title: 'docs(rfc): RFC-0043 Phase 7 amendment — Docker v1 reference runtime + in-sandbox reviewer via inference.local'
+status: To Do
+assignee: []
+created_date: '2026-06-04'
+labels:
+  - rfc-0043
+  - phase-7
+  - integration
+  - architecture
+  - docs
+dependencies: []
+references:
+  - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Records the two Phase-7 architecture decisions (operator-approved via decision rubric, 2026-06-04) into RFC-0043 so the implementation tasks (AISDLC-508..515) have a signed contract. **The decisions are already made — this task documents them, it does not re-open them.**
+
+- **AQ1 — Sandbox runtime:** **Docker (hardened)** is the v1 reference runtime, behind the existing `SandboxDriver` abstraction. gVisor and MicroVM/Firecracker become documented *upgrade* drivers (MicroVM is the RFC-0022 compliance path). NVIDIA OpenShell is demoted from "the" runtime to an optional driver pending resolution of its GitHub-runner install-hang. Rationale: Docker is the only zero-install path on stock GitHub-hosted runners (no `/dev/kvm`), so it is the only viable route to a working end-to-end gate now; the driver abstraction preserves the upgrade path.
+- **AQ2 — Reviewer execution:** the 3-reviewer matrix runs **inside the sandbox**, reaching the model through an **`inference.local` proxy** that injects provider credentials out-of-process so the reviewer/untrusted process never holds the key. This matches the RFC's original credential-withholding design and keeps the agentic-review upgrade path open.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 RFC-0043 revision history + body updated: Docker named the v1 reference runtime; gVisor/MicroVM/OpenShell documented as alternative drivers behind the abstraction
+- [ ] #2 RFC-0043 documents the in-sandbox reviewer + `inference.local` credential-withholding proxy as the Stage-3 execution model
+- [ ] #3 The whitepaper + concept page + operator runbook claims are reconciled with "Docker v1 / others are upgrade drivers" (no implied MicroVM-is-shipping)
+- [ ] #4 A short "Phase 7 — Integration & End-to-End Hardening" section enumerates the implementation tasks (508..515) + the e2e milestone definition
+- [ ] #5 RFC-0043 lifecycle stays Signed Off; this is an amendment, not a re-sign-off
+<!-- AC:END -->
+
+## Notes
+
+Decision rubric run 2026-06-04 (AQ1 → Docker; AQ2 → in-sandbox + inference.local). Foundational — 508..515 reference this amendment.

--- a/backlog/tasks/aisdlc-508 - feat-RFC-0043-phase-7-docker-sandbox-driver-real-execution-isolation-resource-enforcement.md
+++ b/backlog/tasks/aisdlc-508 - feat-RFC-0043-phase-7-docker-sandbox-driver-real-execution-isolation-resource-enforcement.md
@@ -1,0 +1,40 @@
+---
+id: AISDLC-508
+title: 'feat(sandbox): RFC-0043 Phase 7 — real Docker sandbox driver (isolation + resource enforcement)'
+status: To Do
+assignee: []
+labels:
+  - rfc-0043
+  - phase-7
+  - sandbox
+  - security
+dependencies:
+  - AISDLC-507
+references:
+  - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification.md
+  - pipeline-cli/src/pipeline/sandbox-runner.ts
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the real `DockerSandboxDriver` (W1). Today `doSpawn` returns an error unless `AI_SDLC_SANDBOX_INTEGRATION_TESTS=1`, and `runDockerDifferentialTest` throws `"not yet implemented"`; the `docker run` invocation and resource enforcement exist only as comments, and `teardown()` is a no-op. This is the execution substrate everything else depends on.
+
+Per AISDLC-507 (AQ1): Docker is the v1 reference runtime behind the existing `SandboxDriver` abstraction.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 `DockerSandboxDriver` spawns a real container with hardened isolation: `--network=none` (until the inference.local bridge is added in AISDLC-510), `--cap-drop=ALL`, `--read-only` rootfs + explicit `tmpfs`, `--pids-limit`, `--memory`, `--cpus`, non-root `--user`, `--rm`, and a seccomp profile
+- [ ] #2 Real resource enforcement: the wall-clock AbortController actually SIGKILLs the container on breach (not a post-hoc duration comparison); breach → `outcome: 'resource-breach'`
+- [ ] #3 `teardown()` is real and idempotent (`docker rm -f`); no orphaned containers on success, error, or timeout
+- [ ] #4 Credential-withholding enforced for the real run: `WITHHELD_ENV_VARS` (signing key, write-scoped `GITHUB_TOKEN`, `NPM_TOKEN`, `AI_SDLC_PAT`) provably never enter container env; add a test asserting this
+- [ ] #5 Real-container tests behind `AI_SDLC_SANDBOX_INTEGRATION_TESTS=1`; hermetic mock path unchanged for default CI
+- [ ] #6 `pnpm --filter @ai-sdlc/pipeline-cli build/test/lint` clean; new logic ≥80% patch coverage
+<!-- AC:END -->
+
+## Notes
+
+Does NOT include the differential-test logic inside the container (AISDLC-509) or the inference bridge (AISDLC-510) — this is the container lifecycle + isolation + enforcement only.

--- a/backlog/tasks/aisdlc-509 - feat-RFC-0043-phase-7-differential-test-execution-inside-sandbox.md
+++ b/backlog/tasks/aisdlc-509 - feat-RFC-0043-phase-7-differential-test-execution-inside-sandbox.md
@@ -1,0 +1,34 @@
+---
+id: AISDLC-509
+title: 'feat(sandbox): RFC-0043 Phase 7 — differential test execution inside the container'
+status: To Do
+assignee: []
+labels:
+  - rfc-0043
+  - phase-7
+  - sandbox
+dependencies:
+  - AISDLC-508
+references:
+  - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification.md
+  - pipeline-cli/src/pipeline/sandbox-runner.ts
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement `runDockerDifferentialTest` (W2): the actual work inside the container. Currently throws `"not yet implemented"`. Produces the real `DifferentialTestResult` that feeds the unsigned report.
+
+The diff is applied as **data** (the fork-PR safety guard): clone the base, apply the PR diff, run the suite — never execute fork-provided workflow logic.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Inside the container: check out the base (`upstreamMainRef` = baseSha, NOT headSha — preserve the AISDLC-501 fix), apply the PR diff as data, install deps offline where possible
+- [ ] #2 Run the test suite for base vs PR-head (differential), capture pass/fail counts + coverage delta into `DifferentialTestResult`
+- [ ] #3 Per-test + wall-clock timeouts honored (compose with AISDLC-508 enforcement); a hung test → breach, not a stuck runner
+- [ ] #4 Test output parsing is resilient to missing/garbage output (fail-closed: unparseable → treated as failure, not pass)
+- [ ] #5 Real-container integration test (`AI_SDLC_SANDBOX_INTEGRATION_TESTS=1`) on a small fixture repo proves a passing PR and a failing PR are distinguished; ≥80% patch coverage on parsing logic
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-510 - feat-RFC-0043-phase-7-inference-local-credential-withholding-proxy.md
+++ b/backlog/tasks/aisdlc-510 - feat-RFC-0043-phase-7-inference-local-credential-withholding-proxy.md
@@ -1,0 +1,40 @@
+---
+id: AISDLC-510
+title: 'feat(sandbox): RFC-0043 Phase 7 — inference.local credential-withholding model proxy'
+status: To Do
+assignee: []
+labels:
+  - rfc-0043
+  - phase-7
+  - sandbox
+  - security
+dependencies:
+  - AISDLC-508
+references:
+  - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification.md
+  - pipeline-cli/src/pipeline/sandbox-runner.ts
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Build the `inference.local` proxy (W4) — the security-critical component that makes AQ2 (in-sandbox reviewers) safe. Currently it exists only as comments in `sandbox-runner.ts`. The in-sandbox reviewer process (AISDLC-511) must be able to call the model **without ever holding the provider key**; the proxy injects credentials out-of-process.
+
+This is the trust hinge of the in-sandbox-reviewer architecture: the sandbox is otherwise `--network=none`, with the proxy as the *only* reachable egress.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 A host-side proxy process holds the provider credential and exposes a minimal model endpoint reachable from the container as `inference.local` (e.g. a controlled bridge / host alias) — the credential is NEVER passed into the container env
+- [ ] #2 Sandbox network policy: the container can reach ONLY the proxy endpoint; all other egress denied (compose with AISDLC-508's `--network=none` + an explicit allow for the proxy)
+- [ ] #3 The proxy is request-scoped to the PR being reviewed and rate/size-capped; it refuses tool-use / non-review calls so a prompt-injected reviewer can't turn it into a general exfiltration channel
+- [ ] #4 Proxy logs requests for audit without logging the credential; redaction tested
+- [ ] #5 Test: a process inside the container can complete a model call via inference.local with NO provider env var present; a direct outbound call to any other host fails
+- [ ] #6 build/test/lint clean; ≥80% patch coverage on proxy logic
+<!-- AC:END -->
+
+## Notes
+
+Security-critical — recommend the operator-composed verdict pattern at reconcile time (this closes a trust-chain hole). Threat to design against: a prompt-injected in-sandbox reviewer trying to use the proxy as an egress for exfiltrated secrets — hence the request-scoping + no-tool-use constraints.

--- a/backlog/tasks/aisdlc-511 - feat-RFC-0043-phase-7-in-sandbox-reviewer-execution-real-verdicts.md
+++ b/backlog/tasks/aisdlc-511 - feat-RFC-0043-phase-7-in-sandbox-reviewer-execution-real-verdicts.md
@@ -1,0 +1,39 @@
+---
+id: AISDLC-511
+title: 'feat(reviewers): RFC-0043 Phase 7 — in-sandbox 3-reviewer execution + real verdicts'
+status: To Do
+assignee: []
+labels:
+  - rfc-0043
+  - phase-7
+  - reviewers
+dependencies:
+  - AISDLC-509
+  - AISDLC-510
+references:
+  - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification.md
+  - pipeline-cli/src/pipeline/reviewer-matrix.ts
+  - pipeline-cli/src/cli/ucvg.ts
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The missing review brain (W3). Today `reviewer-matrix.ts` only *builds prompts* and *detects injection* (string heuristics) — no reviewer ever runs — and `buildUnsignedReport` hardcodes all three reviewers to `approved: false`, so the gate is permanently fail-closed. This task makes the reviewers actually run (in-sandbox, per AQ2) and populates real verdicts.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 In-sandbox runner invokes the 3 reviewers (code/test/security) via `inference.local` (AISDLC-510) against the hardened-framed diff (`buildHardenedDiffSection`) + the differential test results (AISDLC-509)
+- [ ] #2 Each reviewer verdict is parsed + schema-validated into `{ approved, findings, promptInjectionDetected }`; `detectInjectionAttempts` results are merged in (defense-in-depth)
+- [ ] #3 `buildUnsignedReport` is populated with the REAL reviewer verdicts + computed consensus — the hardcoded `approved: false` placeholders are removed
+- [ ] #4 Reviewers are constrained (no tool-use / no shell / no egress beyond inference.local) so a prompt injection can at most produce a bad verdict — which consensus + injection-detection + Stage-4 refusal already catch
+- [ ] #5 A genuinely-good benign PR now yields `consensus.approved: true`; an injected/should-fail PR yields `approved: false` with the right findings
+- [ ] #6 build/test/lint clean; ≥80% patch coverage; no shared `/tmp/.ai-sdlc` pollution in tests
+<!-- AC:END -->
+
+## Notes
+
+Evaluate reuse of existing pipeline-cli model-invocation infra (invoker-loader / classifier substrate) for the reviewer calls rather than a bespoke client.

--- a/backlog/tasks/aisdlc-512 - feat-RFC-0043-phase-7-integration-glue-report-to-clean-room-sign-e2e.md
+++ b/backlog/tasks/aisdlc-512 - feat-RFC-0043-phase-7-integration-glue-report-to-clean-room-sign-e2e.md
@@ -1,0 +1,33 @@
+---
+id: AISDLC-512
+title: 'feat(ucvg): RFC-0043 Phase 7 — integration glue: real report → clean-room sign → attestation'
+status: To Do
+assignee: []
+labels:
+  - rfc-0043
+  - phase-7
+  - integration
+dependencies:
+  - AISDLC-511
+references:
+  - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification.md
+  - pipeline-cli/src/cli/ucvg.ts
+  - pipeline-cli/src/pipeline/clean-room-signer.ts
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Wire the now-real pieces together end-to-end in `cli-ucvg` (W5): real differential results (AISDLC-509) + real reviewer verdicts (AISDLC-511) → unsigned report → cross-runner artifact transfer → clean-room signer (Stage 4, already implemented) → v6 attestation. Stage 4 already refuses unapproved/injection-flagged reports; this task proves the *happy path* actually reaches it with genuine data.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 `sandbox-run` writes an unsigned report containing real differential results + real reviewer verdicts (no placeholders)
+- [ ] #2 The cross-runner artifact transfer (sandbox-and-review → clean-room-sign, upload/download-artifact from AISDLC-501) is validated end-to-end with real content
+- [ ] #3 Stage 4 signs a genuinely-approved report → produces a v6 attestation that `verify-attestation.mjs` reports `status=valid`; an unapproved/injection-flagged report is refused (`phase: consensus-rejected`)
+- [ ] #4 The `untrusted-pr-gate.yml` job chain runs the real path (Docker driver) instead of erroring on the stub
+- [ ] #5 build/test/lint clean; ≥80% patch coverage on new glue
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-513 - test-RFC-0043-phase-7-integration-harness-adversarial-threat-model-fixtures.md
+++ b/backlog/tasks/aisdlc-513 - test-RFC-0043-phase-7-integration-harness-adversarial-threat-model-fixtures.md
@@ -1,0 +1,32 @@
+---
+id: AISDLC-513
+title: 'test(sandbox): RFC-0043 Phase 7 — integration harness + adversarial threat-model fixtures'
+status: To Do
+assignee: []
+labels:
+  - rfc-0043
+  - phase-7
+  - test
+  - security
+dependencies:
+  - AISDLC-512
+references:
+  - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prove each threat-model vector actually holds against the real runtime (W6). Today only hermetic mocks exist; this builds the real-container integration harness (`AI_SDLC_SANDBOX_INTEGRATION_TESTS=1`) + a fixture corpus of sample PRs, one per vector from the whitepaper threat model.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Integration harness runs the full gate against a real Docker runtime on a fixture repo
+- [ ] #2 Fixture PRs + assertions, one per vector: benign → passes + valid attestation; protected-path mutation → Stage 1 `abort-protected-path`; lifecycle-script / new-action injection → Stage 1 abort; prompt injection → Stage 3 `promptInjectionDetected` + Stage 4 refusal; credential exfiltration attempt → Stage 3 network-deny / withholding blocks it; resource exhaustion → `resource-breach` fail-closed; report forgery → Stage 4 Zod refusal
+- [ ] #3 A credential-exfil fixture proves a process in the sandbox cannot reach the signing key, write tokens, or any host beyond inference.local
+- [ ] #4 Harness is gated (not in default CI) + documented so a maintainer can run it locally; flaky-free (isolated temp dirs, no shared `/tmp/.ai-sdlc`)
+- [ ] #5 Results documented (which vector → which stage → observed outcome) as the conformance evidence the whitepaper references
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-514 - feat-RFC-0043-phase-7-end-to-end-on-real-repo-enable-runtime-in-ci.md
+++ b/backlog/tasks/aisdlc-514 - feat-RFC-0043-phase-7-end-to-end-on-real-repo-enable-runtime-in-ci.md
@@ -1,0 +1,40 @@
+---
+id: AISDLC-514
+title: 'feat(e2e): RFC-0043 Phase 7 — end-to-end on a real test repo + enable Docker runtime in CI'
+status: To Do
+assignee: []
+labels:
+  - rfc-0043
+  - phase-7
+  - e2e
+  - milestone
+dependencies:
+  - AISDLC-513
+references:
+  - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification.md
+  - .github/workflows/untrusted-pr-gate.yml
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The milestone (W7): the gate runs end-to-end on a real repository with a real fork PR. Stand up a dedicated test repo configured for the gate, re-enable the runtime in the workflow (the OpenShell install step is currently disabled "may hang the runner" — replace with the Docker path per AISDLC-507/508), and demonstrate the full pipeline.
+
+**This is the point at which "send a live demo" becomes a true statement** — until this passes, do not offer external live demos on arbitrary repos.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 A test repo configured with `.ai-sdlc/untrusted-pr-gate.yaml`, `trusted-reviewers.yaml`, the `untrusted-pr-gate.yml` workflow, and a signing key
+- [ ] #2 `untrusted-pr-gate.yml` runs the Docker runtime path (disabled OpenShell install replaced/guarded); the watchdog + fail-closed degradation still behave correctly
+- [ ] #3 A benign untrusted (fork) PR flows through all four stages and produces a v6 attestation that verifies `status=valid` + posts the success status
+- [ ] #4 Adversarial fork PRs (the AISDLC-513 vectors) are each blocked at the correct stage on the live gate
+- [ ] #5 AISDLC-505 (ast-gate glob false-positive) is merged first so benign files aren't mis-blocked
+- [ ] #6 A short runbook documents how to reproduce the e2e run; feature flag flip criteria recorded
+<!-- AC:END -->
+
+## Notes
+
+Blocking dependency for clean runs: **AISDLC-505** (glob false-positive). Minor test-quality follow-ups AISDLC-503/504 are non-blocking.

--- a/backlog/tasks/aisdlc-515 - feat-RFC-0043-phase-7-deferred-gvisor-microvm-drivers-rfc-0022-compliance.md
+++ b/backlog/tasks/aisdlc-515 - feat-RFC-0043-phase-7-deferred-gvisor-microvm-drivers-rfc-0022-compliance.md
@@ -1,0 +1,37 @@
+---
+id: AISDLC-515
+title: 'feat(sandbox): RFC-0043 Phase 7 (deferred) — gVisor + MicroVM drivers for RFC-0022 compliance regimes'
+status: To Do
+assignee: []
+labels:
+  - rfc-0043
+  - phase-7
+  - sandbox
+  - compliance
+  - deferred
+dependencies:
+  - AISDLC-514
+references:
+  - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification.md
+  - spec/rfcs/RFC-0022-compliance-posture-audit-surface.md
+priority: low
+dispatchable: false
+dispatchableReason: 'Deferred until after the Docker v1 e2e milestone (AISDLC-514); requires self-hosted KVM runners + operator infra decisions for MicroVM'
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the stronger sandbox drivers behind the abstraction (W9) so the RFC-0022 compliance-regime story is real: gVisor (userspace kernel, runs without KVM) and MicroVM/Firecracker (the HIPAA / FedRAMP / PCI-DSS Level 1 → MicroVM override). Today Podman/Kata/gVisor/MicroVM are throwing stubs, so `resolveEffectiveDriver` returning `microvm` for a regime would fail at spawn.
+
+Deferred on purpose: the Docker v1 path (AISDLC-508..514) is the priority; MicroVM needs `/dev/kvm` (self-hosted runners), which is an infra decision, not a blocker for the first e2e.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 `GVisorSandboxDriver` implemented (runsc) + integration-tested; documented setup
+- [ ] #2 `MicroVmSandboxDriver` implemented (Firecracker/Kata) for self-hosted KVM runners; `resolveEffectiveDriver` regime override (HIPAA/FedRAMP/PCI-DSS L1 → microvm) actually spawns instead of throwing
+- [ ] #3 Driver-selection docs + the compliance-regime claims in the whitepaper/runbook reconciled with what actually ships
+- [ ] #4 build/test/lint clean; integration tests gated behind the runtime flag
+<!-- AC:END -->


### PR DESCRIPTION
Maps the work to make the untrusted-PR gate **testable end-to-end**. Filed after the operator decision-rubric on the two architecture questions (2026-06-04).

**The gap:** today the gate is permanently fail-closed and non-functional end-to-end — `DockerSandboxDriver.runDockerDifferentialTest` throws `'not yet implemented'`, every other driver is a throwing stub, and `buildUnsignedReport` hardcodes all three reviewers to `approved: false`. No contributor code is ever executed or reviewed.

**Decisions baked in:**
- **AQ1 → Docker (hardened)** is the v1 reference runtime behind the driver abstraction; gVisor/MicroVM are upgrade drivers; OpenShell demoted to optional (its install hangs GH runners). Requires an RFC-0043 amendment (AISDLC-507).
- **AQ2 → reviewers run *inside* the sandbox** via an `inference.local` credential-withholding proxy.

**Tasks (dependency-ordered):**
| Task | Workstream |
|---|---|
| 507 | RFC-0043 Phase 7 amendment (records AQ1/AQ2) |
| 508 | Real Docker sandbox driver — isolation + resource enforcement |
| 509 | Differential test execution inside the container |
| 510 | `inference.local` credential-withholding proxy |
| 511 | In-sandbox 3-reviewer execution + real verdicts (kills the hardcoded `false`) |
| 512 | Integration glue: real report → clean-room sign → attestation |
| 513 | Integration harness + adversarial threat-model fixtures |
| 514 | **Milestone** — e2e on a real repo + enable Docker runtime in CI |
| 515 | *(deferred)* gVisor/MicroVM drivers for RFC-0022 compliance |

**Sequence:** 507 → 508 → 509 → (510 ‖ then 511) → 512 → 513 → 514; 515 deferred. Also depends on **AISDLC-505** (ast-gate glob false-positive) landing for clean e2e.

**Milestone definition:** on a real repo under a real container runtime, a benign untrusted PR produces a verifiable v6 attestation and adversarial PRs are each blocked at the correct stage. That's when "live demo on a repo" becomes a true statement.

Docs-only (backlog task specs).