### PR TITLE
docs(backlog): file AISDLC-567 + AISDLC-568 — workflow blockedPaths config + attestation independence anchor

### DIFF
--- a/backlog/tasks/aisdlc-567 - make-github-workflows-blocking-project-configurable-via-blockedpaths.md
+++ b/backlog/tasks/aisdlc-567 - make-github-workflows-blocking-project-configurable-via-blockedpaths.md
@@ -1,0 +1,66 @@
+---
+id: aisdlc-567
+title: Make `.github/workflows/**` blocking project-configurable via agent-role blockedPaths + isolate agents from sibling repos
+status: To Do
+priority: high
+labels:
+  - governance
+  - worktree-isolation
+  - adoption
+---
+
+## Description
+
+Two related problems surfaced when a downstream consumer repo (which the operator
+permits to edit its own CI workflows) hit the PreToolUse governance, and the
+agent working for it made **direct, uncommitted edits to the ai-sdlc framework
+repo's read-only parent working tree** (from a 2-commit-stale base, reverting
+merged AISDLC-554/557/559 work as collateral). See GitHub issue #977 for the full
+incident write-up; the debris was discarded and its intent captured here.
+
+### Part A — configurable workflow blocking
+
+Today the PreToolUse hook hard-blocks `Write`/`Edit` on `.github/workflows/**`
+for every agent in every project. Consumer repos that legitimately want agents to
+maintain their own CI have no supported opt-in. Make it project-configurable:
+
+- `.github/workflows/**` is **NOT** blocked by default.
+- It is refused **only** when the project's `.ai-sdlc/agent-role.yaml` lists it
+  (or a matching glob) under `blockedPaths`.
+- `.ai-sdlc/**` remains never-editable regardless.
+- Net rule: refuse `Write`/`Edit` on `.ai-sdlc/**`, any path in the project's
+  `agent-role.yaml` `blockedPaths`, and any path outside the worktree not in
+  `permittedExternalPaths`.
+
+Surfaces: the PreToolUse hook enforcement + the `agent-role.yaml` schema/loader,
+and the governance text in the agent/command docs (`developer`, `execute`,
+`orchestrator-tick`, `dispatch-worker`, reviewer/resolver agents) plus their tests.
+(Note: internal CLAUDE.md already says the workflow-edit rule is external-only —
+this task makes the *enforcement* match that intent and makes it configurable.)
+
+### Part B — isolate agents from sibling/parent repos (the incident's root cause)
+
+An agent scoped to repo X was able to write into an unrelated framework checkout Y
+on the same machine because Y was a filesystem sibling. Harden isolation:
+
+- An agent should not be able to `Write`/`Edit` any path **outside its active
+  worktree** that is not in `permittedExternalPaths` — regardless of whether the
+  target is itself a git repo. (Extends the existing outside-worktree refusal to
+  cover sibling repos, not just loose files.)
+- Warn/refuse when the agent's working tree HEAD is behind `origin/main` before it
+  begins mutating, so stale-base edits can't silently revert merged work.
+
+## Acceptance Criteria
+
+- [ ] `.github/workflows/**` is editable by default and refused only when listed
+      in the project's `agent-role.yaml` `blockedPaths`; `.ai-sdlc/**` still never
+      editable. Enforced in the PreToolUse hook, with hermetic tests for both the
+      permitted and blocked configurations.
+- [ ] `agent-role.yaml` schema/loader documents and validates `blockedPaths`.
+- [ ] Agent/command governance docs updated to state the configurable rule; their
+      tests assert `blockedPaths` scoping (not a hardcoded `.github/workflows` ban).
+- [ ] PreToolUse refuses writes to any sibling repo / path outside the active
+      worktree not in `permittedExternalPaths`, with a hermetic test simulating a
+      sibling-repo path.
+- [ ] Stale-base guard: an agent whose worktree HEAD is behind `origin/main`
+      surfaces a warning (or refusal) before mutating; covered by a test.

