### PR TITLE
docs(backlog): file AISDLC-534 (dependabot.yml docs-only classification) + sync AISDLC-533

### DIFF
--- a/backlog/tasks/aisdlc-533 - fix-flaky-capture-test-against-current-pr-graceful-fallback-timeout.md
+++ b/backlog/tasks/aisdlc-533 - fix-flaky-capture-test-against-current-pr-graceful-fallback-timeout.md
@@ -1,0 +1,43 @@
+---
+id: AISDLC-533
+title: >-
+  fix(test): de-flake capture.test.ts against-current-pr graceful-fallback
+  (5000ms timeout in CI)
+status: To Do
+assignee: []
+labels:
+  - bug
+  - test
+  - flaky
+  - ci:no-issue-required
+priority: medium
+dependencies: []
+references:
+  - pipeline-cli/src/cli/capture.test.ts
+  - pipeline-cli/src/cli/capture.ts
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The test `pipeline-cli/src/cli/capture.test.ts` > `against-current-pr subcommand` > `files a capture with a null PR when git/gh are not available (graceful fallback)` (around line 524) intermittently fails with `Error: Test timed out in 5000ms`. It has bitten CI repeatedly: e.g. the 2026-06-10 main-push Coverage run and the AISDLC-531/532 sync PR's PR-Ready-Gate Build-and-Test, while the SAME commit passed in the main CI workflow's Build-and-Test — the hallmark of a flake, not a real regression.
+
+Likely root cause: the test exercises the null-PR branch of `detectCurrentPrNumber` "when git/gh are not available", but instead of injecting a fake/stubbed git+gh runner it appears to let the code actually shell out to real `git`/`gh`. In CI those can block (e.g. `gh` waiting on auth/network, or `git` on an unexpected state) past the 5000ms vitest default, producing the timeout. The "graceful fallback" path should be exercised with the external commands STUBBED to fail/return-not-available deterministically and instantly — never by relying on the ambient environment lacking git/gh.
+
+Fix direction (implementer confirms against the code):
+- Inject a stub command-runner (or mock the git/gh invocation seam) so the "not available" path returns immediately and deterministically, with no real subprocess.
+- If the production code has no injection seam for the git/gh calls, add one (small refactor) so the test can drive the fallback without real subprocesses — this also makes the test hermetic.
+- As a secondary safety net (not the primary fix), an explicit per-test timeout is acceptable, but the real fix is removing the real-subprocess dependency so the test is deterministic and fast.
+- Audit sibling tests in the same file that shell out to git/gh for the same flake class and apply the same stubbing.
+
+This is the same cli-capture flake family seen earlier in the session (decisions.test.ts / capture.test.ts shared-/tmp + real-subprocess issues). Keep the fix scoped to making the test hermetic; do not weaken what it asserts (the null-PR fallback must still be verified).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The `against-current-pr ... graceful fallback` test no longer depends on real `git`/`gh` subprocesses — the "not available" path is driven by an injected stub/mock that returns deterministically and instantly
+- [ ] #2 If needed, a git/gh invocation seam is added to the production code so the fallback is testable without real subprocesses (small, behavior-preserving refactor)
+- [ ] #3 The test still asserts the same behavior (a capture is filed with a null PR when git/gh are unavailable) — assertion not weakened
+- [ ] #4 Other tests in capture.test.ts that shell out to real git/gh are audited and stubbed for the same flake class
+- [ ] #5 `pnpm --filter @ai-sdlc/pipeline-cli test` and `test:coverage` pass consistently across repeated local runs; lint + format clean
+<!-- AC:END -->

