### PR TITLE
chore: sync 2 untracked task files

### DIFF
--- a/backlog/tasks/aisdlc-531 - chore-prep-ucvg-option-b-for-external-kiro-runner-pr.md
+++ b/backlog/tasks/aisdlc-531 - chore-prep-ucvg-option-b-for-external-kiro-runner-pr.md
@@ -1,0 +1,72 @@
+---
+id: AISDLC-531
+title: >-
+  chore: prep UCVG Option B for the external Kiro-runner PR (allow-list runner
+  path + enable AI_SDLC_UNTRUSTED_PR_GATE)
+status: To Do
+assignee: []
+labels:
+  - chore
+  - security
+  - ci:no-issue-required
+dependencies: []
+priority: medium
+dispatchable: false
+dispatchableReason: >-
+  Operator-led security prep: the allow-list scope + flipping the untrusted-PR-gate
+  feature flag are operator decisions tied to the arrival of the external Kiro PR
+  (GitHub #870 / contributor Fridayana). Do not auto-dispatch.
+references:
+  - .ai-sdlc/untrusted-pr-gate.yaml
+  - .github/workflows/untrusted-pr-gate.yml
+  - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification-gate.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Prep so the RFC-0043 untrusted-contributor PR gate (UCVG) actually VERIFIES the external
+Kiro-runner contribution rather than hard-blocking it at Stage 1 — the "Option B" the
+operator chose (run real external executable code through the sandbox + hardened reviewers
++ clean-room attestation, instead of rejecting it at the AST gate).
+
+Context: external contributor Fridayana (GitHub #870) will submit a `KiroRunner` PR against
+the runner seam landed in AISDLC-529 (`--runner` / `AI_SDLC_RUNNER_PLUGIN`). A runner is
+executable code the orchestrator invokes, so UCVG's Stage-1 AST gate (allowed-globs) will
+reject it as a protected/disallowed path unless we explicitly admit the runner contribution
+path for sandbox review.
+
+This task is the deliberate, operator-overseen config change to enable that — DO NOT enable
+the gate broadly or before the Kiro PR is imminent.
+
+Steps (operator-gated):
+1. Decide + add the runner-contribution path(s) to `allowed-globs` in
+   `.ai-sdlc/untrusted-pr-gate.yaml` — scoped NARROWLY to where a contributed runner lives
+   (e.g. a dedicated `contrib/runners/**` dir, or the specific runner file path), NOT a broad
+   source allow. The goal: the Kiro PR passes Stage 1 into Stage 2-4 sandbox verification.
+2. Confirm the Stage-2 differential-test harness can actually exercise a runner contribution
+   (today it is wired around the `ucvg-demo` fixture) so the hardened reviewers get real
+   signal on the runner's own tests. Extend the harness if needed, or document the limitation.
+3. Enable the gate for the test: `gh variable set AI_SDLC_UNTRUSTED_PR_GATE --body 1`
+   (currently default-off per RFC-0043 §Migration Path). Decide scope: repo-wide vs only for
+   the window of the Kiro PR.
+4. Eyes-open note (record in the PR/decision): the sandbox prevents exfiltration DURING
+   review (network=none + credential-withholding proxy), but a merged runner executes with
+   REAL credentials on normal runs — so the hardened-reviewer verdict + clean-room attestation
+   are the load-bearing gate for executable contributions. This is the intended UCVG test.
+5. After the Kiro PR is resolved, decide whether to leave the gate enabled (promotion) or
+   revert to default-off + remove the runner path from allowed-globs.
+
+Cross-refs: AISDLC-529 (runner seam, merged), RFC-0043 (UCVG), the UCVG live-demo work
+(fork harness, AQ2). The flag check + allowed-globs live in untrusted-pr-gate.yml /
+untrusted-pr-gate.yaml.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The runner-contribution path is added to `allowed-globs` in `.ai-sdlc/untrusted-pr-gate.yaml`, scoped narrowly to where a contributed runner lives (not a broad source allow), so the Kiro PR passes Stage 1 into sandbox verification
+- [ ] #2 The Stage-2 differential-test harness can exercise a runner contribution's own tests (or the limitation is documented), so Stage-3 hardened reviewers get real signal
+- [ ] #3 `AI_SDLC_UNTRUSTED_PR_GATE` is enabled for the test window (`gh variable set AI_SDLC_UNTRUSTED_PR_GATE --body 1`), with the scope (repo-wide vs PR-window) decided + recorded
+- [ ] #4 The executable-contribution risk note (sandbox protects during review; merged runner runs with real creds → reviewer verdict + attestation are the gate) is recorded in the PR/decision
+- [ ] #5 A post-test plan is recorded: leave the gate enabled (promote) OR revert to default-off + remove the runner allow-list path after the Kiro PR resolves
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-531 - chore-prep-ucvg-option-b-for-external-kiro-runner-pr.md
+++ b/backlog/tasks/aisdlc-531 - chore-prep-ucvg-option-b-for-external-kiro-runner-pr.md
@@ -19,7 +19,7 @@ dispatchableReason: >-
 references:
   - .ai-sdlc/untrusted-pr-gate.yaml
   - .github/workflows/untrusted-pr-gate.yml
-  - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification-gate.md
+  - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification.md
 ---
 
 ## Description

--- a/backlog/tasks/aisdlc-532 - chore-migrate-npm-publish-to-oidc-trusted-publishing.md
+++ b/backlog/tasks/aisdlc-532 - chore-migrate-npm-publish-to-oidc-trusted-publishing.md
@@ -1,0 +1,65 @@
+---
+id: AISDLC-532
+title: >-
+  chore(release): migrate npm publishing from long-lived NPM_TOKEN to OIDC
+  trusted publishing
+status: To Do
+assignee: []
+labels:
+  - chore
+  - security
+  - release
+  - ci:no-issue-required
+priority: medium
+dependencies: []
+dispatchable: false
+dispatchableReason: >-
+  Operator-coordinated: the npmjs.com per-package trusted-publisher config is operator-only
+  and is a HARD precondition for the workflow change (removing the token before npmjs trusts
+  the workflow breaks the next release). Also a pnpm 9->10 MAJOR upgrade that needs careful
+  verification. Operator sequences; the pnpm+workflow edit may be dispatched as a sub-step
+  only AFTER the npmjs config is in place.
+references:
+  - .github/workflows/release.yml
+  - package.json
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Replace the long-lived `NPM_TOKEN` GitHub Actions secret (consumed at `release.yml` `pnpm -r publish` via `NODE_AUTH_TOKEN`) with **npm OIDC trusted publishing**, so npm publishes use a short-lived credential minted from the workflow's OIDC identity — no rotatable secret. PyPI in this same workflow already uses OIDC trusted publishing (`pypa/gh-action-pypi-publish`, `id-token: write`), so the pattern is proven here; npm just needs per-package config + a tooling-version bump.
+
+**Blocker (verified 2026-06-10):** the repo is on `pnpm@9.15.4`, which does NOT support OIDC trusted publishing. Support landed in **pnpm 10.x** (OIDC exchange in `pnpm publish`; needs npm CLI >= 11.5.1 underneath). Two approaches:
+
+- **Approach A (recommended):** bump `packageManager` to an OIDC-capable `pnpm@10.x` (confirm the exact minimum in pnpm's release notes), keep `pnpm -r publish`, drop the token env. Risk: pnpm 9->10 is a MAJOR — verify the whole monorepo installs/builds/tests + the lockfile is regenerated cleanly on pnpm 10 in a dedicated PR (do NOT bundle unrelated changes).
+- **Approach B:** replace `pnpm -r publish` with a per-package `npm publish` loop (npm >= 11.5.1). Avoids the pnpm major but you hand-manage workspace `workspace:*` resolution + the publish loop.
+
+**npmjs.com config (operator-only, HARD PRECONDITION — must be done before removing the token):** for EACH published package, add a GitHub Actions trusted publisher (org `ai-sdlc-framework`, repo `ai-sdlc`, workflow `release.yml`). npm trusted publishing is PER-PACKAGE (no scope-level yet). The 5 published packages:
+- `@ai-sdlc/orchestrator`
+- `@ai-sdlc/reference`
+- `@ai-sdlc/pipeline-cli`
+- `@ai-sdlc/mcp-advisor`
+- `@ai-sdlc/plugin-mcp-server`
+All are already published, so they are eligible for trusted-publisher config.
+
+**release.yml changes:** `permissions: id-token: write` is ALREADY present (used for provenance today). Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step; `--provenance` becomes automatic under trusted publishing (drop the flag); keep `registry-url: 'https://registry.npmjs.org'`.
+
+**Rollout sequencing (avoid a broken release):**
+1. Operator configures trusted publishers on npmjs for all 5 packages.
+2. Bump pnpm to OIDC-capable 10.x (Approach A) in a dedicated PR; verify install/build/test + lockfile regen green.
+3. Edit release.yml to drop `NODE_AUTH_TOKEN` (rely on OIDC).
+4. Validate the next release actually publishes via OIDC (watch the `publish-npm` job).
+5. Operator DELETES the `NPM_TOKEN` secret once trusted publishing is confirmed working.
+
+**Follow-on note:** any NEW publishable package added later must get its own trusted-publisher config before its first CI publish.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 (operator) A GitHub Actions trusted publisher is configured on npmjs.com for all 5 published packages (orchestrator, reference, pipeline-cli, mcp-advisor, plugin-mcp-server): org ai-sdlc-framework, repo ai-sdlc, workflow release.yml
+- [ ] #2 Tooling supports OIDC publishing: either packageManager bumped to an OIDC-capable pnpm 10.x with the monorepo installing/building/testing green + lockfile regenerated (Approach A), OR the publish step switched to npm publish (npm >= 11.5.1) per package (Approach B)
+- [ ] #3 release.yml publish step no longer references NODE_AUTH_TOKEN / NPM_TOKEN; id-token: write retained; registry-url retained; --provenance dropped (automatic under trusted publishing)
+- [ ] #4 A release run publishes all packages successfully via OIDC trusted publishing (verified on the publish-npm job — no E401/E403; provenance attestations still produced)
+- [ ] #5 (operator) The NPM_TOKEN GitHub Actions secret is DELETED after trusted publishing is confirmed working
+- [ ] #6 docs/operations/release-flow.md updated to document trusted publishing + the per-package trusted-publisher requirement for any new package
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-532 - chore-migrate-npm-publish-to-oidc-trusted-publishing.md
+++ b/backlog/tasks/aisdlc-532 - chore-migrate-npm-publish-to-oidc-trusted-publishing.md
@@ -42,7 +42,7 @@ Replace the long-lived `NPM_TOKEN` GitHub Actions secret (consumed at `release.y
 - `@ai-sdlc/plugin-mcp-server`
 All are already published, so they are eligible for trusted-publisher config.
 
-**release.yml changes:** `permissions: id-token: write` is ALREADY present (used for provenance today). Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step; `--provenance` becomes automatic under trusted publishing (drop the flag); keep `registry-url: 'https://registry.npmjs.org'`.
+**release.yml changes:** `permissions: id-token: write` is ALREADY present (used for provenance today). Remove `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step; `--provenance` becomes automatic under trusted publishing (drop the flag); keep the npm `registry-url` setup-node config.
 
 **Rollout sequencing (avoid a broken release):**
 1. Operator configures trusted publishers on npmjs for all 5 packages.


### PR DESCRIPTION
Auto-opened by Step 0.5 — backstop for Pattern C untracked-file drift (AISDLC-217).

## Files
- `backlog/tasks/aisdlc-531 - chore-prep-ucvg-option-b-for-external-kiro-runner-pr.md`
- `backlog/tasks/aisdlc-532 - chore-migrate-npm-publish-to-oidc-trusted-publishing.md`

This is a docs-only PR (`backlog/tasks/` and `backlog/completed/` are under `paths-ignore` for attestation workflows) and will auto-merge once CI passes.

> Source: AISDLC-216 (Pattern-C MCP routing) is the upstream fix; Step 0.5 is the backstop for cases #216 misses.