--- a/backlog/tasks/aisdlc-568 - anchor-attestation-independence-to-real-reviewer-execution-transcript.md
+++ b/backlog/tasks/aisdlc-568 - anchor-attestation-independence-to-real-reviewer-execution-transcript.md
@@ -1,0 +1,77 @@
+---
+id: aisdlc-568
+title: >-
+  Anchor attestation independence to the reviewer's real execution transcript +
+  a lower-trust self-review verdict class
+status: To Do
+priority: high
+labels:
+  - attestation
+  - proof-of-execution
+  - adoption
+drift_status: flagged
+drift_checked: '2026-09-04'
+drift_log:
+  - date: '2026-09-04'
+    type: ref-deleted
+    detail: 'Referenced file no longer exists: AISDLC-566'
+    resolution: flagged
+  - date: '2026-09-04'
+    type: refs-orphaned
+    detail: All referenced files have been deleted
+    resolution: flagged
+---
+
+## Description
+
+From the Proof-of-Execution consumer-repo investigation (external report at GitHub
+issue #976). AISDLC-554 restored the signer's **reachability** in consumer repos,
+and [[aisdlc-566]] covers the missing consumer-runnable **verifier**. This task
+covers the remaining, deeper gap: **independence is not structurally anchored** —
+even with a valid signature, nothing distinguishes "an independent reviewing
+actor" from "the coordinator/author that also made the ship decision."
+
+Confirmed at `main`: the signature is over the Merkle root only, using
+`~/.ai-sdlc/signing-key.pem` (`sign-attestation.mjs`, `pipeline-cli/src/attestation/sign-v6.ts`).
+Any process with a repo checkout + read access to that key can author a reviewer
+transcript file and sign it. Forge-resistance (transcript ≈ cost of real review)
+does **not** stop an *expensive self-review*: the coordinator paying full cost,
+running the review itself, and recording it as "the reviewer."
+
+## Scope
+
+1. **Bind the leaf to the reviewer's real, auto-captured execution transcript**,
+   not a hand-written summary file. The agent harness already emits a full
+   per-subagent execution JSONL (prompt, tool calls, outputs). Hash *that*
+   artifact into the leaf so the forgery floor becomes "actually spawn and run an
+   independent reviewer subagent," which a coordinator cannot fake by writing a
+   file. (This is the closest thing to true PoE achievable on a single machine.)
+2. **Represent a coordinator/self-authored attestation as a distinct, lower-trust
+   verdict class** rather than silently equivalent to an independent review, so an
+   honest-wording configuration is enforceable and a self-review is visibly not
+   independent.
+3. **Correct the claim wording** everywhere to what is actually guaranteed:
+   "records that a real review ran against this exact code state by a process with
+   repo access; does NOT by itself prove reviewer identity or independence" —
+   unless/until (1) is in place.
+
+Composes with the operator-signs-root anchor and the consumer-verifier work
+([[aisdlc-566]]); overlaps the enforcement-gap tasks [[aisdlc-560]],
+[[aisdlc-561]], [[aisdlc-562]] (init installs artifacts without enforcement;
+SessionStart claims policy active when nothing enforces it; never write
+unattributable transcripts under `unknown`).
+
+## Acceptance Criteria
+
+- [ ] Transcript leaf hashes the reviewer subagent's real auto-captured execution
+      JSONL (not a coordinator-writable summary file); a coordinator that only
+      writes a summary cannot produce a passing independent-tier leaf.
+- [ ] A coordinator/self-authored attestation is recorded and verified as a
+      distinct lower-trust verdict class, visibly not equivalent to an
+      independent-reviewer verdict.
+- [ ] Claim wording (docs + any emitted human-readable summaries) states the true
+      guarantee and does not assert independence where it isn't structurally
+      anchored.
+- [ ] Hermetic tests: (a) independent-reviewer path produces an independent-tier
+      leaf; (b) self-authored path is rejected or downgraded to the lower-trust
+      class; (c) verifier surfaces the trust class.


### PR DESCRIPTION
## Summary

Files two backlog tasks driving the fixes surfaced by the consumer-repo
attestation + governance investigation. Backlog-only (docs) PR; no attestation.

- **AISDLC-567** — make `.github/workflows/**` blocking project-configurable via
  `.ai-sdlc/agent-role.yaml` `blockedPaths` (editable by default; blocked only when
  the project lists it), **and** isolate agents from writing into sibling/parent
  repos outside their worktree + guard against stale-base edits. Captures the
  feature intent + root cause from the incident where a downstream agent wrote
  directly into this framework repo's read-only parent tree (was GH issue #977).
- **AISDLC-568** — anchor attestation **independence** to the reviewer's real
  auto-captured execution transcript + represent a coordinator/self-authored
  attestation as a distinct lower-trust verdict class (Claim 3 of the
  Proof-of-Execution report #976). Complements AISDLC-566 (consumer verifier).

Both tasks stay `To Do` for the orchestrator to pick up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