--- a/backlog/tasks/aisdlc-534 - classify-github-config-as-docs-only-skip-attestation.md
+++ b/backlog/tasks/aisdlc-534 - classify-github-config-as-docs-only-skip-attestation.md
@@ -1,0 +1,73 @@
+---
+id: AISDLC-534
+title: >-
+  fix(ci): classify human-authored .github/dependabot.yml (non-workflow config)
+  as docs-only / skip-attestation so it doesn't require a full code-PR attestation
+status: To Do
+assignee: []
+labels:
+  - bug
+  - ci
+  - dx
+  - ci:no-issue-required
+priority: medium
+dependencies: []
+references:
+  - scripts/is-docs-only-changeset.mjs
+  - .github/workflows/verify-attestation.yml
+  - .github/workflows/ai-sdlc-review.yml
+  - .github/dependabot.yml
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A **human-authored** PR that only changes `.github/dependabot.yml` (or other non-workflow
+`.github/**` config) is currently classified as a **code PR** by the change-detection logic,
+because `.github/dependabot.yml` is not in the docs-only paths-ignore set
+(`spec/rfcs/**`, `docs/**`, `backlog/**`, root `*.md`). The `Attestation gate (code PRs)`
+job then polls for `ai-sdlc/attestation: success` and FAILS the `ai-sdlc/pr-ready` rollup
+because a config-only PR has no DSSE envelope.
+
+Dependabot-AUTHORED PRs for the same file sail through via the
+`Auto-approve automation PR (Dependabot)` bypass — but that bypass is keyed on the PR
+author being dependabot, NOT on the file being config. So when a maintainer hand-authors a
+superseding/remade config PR, the bypass is lost and the maintainer must run the entire
+attestation reconcile (3 reviewers → emit-leaf → sign v6 → verify status=valid → push)
+plus a fresh-worktree `pnpm install` + build of pipeline-cli AND orchestrator — heavyweight
+overhead for a few lines of YAML.
+
+**Motivating incident (2026-06-12 window):** PR #893 (react patch-version dependabot
+`ignore:` block, a 19-line YAML addition that superseded the closed dependabot PR #876)
+was blocked by `Attestation gate (code PRs)` for exactly this reason and required a full
+manual v6 attestation to land.
+
+**Fix direction (implementer confirms against the workflows):**
+- Treat `.github/dependabot.yml` (and ideally other non-workflow `.github/**` config such as
+  `.github/CODEOWNERS`, `.github/*.md`) as **docs-only / attestation-exempt** for the
+  `verify-attestation.yml` + `ai-sdlc-review.yml` gates, so a config-only changeset
+  short-circuits the same way `spec/rfcs/**` / `docs/**` / `backlog/**` do.
+- The shared classifier is `scripts/is-docs-only-changeset.mjs` (used on `merge_group`)
+  plus the `paths-ignore` lists on the `pull_request` triggers — update BOTH in lockstep so
+  the PR-event path and the merge_group path agree (asymmetry between them is its own bug class).
+- **Do NOT** exempt `.github/workflows/**` — actual workflow YAML is security-sensitive and
+  MUST keep its gate. Scope the exemption tightly to non-executable config files.
+- Add hermetic coverage to `scripts/is-docs-only-changeset.test.mjs` (or equivalent): a
+  changeset touching only `.github/dependabot.yml` is docs-only; a changeset touching
+  `.github/workflows/*.yml` is NOT docs-only; a mixed changeset (config + source) is NOT
+  docs-only.
+
+**Related:** AISDLC-484 (fix dead docs-only CI fast-path — same classification surface;
+coordinate so the two don't conflict). The maintainer-config-needs-attestation gotcha is
+captured in operator memory `feedback_human_authored_config_pr_needs_attestation`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A PR that changes ONLY `.github/dependabot.yml` is classified as docs-only / attestation-exempt and merges without requiring a DSSE attestation envelope (the `Attestation gate (code PRs)` job does not block it)
+- [ ] #2 The exemption is applied consistently on BOTH the `pull_request` paths-ignore path and the `merge_group` inline `is-docs-only-changeset.mjs` path (no asymmetry)
+- [ ] #3 `.github/workflows/**` remains a code-PR / attestation-required surface — workflow YAML is explicitly NOT exempted
+- [ ] #4 A mixed changeset (config + any source/test file) is still treated as a code PR requiring attestation
+- [ ] #5 Hermetic tests cover the dependabot-only (exempt), workflow-yml (not exempt), and mixed (not exempt) cases; lint + format clean
+- [ ] #6 Coordinated with AISDLC-484 so the two docs-only-classification changes do not conflict
+<!-- AC:END -->


### PR DESCRIPTION
Docs-only backlog PR (no code; `backlog/**` is attestation-exempt via paths-ignore).

## What
- **AISDLC-534** (new) — fix(ci): classify human-authored `.github/dependabot.yml` (non-workflow config) as docs-only / skip-attestation so a config-only PR doesn't require a full code-PR attestation envelope. Follow-up to the **PR #893** incident where a 19-line dependabot `ignore:` block was blocked by `Attestation gate (code PRs)` and required a full manual v6 attestation. Coordinates with AISDLC-484.
- **AISDLC-533** (sync) — de-flake `capture.test.ts` against-current-pr graceful-fallback (5000ms CI timeout). The task file was created earlier in-session but never synced to `main`; bundling it here.

## Why now
Both #893 and #894 (the two dependabot fixes) just merged. #534 closes the loop so the next human-authored config tweak skips the attestation dance; #533 captures the recurring `capture.test.ts`/`bin-invocation.test.ts` spawn-timeout flake that bit both PRs' CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)