### PR TITLE
docs: file 3 RFC-0043 Phase 7 follow-up tasks (AISDLC-516/517/518)

### DIFF
--- a/backlog/tasks/aisdlc-516 - docs-align-signing-key-secret-name-to-AISDLC-SIGNING-KEY-CONTENT.md
+++ b/backlog/tasks/aisdlc-516 - docs-align-signing-key-secret-name-to-AISDLC-SIGNING-KEY-CONTENT.md
@@ -1,0 +1,43 @@
+---
+id: AISDLC-516
+title: 'docs(rfc-0043): align signing-key secret name to AISDLC_SIGNING_KEY_CONTENT across remaining docs'
+status: To Do
+assignee: []
+created_date: '2026-06-04'
+labels:
+  - rfc-0043
+  - docs
+  - follow-up
+references:
+  - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification.md
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+AISDLC-514 made the UCVG signing key materialize from the `AISDLC_SIGNING_KEY_CONTENT`
+secret (PEM content) inside the clean-room job — the canonical name going forward. Three
+pre-existing docs still describe the secret as `AISDLC_SIGNING_KEY_PATH` (a path-valued
+secret, which is meaningless on an ephemeral runner). This is cosmetic, not a security
+issue (an env-var name is not a credential), but it can lead an operator to create a
+useless path-valued secret. Surfaced by the security reviewer during the AISDLC-514
+reconcile.
+
+Files to align (verified present on main at filing time):
+- `docs/operations/untrusted-contributor-pr-verification.md` (~line 442)
+- `docs/concepts/untrusted-contributor-verification.md` (~line 180)
+- `docs/api-reference/rfc-0043-ucvg.md` (~line 646)
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The three docs describe the secret as `AISDLC_SIGNING_KEY_CONTENT` (PEM content), noting the workflow materializes it into the `AISDLC_SIGNING_KEY_PATH` env at run time in the clean-room job.
+- [ ] #2 No doc instructs storing a filesystem path as the secret, and none teaches `echo "${{ secrets.* }}"` for the key (the secure env+printf+chmod 600 pattern from AISDLC-514 is the reference).
+- [ ] #3 `pnpm format:check` clean; the canonical wiring in `docs/ucvg-test-repo-setup/signing-key-setup.md` (already correct) and the three updated docs agree.
+<!-- AC:END -->
+
+## Notes
+
+Doc-only change; lands via the docs-only PR path (paths-ignored from review/attestation). Discovered during the RFC-0043 Phase 7 drain (AISDLC-514 security re-review).

--- a/backlog/tasks/aisdlc-517 - fix-orchestrator-webhook-manager-implicit-any-typecheck.md
+++ b/backlog/tasks/aisdlc-517 - fix-orchestrator-webhook-manager-implicit-any-typecheck.md
@@ -1,0 +1,37 @@
+---
+id: AISDLC-517
+title: 'fix(orchestrator): resolve implicit-any (TS7006) in webhook-manager.ts surfaced on fresh-worktree typecheck'
+status: To Do
+assignee: []
+created_date: '2026-06-04'
+labels:
+  - orchestrator
+  - bug
+  - follow-up
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+During two RFC-0043 Phase 7 reconciles (AISDLC-513 and AISDLC-514), a fresh-worktree
+`pnpm -r --parallel exec tsc --noEmit` reported a TS7006 (implicit-any) error in
+`orchestrator/src/webhook-manager.ts`. It reproduced before any task changes and is
+unrelated to those PRs. Building the orchestrator first (`pnpm --filter @ai-sdlc/orchestrator build`)
+cleared the typecheck, so the symptom is build-order/stale-dist sensitive rather than a
+hard type break — `main-health-monitor` was green throughout. This task is to pin down
+the real cause and make the typecheck robust regardless of build order.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Reproduce the TS7006 on a clean checkout without a prior orchestrator build; capture the exact parameter/line.
+- [ ] #2 Add an explicit type annotation (or the correct import) so the parameter is no longer implicitly `any`.
+- [ ] #3 `pnpm -r --parallel exec tsc --noEmit` is clean on a fresh worktree with no pre-build step.
+- [ ] #4 `pnpm --filter @ai-sdlc/orchestrator build && pnpm --filter @ai-sdlc/orchestrator test` clean; patch coverage >= 80% on any changed source.
+<!-- AC:END -->
+
+## Notes
+
+Low blast radius (single annotation likely). Surfaced during the RFC-0043 Phase 7 drain.

--- a/backlog/tasks/aisdlc-518 - fix-pipeline-cli-captures-test-output-pollution.md
+++ b/backlog/tasks/aisdlc-518 - fix-pipeline-cli-captures-test-output-pollution.md
@@ -1,0 +1,36 @@
+---
+id: AISDLC-518
+title: 'fix(pipeline-cli): stop test runs leaving _artifacts/_captures debris + mutating tracked classifier-corpus'
+status: To Do
+assignee: []
+created_date: '2026-06-04'
+labels:
+  - pipeline-cli
+  - test
+  - follow-up
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Across every RFC-0043 Phase 7 worktree, running the pipeline-cli test suite left untracked
+`pipeline-cli/_artifacts/_captures/cap_*.jsonl` files behind and modified the tracked file
+`pipeline-cli/.ai-sdlc/classifier-corpus/pr-comment-is-capture.yaml`. Each reconcile had to
+manually `rm` the captures and `git checkout --` the corpus file before staging the
+attestation, or they would surface as a dirty tree / `gh pr create` "uncommitted files"
+warning. Tests should not write into the tracked tree or a non-ignored artifacts dir.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Identify which capture/classifier tests write to `pipeline-cli/_artifacts/_captures/` and to `.ai-sdlc/classifier-corpus/pr-comment-is-capture.yaml`.
+- [ ] #2 Redirect those writes to an isolated `mkdtempSync` dir cleaned up in a `finally` (never the tracked tree, never a shared path), OR add `_artifacts/` to `.gitignore` if it is genuinely a throwaway runtime dir.
+- [ ] #3 After a full `pnpm --filter @ai-sdlc/pipeline-cli test` run, `git status --porcelain` shows no new/modified tracked or untracked files in the package.
+- [ ] #4 No shared `/tmp/.ai-sdlc` writes introduced (guards the cross-package ancestor-walk pollution class).
+<!-- AC:END -->
+
+## Notes
+
+Quality-of-life / hygiene; recurred on all nine Phase 7 reconciles. Relates to the shared-tmp pollution class.


### PR DESCRIPTION
Files 3 non-blocking follow-ups surfaced during the RFC-0043 Phase 7 drain. Backlog-task-only (docs-only via paths-ignore).

- **AISDLC-516** (docs, low): align signing-key secret name to `AISDLC_SIGNING_KEY_CONTENT` in the 3 remaining docs that still say `AISDLC_SIGNING_KEY_PATH`.
- **AISDLC-517** (orchestrator, medium): resolve the TS7006 implicit-any in `webhook-manager.ts` that surfaces on a fresh-worktree typecheck before the orchestrator is built.
- **AISDLC-518** (pipeline-cli, low): stop test runs leaving `_artifacts/_captures` debris + mutating the tracked classifier-corpus file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)