### PR TITLE
chore: mark AISDLC-531 ready (parked pending external Kiro PR)

### DIFF
--- a/backlog/tasks/aisdlc-531 - chore-prep-ucvg-option-b-for-external-kiro-runner-pr.md
+++ b/backlog/tasks/aisdlc-531 - chore-prep-ucvg-option-b-for-external-kiro-runner-pr.md
@@ -20,6 +20,14 @@ references:
   - .ai-sdlc/untrusted-pr-gate.yaml
   - .github/workflows/untrusted-pr-gate.yml
   - spec/rfcs/RFC-0043-untrusted-contributor-pr-verification.md
+blocked:
+  reason: >-
+    READY — parked pending the external Kiro-runner PR (GitHub #870 / Fridayana);
+    operator sent the invitation email 2026-06-10. Prerequisite is already done:
+    ANTHROPIC_API_KEY is set + funded (~$23.20), held host-side and withheld from
+    the sandbox via the AQ2 proxy. On PR arrival only two steps remain: (1) add the
+    narrow runner allow-list path to .ai-sdlc/untrusted-pr-gate.yaml; (2) set the
+    AI_SDLC_UNTRUSTED_PR_GATE repo variable to 1.
 ---
 
 ## Description


### PR DESCRIPTION
Marks AISDLC-531 (UCVG Option-B prep) as ready-but-parked pending the external Kiro-runner PR (#870). Adds a blocked.reason recording that the ANTHROPIC_API_KEY prerequisite is already set + funded, so on PR arrival only the narrow allow-list path + AI_SDLC_UNTRUSTED_PR_GATE=1 remain. Docs-only (single backlog task file).

References AISDLC-531