### PR TITLE
docs(backlog): sync task files AISDLC-581/582/584/585

### DIFF
--- a/backlog/tasks/aisdlc-581 - Cache-session-start-runtime-version-check-with-a-TTL-avoid-per-session-npm-view-calls.md
+++ b/backlog/tasks/aisdlc-581 - Cache-session-start-runtime-version-check-with-a-TTL-avoid-per-session-npm-view-calls.md
@@ -1,0 +1,39 @@
+---
+id: AISDLC-581
+title: >-
+  Cache session-start runtime version-check with a TTL (avoid per-session npm
+  view calls)
+status: To Do
+assignee: []
+created_date: '2026-09-05 22:05'
+labels:
+  - plugin
+  - performance
+  - aisdlc-580-followup
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem
+AISDLC-580 wired a version-aware self-heal into `ai-sdlc-plugin/hooks/session-start.js` via the shared `check-stale-runtime-deps.mjs`, which runs 1-3 `npm view <pkg>@<pin> version` registry round-trips on EVERY session start (bounded to an 8s fail-open budget). That's correct and safe (fails open, once per session, not per keystroke), but it adds registry latency to every session start with no caching.
+
+`ai-sdlc-plugin/hooks/check-plugin-version.js` already solves the identical concern with a **24h TTL cache** at `~/.cache/ai-sdlc-plugin/version-check.json` (+ `AI_SDLC_DISABLE_VERSION_CHECK=1` opt-out). The stale-runtime check should reuse the same pattern.
+
+## Scope
+1. Add a short-TTL cache (suggest ~1-6h; shorter than the version-check's 24h since a stale runtime is more actionable) to the `check-stale-runtime-deps.mjs` / session-start path so it doesn't hit the registry on every session start — reuse or mirror `check-plugin-version.js`'s cache mechanism (cache dir, TTL, corrupt-cache tolerance).
+2. Respect the same disable env var (or a dedicated one) for parity.
+3. Keep fail-open behavior + the once-installed-then-stale detection intact (a cache MISS still checks; a cache HIT within TTL skips the network).
+4. Hermetic test: cache-hit-within-TTL performs no `npm view`; cache-miss/expired does; corrupt cache tolerated.
+
+## Acceptance Criteria
+- Session start does NOT perform an `npm view` when a fresh (within-TTL) stale-runtime cache entry exists.
+- Cache miss/expiry still detects a stale runtime and triggers the self-heal.
+- Fail-open + corrupt-cache tolerance preserved; hermetic test covering hit/miss/corrupt.
+- `pnpm build && pnpm test && pnpm lint && pnpm format:check` pass.
+
+## Note
+Low priority — the current behavior is correct + bounded, this is a latency/UX polish. Surfaced by the security + code reviews of [[aisdlc-580]] (PR #1009). Reuses the [[check-plugin-version]] cache pattern.
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/aisdlc-582 - ai-sdlc-doctor-remaining-seed-catalog-checks-4568910-trusted-reviewers-schema.md
+++ b/backlog/tasks/aisdlc-582 - ai-sdlc-doctor-remaining-seed-catalog-checks-4568910-trusted-reviewers-schema.md
@@ -1,0 +1,61 @@
+---
+id: AISDLC-582
+title: >-
+  ai-sdlc doctor — remaining seed-catalog checks (4,5,6,8,9,10) +
+  trusted-reviewers schema
+status: To Do
+assignee: []
+created_date: '2026-09-05 22:38'
+labels:
+  - adoption
+  - cli
+  - doctor
+  - config-validation
+  - aisdlc-578-followup
+dependencies: []
+references:
+  - >-
+    backlog/completed/aisdlc-578 -
+    ai-sdlc-doctor---end-to-end-project-config-health-audit-fix-workflow-recommendations.md
+  - spec/rfcs/RFC-0045-adopter-health-upstream-reporting.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Problem
+
+AISDLC-578 shipped the `ai-sdlc doctor` check registry with a battle-tested priority subset of the 12-check seed catalog (checks 1 plugin-version, 2 runtime-deps-pins + caret-trap, 3 manifests-agree, 7 attestation-governance, 11 marketplace-catalog-drift, 12 npm-dist-tag-reachability), plus `--fix` for the mechanical subset and a shared branch-protection helper. Per the task's own explicit fallback clause ("land a coherent set... note any deferred check in the PR body"), the remaining checks were deferred to keep the first PR reviewable. This task finishes the catalog.
+
+## Scope (remaining checks from the AISDLC-578 seed catalog)
+
+Implement as new modules in the same `doctor-checks.ts` registry (documented extension point already exists):
+
+- **Check 4** — `.ai-sdlc/agent-role.yaml` present + schema-valid against `spec/schemas/agent-role.schema.json` (surface what SessionStart swallows silently). Needs an ajv (or equivalent) JSON-schema validator dependency — the reason this group was deferred.
+- **Check 5** — `.ai-sdlc/dor-config.yaml` present + schema-valid against `spec/schemas/dor-config.v1.schema.json` (only when the DoR feature is enabled).
+- **Check 6** — `.ai-sdlc/trusted-reviewers.yaml` present + parseable + ≥1 pubkey; operator signing key (`~/.ai-sdlc/signing-key.pem`) present and its pubkey listed (when attestation enabled). **Add a `trusted-reviewers.schema.json` under `spec/schemas/`** (none exists yet) and wire check 6 to it.
+- **Check 8** — husky pre-push gate wired (`.husky/pre-push` present + references the sign snippet).
+- **Check 9** — feature-flag sanity (AI_SDLC_DEPS_COMPOSITION / AI_SDLC_AUTONOMOUS_ORCHESTRATOR default-ON expectations).
+- **Check 10** — workflow-file presence for enabled features (diff against init-templates).
+
+## Fold-in from AISDLC-578 review (security-reviewer completeness gap)
+
+The `fetchBranchProtectionStatus` helper in `branch-protection-shared.ts` currently surfaces only `requiresPrReady` (+ approving-review + the attestation-direct misconfiguration). The AISDLC-388 contract requires BOTH `ai-sdlc/pr-ready` AND `Backlog Drift` as required contexts. Add a `requiresBacklogDrift` signal so the attestation-governance check (7) fully reflects the required-contexts contract. Read-only (no mutation) — a repo missing `Backlog Drift` should surface as a fail/warn, not be silently classified fully-configured.
+
+## Reuse (do NOT reimplement)
+- The existing `doctor-checks.ts` registry + `DoctorCheckAdapters` (exists/readFile/writeFile/listDir/homeDir/env/runCommand — runCommand now returns optional `stderr`).
+- `spec/schemas/agent-role.schema.json` + `spec/schemas/dor-config.v1.schema.json` (validate with a real JSON-schema validator).
+- The shared `branch-protection-shared.ts` helper for check 7's Backlog-Drift extension.
+
+## Acceptance Criteria
+- [ ] Checks 4, 5, 6, 8, 9, 10 implemented as registry modules with hermetic tests (known-good passes; each seeded misconfig detected with the right severity + remediation).
+- [ ] `trusted-reviewers.schema.json` added under `spec/schemas/` and wired into check 6.
+- [ ] JSON-schema validator dependency added (ajv or equivalent) and used by checks 4/5/6.
+- [ ] `requiresBacklogDrift` signal added to `fetchBranchProtectionStatus`; check 7 flags a repo missing the `Backlog Drift` required context (read-only).
+- [ ] `--fix` extended only where mechanically safe (e.g. add missing husky snippet); never touches `.ai-sdlc/**` content it shouldn't.
+- [ ] `pnpm build && pnpm test && pnpm lint && pnpm format:check` pass.
+
+## Note
+Follow-up to AISDLC-578 (merged via PR #1012). Local audit only — upstream reporting remains the separate RFC-0045 layer (do NOT build phone-home/telemetry here). Composes with the RFC-0045 reporting seam already stubbed in doctor's typed result set.
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/aisdlc-584 - harden-consumer-CI-agent-def-resolution-self-location-fallback-containment-guard-resolution-order-test.md
+++ b/backlog/tasks/aisdlc-584 - harden-consumer-CI-agent-def-resolution-self-location-fallback-containment-guard-resolution-order-test.md
@@ -1,0 +1,53 @@
+---
+id: AISDLC-584
+title: >-
+  doctor/attestation: harden consumer-CI agent-def resolution — self-location
+  fallback + containment-guard symmetry + resolution-order test
+status: To Do
+assignee: []
+created_date: '2026-09-06 03:44'
+labels:
+  - adoption
+  - attestation
+  - pipeline-cli
+  - consumer-repo
+  - aisdlc-583-followup
+dependencies: []
+references:
+  - >-
+    backlog/completed/aisdlc-583 -
+    Fix-cli-attestation-verify-fails-closed-in-consumer-repos-resolve-reviewer-agent-definition-files-from-installed-plugin.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Context
+Follow-up to AISDLC-583 (merged via PR #1013), which fixed `cli-attestation verify` failing closed in consumer repos by resolving reviewer agent-definition files from the installed plugin. All three reviewers APPROVED; these are the non-blocking minor findings they surfaced, consolidated.
+
+**Important scoping:** the `agentFileHash` binding these findings concern is consumed ONLY on the legacy v3/v4/v5 verify path — `runVerifier` returns on the v6 fast-path BEFORE the agent-dir is ever read. v6 (the default schema) is unaffected. So this is defense-in-depth hardening for the shrinking set of adopters still verifying legacy envelopes; it does NOT affect v6 adopters (e.g. local-trades). Prioritize accordingly (medium/low).
+
+## Findings to address
+
+### 1. Self-location fallback for the plugin-script driver (code-reviewer + security-reviewer, convergent)
+`ai-sdlc-plugin/scripts/verify-attestation.mjs`'s `resolvePluginAgentDir` (~line 220) resolves the agent dir ONLY from `CLAUDE_PLUGIN_DIR`/`CLAUDE_PLUGIN_ROOT` env vars — unlike `trustedRuntimeModuleCandidates()`, which also walks up `node_modules` from the script's own on-disk location. Per this PR's own `docs/operations/adopter-attestation-verify-ci.md`, those env vars are absent in the documented plain-CI recipe, so `resolvePluginAgentDir()` returns null on essentially every adopter CI run using this driver → the legacy `agentFileHash` binding downgrades (warned, never false-valid) for ALL reviewers rather than being enforced. Fix EITHER:
+  - (a) add a self-location / node_modules-adjacent `agents/` probe to this driver mirroring the runtime-module fallback — **with a fixture-path guard** to avoid the test-environment false positive the AISDLC-583 dev flagged (self-location resolved the monorepo's real `ai-sdlc-plugin/agents/` instead of the test fixture); OR
+  - (b) update the CI-recipe docs (`docs/operations/adopter-attestation-verify-ci.md`) to explicitly set `CLAUDE_PLUGIN_ROOT` in the plugin-installed recipe so the binding is actually enforceable as documented.
+  Option (a) is the real fix; (b) is the minimum if the fixture-guard proves fiddly.
+
+### 2. Containment-guard symmetry (security-reviewer)
+`pipeline-cli/src/attestation/agent-dir-resolver.ts` `resolveInstalledPluginAgentDir()` has no containment guard, whereas the plugin-script driver applies an `isInsideRepoRoot`-style guard. Non-exploitable (agentDir is only `existsSync`/`readFileSync`'d for fixed `${agentId}.md` hashing, never `import()`ed), but mirroring the guard keeps the two drivers symmetric and prevents a future maintainer from wiring the resolved dir into an executable path without the guard.
+
+### 3. Resolution-order test assertion (test-reviewer)
+`scripts/verify-attestation.test.mjs` (~line 490): add one test that exercises the 'both an injected agentDir AND a repo-relative `ai-sdlc-plugin/agents` exist' case to confirm the injected (installed-plugin) dir WINS. Each current test isolates one tier by rmSync-ing the other, so the precedence branch of `resolveAgentDefinitionDir` is the last untested branch of the resolution-order contract.
+
+## Acceptance Criteria
+- [ ] Plugin-script driver resolves the agent dir in the documented plain-CI recipe (self-location probe with fixture-guard) OR the recipe docs set `CLAUDE_PLUGIN_ROOT` — the legacy `agentFileHash` binding is enforceable (not universally downgraded) for a properly-installed adopter; hermetic tests cover it without the monorepo false-positive.
+- [ ] `resolveInstalledPluginAgentDir()` mirrors the plugin-script driver's containment guard.
+- [ ] A resolution-order test asserts the injected installed-plugin dir wins when both it and the repo-relative dir exist.
+- [ ] `pnpm build && pnpm test && pnpm lint && pnpm format:check` pass.
+
+## References
+Follow-up to AISDLC-583 (PR #1013). Legacy-verify defense-in-depth only; v6 default path unaffected.
+<!-- SECTION:DESCRIPTION:END -->

--- a/backlog/tasks/aisdlc-585 - Deprecate-attestation-schema-versions-v3-v4-v5-warn-on-sign-now-plan-removal-via-RFC-0042-amendment.md
+++ b/backlog/tasks/aisdlc-585 - Deprecate-attestation-schema-versions-v3-v4-v5-warn-on-sign-now-plan-removal-via-RFC-0042-amendment.md
@@ -1,0 +1,50 @@
+---
+id: AISDLC-585
+title: >-
+  Deprecate attestation schema versions v3/v4/v5 — warn on sign now, plan
+  removal via RFC-0042 amendment
+status: To Do
+assignee: []
+created_date: '2026-09-06 04:07'
+labels:
+  - attestation
+  - pipeline-cli
+  - deprecation
+  - rfc-0042
+dependencies: []
+references:
+  - spec/rfcs/RFC-0042-proof-of-execution-attestation.md
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+## Directive
+Operator (2026-09-06): "mark the previous signing signature versions less than v6 as deprecated and no longer support them soon."
+
+## Current state
+- **v6 is the default** signing schema (RFC-0042, since AISDLC-409). v3/v4/v5 signing is opt-in via `--schema-version v5` / `AI_SDLC_V5_LEGACY=1`.
+- Per CLAUDE.md + RFC-0042 **OQ-7**, the v3/v4/v5 **verifier** code is retained READ-ONLY specifically so every historical PR remains auditable. Removing verify support breaks auditability of already-merged PRs; removing SIGN support does not.
+- AISDLC-583's legacy `agentFileHash` binding (and its follow-up AISDLC-584) live entirely on the pre-v6 verify path — if legacy is deprecated/removed, 584's hardening becomes moot (note the linkage).
+
+## Two-phase plan (deprecate ≠ remove)
+
+### Phase A — Deprecate signing NOW (this task, low-risk)
+1. Emit a clear **deprecation warning** whenever a v3/v4/v5 envelope is SIGNED (`--schema-version v3|v4|v5` or `AI_SDLC_V5_LEGACY=1` / legacy `AI_SDLC_V6_CUTOVER_ACTIVE=0`): "schema <v> is deprecated; v6 is the only supported signing schema — see <migration doc>." Point at the transcript-leaf emission prerequisite (the reason legacy opt-in existed).
+2. Docs: mark v5 opt-out as deprecated in CLAUDE.md's "Review attestations" section + the RFC-0042 status, with a target removal window.
+3. Do NOT change the VERIFIER — it must keep reading v3/v4/v5 for historical auditability until the RFC decides otherwise (Phase B).
+
+### Phase B — Remove support (SEPARATE, needs an RFC-0042 amendment / OQ walkthrough — DO NOT self-resolve)
+Removing v3/v4/v5 **verify** support directly contradicts OQ-7's retention decision, so it requires an operator-driven RFC-0042 amendment answering: (a) do we drop the legacy SIGN path entirely; (b) do we drop legacy VERIFY, and if so how do we preserve auditability of already-merged legacy PRs (e.g. one-time re-attestation sweep to v6, or an archived verifier); (c) the removal timeline. This is an architectural/audit-trail decision for the operator, not the implementer.
+
+## Acceptance Criteria (Phase A only)
+- [ ] Signing a v3/v4/v5 envelope emits a deprecation warning naming the schema + pointing to v6 migration; v6 signing is unchanged and silent.
+- [ ] The verifier is UNCHANGED (still reads v3/v4/v5 for historical PRs — OQ-7).
+- [ ] CLAUDE.md + RFC-0042 status note the v3/v4/v5 signing deprecation + a target removal window; Phase B (removal) is explicitly deferred to an RFC-0042 amendment.
+- [ ] Hermetic test asserts the deprecation warning fires on legacy sign and NOT on v6.
+- [ ] `pnpm build && pnpm test && pnpm lint && pnpm format:check` pass.
+
+## References
+RFC-0042 (attestation schema lifecycle, OQ-7 legacy retention). Linked: AISDLC-583/584 (legacy agentFileHash binding — moot if legacy removed).
+<!-- SECTION:DESCRIPTION:END -->


### PR DESCRIPTION
Syncs 4 backlog task files that were filed via MCP into the Pattern-C parent working tree during the doctor/attestation session but never landed on main:

- **AISDLC-581** — cache session-start runtime version check with a TTL (581, low)
- **AISDLC-582** — ai-sdlc doctor remaining seed-catalog checks 4/5/6/8/9/10 + trusted-reviewers schema
- **AISDLC-584** — harden consumer-CI agent-def resolution (583 review minors)
- **AISDLC-585** — deprecate attestation schema v3/v4/v5 (warn-on-sign now, removal via RFC-0042 amendment)

Docs-only (`backlog/` is paths-ignored for attestation/review gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VtN3wGbg8ffee4c1W5Bub