### PR TITLE
fix(orchestrator): symlink-safe entry-point detection so CLI/init run via npm bin (AISDLC-526)

### DIFF
--- a/backlog/completed/aisdlc-526 - fix-cli-bin-shim-entry-detection-fails-via-npm-symlink.md
+++ b/backlog/completed/aisdlc-526 - fix-cli-bin-shim-entry-detection-fails-via-npm-symlink.md
@@ -1,0 +1,39 @@
+---
+id: AISDLC-526
+title: >-
+  fix(cli): bin-shim entry detection fails via npm symlink — all commands
+  silently exit 0 with no output
+status: Done
+assignee: []
+labels:
+  - bug
+  - adopter-experience
+  - ci:no-issue-required
+dependencies: []
+priority: high
+references:
+  - orchestrator/src/cli/index.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+External contributor (GitHub #870, WSL2 Ubuntu, Node 22, installed `@ai-sdlc/orchestrator` via npm) reports: the `isMainEntry` check in `dist/cli/index.js` (source: `orchestrator/src/cli/index.ts`) fails when the CLI is invoked through an npm bin symlink. Result: **every command** (`ai-sdlc --help`, `--version`, `run`, `init`) produces zero output and exits 0 — the CLI looks like it does nothing. This is the first wall a non-dogfood adopter hits; it blocks all use of the package.
+
+Root cause: the "is this module the entry point?" guard (typically `if (process.argv[1] === fileURLToPath(import.meta.url))` or an equivalent `require.main`/realpath comparison) does not account for npm placing a **symlink** in `node_modules/.bin/`. When invoked via the symlink, `process.argv[1]` is the symlink path while `import.meta.url` resolves to the real file, so the equality check is false and the CLI body never runs — silently.
+
+Fix direction (implementer chooses the robust form): make the entry-point detection symlink-safe — e.g. `fs.realpathSync` both sides before comparing, or detect via the npm bin target / `process.argv[1]` basename, or always run when the file is the resolved bin target. Whatever form, it MUST work in all three cases: (a) direct `node dist/cli/index.js`, (b) `npx`/global bin symlink, (c) local `node_modules/.bin/ai-sdlc` symlink. Add a regression test that simulates the symlink-invocation case.
+
+Empirical source: GitHub issue #870 + the contributor's email report ("9 patches"); this is patch #1 and #9 (the same root cause also breaks `ai-sdlc init`).
+
+Scope: `orchestrator/` CLI entry only. Do not change command behavior — only the entry-point detection.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Entry-point detection in orchestrator/src/cli/index.ts is symlink-safe: the CLI body runs (and produces output) when invoked via an npm bin symlink, not just via direct `node dist/cli/index.js`
+- [x] #2 `ai-sdlc --help` and `ai-sdlc --version` produce output and exit 0 in all three invocation modes (direct, global bin symlink, local node_modules/.bin symlink); `ai-sdlc init` and `ai-sdlc run` reach their command handlers
+- [x] #3 A regression test covers the symlink-invocation case (e.g. compares realpath-resolved entry vs argv[1] through a symlink) so this cannot silently regress
+- [x] #4 No change to any command's behavior — only entry-point detection
+- [x] #5 pnpm build + pnpm -F @ai-sdlc/orchestrator test + lint + format:check pass
+<!-- AC:END -->


### PR DESCRIPTION
## Summary

This PR closes AISDLC-526 by confirming and documenting that the symlink-safe entry-point detection fix is fully implemented, tested, and passing.

## Background: The Silent-Exit Symptom

An external contributor (GitHub issue #870, WSL2 Ubuntu, Node 22, global npm install) reported that ALL ai-sdlc commands (`--help`, `--version`, `run`, `init`) produced zero output and exited 0. The CLI appeared completely non-functional.

**Root cause:** When npm installs a package globally, it places a symlink in the bin directory (e.g. `/usr/local/bin/ai-sdlc` → `node_modules/@ai-sdlc/orchestrator/dist/cli/index.js`). Node.js does NOT resolve symlinks for `process.argv[1]`. The old `isMainEntry` guard compared `process.argv[1]` (the symlink path) to `fileURLToPath(import.meta.url)` (the real file path) — they never matched, so the guard was always `false`, the CLI body never ran, and every command silently exited 0.

## The Fix (in `orchestrator/src/cli/index.ts`)

The `computeIsMainEntry` function uses `realpathSync` on BOTH sides before comparing:

```typescript
const realArgv1 = realpathSync(argv1);          // resolves npm bin symlink
const realModule = realpathSync(fileURLToPath(moduleUrl));  // resolves OS-level dir symlinks (e.g. macOS /tmp → /private/tmp)
return realArgv1 === realModule;
```

This correctly handles all three invocation modes:
- (a) Direct: `node dist/cli/index.js` — both sides are the same real path
- (b) Global bin symlink: `/usr/local/bin/ai-sdlc` → `realArgv1` resolves to the real dist file
- (c) Local `node_modules/.bin/ai-sdlc` symlink — same resolution applies

The fix also catches OS-level directory symlinks (e.g. macOS `/tmp` → `/private/tmp`) that could cause spurious mismatches even without npm bin symlinks.

## How It Was Tested

The regression test suite in `orchestrator/src/cli/index.test.ts` (`computeIsMainEntry — symlink-aware main detection` describe block) covers:
1. `undefined` argv1 → `false`
2. Non-existent path → `false`  
3. Different file → `false`
4. Exact same file → `true`
5. **Symlink pointing to the module file (npm bin scenario) → `true`** (the core regression test)
6. Symlink pointing to a different file → `false`

All 4534 tests pass (`pnpm -F @ai-sdlc/orchestrator test`).

## Verification

- `pnpm build` — clean
- `pnpm -F @ai-sdlc/orchestrator test` — 4534 passed, 1 skipped
- `pnpm lint` — clean
- `pnpm format:check` — clean

The implementation was already in place via PR #703 (gh-issue-610). This PR closes the AISDLC-526 backlog task and moves it to `backlog/completed/` to formally track the closure.

References AISDLC-526