### PR TITLE
chore(backlog): file consumer-produce gaps for /ai-sdlc execute (AISDLC-598..600)

### DIFF
--- a/backlog/tasks/aisdlc-598 - execute consumer-produce sign in-process when not in monorepo.md
+++ b/backlog/tasks/aisdlc-598 - execute consumer-produce sign in-process when not in monorepo.md
@@ -1,0 +1,50 @@
+---
+id: AISDLC-598
+title: >-
+  /ai-sdlc execute — sign the v6 envelope in-process on consumer repos (don't rely on the monorepo pre-push hook)
+status: To Do
+assignee: []
+created_date: '2026-09-07'
+labels:
+  - pipeline-cli
+  - execute
+  - attestation
+  - adopter
+  - consumer-produce
+dependencies: []
+references:
+  - ai-sdlc-plugin/commands/execute.md
+  - pipeline-cli/bin/cli-attestation.mjs
+  - scripts/check-attestation-sign.sh
+priority: high
+dispatchable: true
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+**Gap 1 of the consumer-produce triage (2026-09-07, observed running `/ai-sdlc execute LT-469` in the local-trades adopter repo, plugin v0.18.0).**
+
+`/ai-sdlc execute` (AISDLC-133) deliberately does NOT sign the DSSE envelope in-line at Step 10/11. It writes a verdict file and relies on the **monorepo's husky `pre-push` hook** (`.husky/pre-push` → `scripts/check-attestation-sign.sh`) to sign the v6 envelope at push time and commit it as a chore.
+
+In a consumer/adopter repo, `.husky/pre-push` is the **adopter's own** hook (in local-trades it runs `pnpm -r test:coverage`), NOT the monorepo attestation-signer. So Step 11's push produces **no envelope**, and `verify-attestation` (fixed for consumers as of pipeline-cli 0.21.0 / AISDLC-583) is red because there is nothing to verify. There is currently no code path in `execute` that signs the envelope itself in a consumer.
+
+Net adopter impact: `execute` runs dev + reviewer fan-out fine, but cannot produce a v6 attestation that `verify-attestation` accepts without manual coordinator intervention — the dispatch works but the gate the dispatch exists to feed does not.
+
+## Scope
+- Add a consumer-repo signing path to `execute` (Step 10.5 / 11): when the push path does NOT carry the monorepo's `check-attestation-sign.sh` signer, `execute` signs the v6 envelope directly via `cli-attestation sign-v6` before push. The signing is deterministic and the command already knows the head SHA + task-id.
+- **Detection, not env-flag:** decide "am I the monorepo?" by probing whether the attestation-signer is actually on the push path (e.g. `scripts/check-attestation-sign.sh` reachable from the repo's `.husky/pre-push`), NOT by hardcoding a monorepo assumption. In the monorepo, keep delegating to the hook (no double-sign). Signing MUST be idempotent / mutually exclusive with the hook so the monorepo path is unchanged.
+- After in-process sign, run the same `verify-attestation` (with `PR_HEAD_SHA`/`PR_BASE_SHA`) the operator would run, so `execute` fails loudly in the consumer if its own produce is red — rather than pushing an unverifiable state.
+- Ensure the signed envelope is committed on the branch before push (mirror the monorepo chore-commit, `--no-verify` as the hook does), respecting the CI-skip-token and `.ai-sdlc/attestations/**` write rules.
+
+## Acceptance Criteria
+- [ ] Running `/ai-sdlc execute <task>` in a consumer repo (no monorepo pre-push signer) produces a committed v6 DSSE envelope that `verify-attestation` accepts, with zero manual coordinator steps.
+- [ ] In the monorepo, behaviour is unchanged: the pre-push hook still signs; `execute` does NOT double-sign (detection correctly identifies the monorepo push path).
+- [ ] `execute` runs `verify-attestation` on its own produce and aborts with an actionable message if red (no unverifiable push).
+- [ ] Detection is push-path-probe based, not a hardcoded monorepo check or a new operator env flag.
+- [ ] Hermetic/integration coverage for both topologies (monorepo delegates; consumer self-signs) including the negative "verify red → abort" case.
+- [ ] `pnpm build && pnpm test && pnpm lint && pnpm format:check` pass.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Notes
+Composes with AISDLC-599 (reviewer transcripts/verdicts must exist under `.ai-sdlc/` for `emit-leaf` to feed `sign-v6`) and AISDLC-600 (runtime pin so the in-process signer is 0.23.0 and stamps `independent`). Also see the two separately-filed produce-flow issues: worktree-topology `harnessTranscriptHash=null` (verdictClass self-authored) and the `sign-v6` per-patch-id vs shared `transcript-leaves.jsonl` fallback divergence — both are on the same produce path this task touches.

--- a/backlog/tasks/aisdlc-599 - execute writes reviewer transcripts verdicts itself not via blocked subagents.md
+++ b/backlog/tasks/aisdlc-599 - execute writes reviewer transcripts verdicts itself not via blocked subagents.md
@@ -1,0 +1,53 @@
+---
+id: AISDLC-599
+title: >-
+  /ai-sdlc execute — coordinator writes reviewer transcripts/verdicts under .ai-sdlc/ itself (reviewer subagents are blocked from it)
+status: To Do
+assignee: []
+created_date: '2026-09-07'
+labels:
+  - pipeline-cli
+  - execute
+  - attestation
+  - governance
+  - adopter
+  - consumer-produce
+dependencies: []
+references:
+  - ai-sdlc-plugin/commands/execute.md
+  - ai-sdlc-plugin/hooks/enforce-blocked-actions.js
+  - pipeline-cli/bin/cli-attestation.mjs
+priority: high
+dispatchable: true
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+**Gap 2 of the consumer-produce triage (2026-09-07, `/ai-sdlc execute LT-469` in local-trades).**
+
+Step 7c of `execute` reads each reviewer's transcript from `<worktree>/.ai-sdlc/transcripts/<task>/<agent>.jsonl` and verdict from `<worktree>/.ai-sdlc/verdicts/<agent>-<task>.json`, then `emit-leaf`s them so `sign-v6` has leaves to sign. Those files are meant to be written by the reviewer subagents.
+
+But the plugin's OWN `enforce-blocked-actions.js` PreToolUse hook **hard-refuses any Write/Edit under `.ai-sdlc/**` — including from the reviewer subagents `execute` just spawned.** So in a consumer repo the reviewers cannot write their transcript/verdict to the path Step 7c reads → `emit-leaf` finds nothing → no leaves → `sign-v6` has nothing to sign.
+
+The manual consumer workaround proven in local-trades: the reviewer's real transcript is the harness-captured `~/.claude/projects/<proj>/subagents/agent-<id>.jsonl`; the coordinator (main session, exempt from the subagent write-block) copies it into `<worktree>/.ai-sdlc/transcripts/...` via `cp` (Bash `cp` is permitted — governance blocks the Write/Edit *tools*, not the shell) and writes the verdict JSON, then `emit-leaf`s. That is what `execute` should do natively.
+
+## Scope
+- After the reviewer subagents return, have `execute` (the main session, exempt from the subagent `.ai-sdlc/**` write-block) itself:
+  - copy each reviewer's harness-captured transcript (`~/.claude/projects/<proj>/subagents/agent-<id>.jsonl`) into `<worktree>/.ai-sdlc/transcripts/<task>/<agent>.jsonl`, and
+  - write each verdict JSON to `<worktree>/.ai-sdlc/verdicts/<agent>-<task>.json`,
+  before `emit-leaf`. Do NOT rely on reviewer subagents to write under `.ai-sdlc/`.
+- Resolve each spawned reviewer's harness transcript path reliably (map agent-id → `subagents/agent-<id>.jsonl`), including the worktree project-dir topology `execute` uses. (Coordinate with the separately-filed `emit-leaf` worktree-topology issue that derives the wrong Claude project dir → `harnessTranscriptHash=null`.)
+- Preferred over narrowly exempting `.ai-sdlc/transcripts/` + `.ai-sdlc/verdicts/` from the subagent write-block (option b in the triage): keeping the config-dir write-block absolute is the safer governance posture, and coordinator-writes matches how a consumer coordinator has to do it anyway. If option (b) is chosen instead, the exemption MUST be narrow (those two subtrees only) and justified.
+
+## Acceptance Criteria
+- [ ] In a consumer repo, after the 3 reviewers return, `execute` populates `.ai-sdlc/transcripts/` + `.ai-sdlc/verdicts/` itself and `emit-leaf` finds all three leaves — no reviewer subagent writes under `.ai-sdlc/`.
+- [ ] The `enforce-blocked-actions.js` `.ai-sdlc/**` Write/Edit block remains in force for subagents (unchanged), OR (if option b) is narrowed to exactly the two produce subtrees with a documented rationale.
+- [ ] Each reviewer's harness transcript path is resolved correctly under the worktree topology `execute` uses (no `harnessTranscriptHash=null` from a mis-derived project dir).
+- [ ] `sign-v6` signs a 3-leaf envelope that `verify-attestation` accepts, produced with zero manual coordinator file-copies.
+- [ ] Hermetic/integration coverage for the coordinator-writes path incl. the negative (subagent attempt to write `.ai-sdlc/` still refused).
+- [ ] `pnpm build && pnpm test && pnpm lint && pnpm format:check` pass.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Notes
+Composes with AISDLC-598 (in-process sign consumes these leaves) and AISDLC-600 (runtime pin). This is the produce-side counterpart to the already-fixed verify path (AISDLC-583) and the RFC-0047 independence work (0.23.0).

--- a/backlog/tasks/aisdlc-600 - bump install-runtime-deps pin to current runtime.md
+++ b/backlog/tasks/aisdlc-600 - bump install-runtime-deps pin to current runtime.md
@@ -1,0 +1,44 @@
+---
+id: AISDLC-600
+title: >-
+  Bump install-runtime-deps.sh pipeline-cli pin to the current runtime (off the caret-0.x trap) so execute's produce stamps independent
+status: To Do
+assignee: []
+created_date: '2026-09-07'
+labels:
+  - pipeline-cli
+  - plugin
+  - runtime-pin
+  - adopter
+  - consumer-produce
+dependencies: []
+references:
+  - ai-sdlc-plugin/scripts/install-runtime-deps.sh
+  - scripts/sync-plugin-runtime-deps.mjs
+priority: high
+dispatchable: true
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+**Gap 3 of the consumer-produce triage (2026-09-07, local-trades).**
+
+`ai-sdlc-plugin/scripts/install-runtime-deps.sh` pins `@ai-sdlc/pipeline-cli@^0.10.0`. The self-heal resolved the plugin `node_modules` to **0.21.0** while npm's latest is **0.23.0**. 0.21.0 has `cli-attestation` + the consumer verify fix (AISDLC-583) but NOT the RFC-0047 independence tier (0.23.0) — so a `/ai-sdlc execute` produce that uses `$PIPELINE_CLI_BIN` (the plugin runtime) stamps `verdictClass=self-authored` even when the marker is present, where 0.23.0 would stamp `independent`. (The triage was only able to get `independent` by producing with a *globally*-installed 0.23.0.)
+
+The `^0.10.0` caret on a 0.x line is the AISDLC-574 caret-0.x trap: `^0.x` does NOT allow `0.(x+1)`, so the pin can never float past the minor it was written at without a manual bump.
+
+## Scope
+- Update `install-runtime-deps.sh`'s pin to track the current published runtime (`>=0.23` or an equivalent range that floats forward on 0.x minors — do NOT reintroduce a `^0.x` caret that traps at one minor, per AISDLC-574).
+- Verify `scripts/sync-plugin-runtime-deps.mjs` (the AISDLC-574 pin-sync gate) keeps this pin coherent with the release-please version on future releases, so this doesn't silently drift again (recall `feedback_release_pr_needs_manual_pin_sync`).
+- Re-check any other `^0.x` pipeline-cli pins in the plugin's install/runtime scripts for the same caret-0.x trap while here.
+
+## Acceptance Criteria
+- [ ] `install-runtime-deps.sh` self-heals the plugin `node_modules` to the current runtime (>=0.23.0), so `execute`'s produce path stamps `independent` (marker present) without the operator swapping in a global install.
+- [ ] The pin range floats forward on future 0.x minor releases (not caret-trapped at one minor); AISDLC-574 pin-sync keeps it coherent with release-please.
+- [ ] No remaining `^0.x` pipeline-cli caret pins in plugin install/runtime scripts.
+- [ ] `pnpm build && pnpm test && pnpm lint && pnpm format:check` pass.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Notes
+Independent of AISDLC-598/599 (a pure pin bump) but they compose: 598 signs in-process, 599 supplies the leaves, and this ensures the runtime doing both is 0.23.0 so the result is `independent`, not `self-authored`. Gap 4 of the triage (monorepo-shaped Step 0/0.5 — `check-orchestrator-state.sh` hard-reset assumption, Pattern-C read-only contract, `sync-parent` aisdlc-N prefix) is lower severity and NOT filed here; capture separately if it becomes an adopter blocker.


### PR DESCRIPTION
## Summary

Triage from running `/ai-sdlc execute LT-469` end-to-end in the **local-trades** adopter repo (plugin v0.18.0). `execute` dispatches fine in a consumer — path resolution, sweep, preflight, worktree/sentinel, developer + reviewer fan-out, classify/nonce all work — but the **produce** wiring is monorepo-shaped and can't emit a v6 attestation `verify-attestation` accepts without manual coordinator intervention. Adopters get the dispatch but not the gate it exists to feed.

This PR files the three actionable produce-wiring gaps as backlog tasks (docs-only). Verify-side is already fixed (AISDLC-583, 0.21.0) and independence is unforgeable (RFC-0047, 0.23.0); these are the remaining ~10%.

## Tasks filed

| ID | Gap | Fix direction |
|----|-----|---------------|
| **AISDLC-598** | Step 10/11 signs via the monorepo `.husky/pre-push` hook consumers don't have → no envelope, verify red | `execute` signs in-process via `cli-attestation sign-v6` when the monorepo signer isn't on the push path (detection, not env-flag); verify its own produce before push |
| **AISDLC-599** | Reviewer subagents are hard-blocked from `.ai-sdlc/**` by the plugin's own `enforce-blocked-actions` hook → no transcripts/verdicts → `emit-leaf` finds nothing | Coordinator (main session, exempt) copies harness transcripts + writes verdicts under `.ai-sdlc/` itself after reviewers return |
| **AISDLC-600** | `install-runtime-deps.sh` pins `^0.10.0` (caret-0.x trap, AISDLC-574); self-heals to 0.21.0 → produce stamps `self-authored` not `independent` | Bump the pin to float forward to current runtime (>=0.23) so produce stamps `independent` natively |

## Not filed here
- **Gap 4** (monorepo-shaped Step 0/0.5 — `check-orchestrator-state.sh` hard-reset, Pattern-C read-only assumption, `sync-parent` aisdlc-N prefix) — lower severity, noted in AISDLC-600; capture separately if it becomes an adopter blocker.
- Two produce-flow issues already filed separately (worktree-topology `harnessTranscriptHash=null`; `sign-v6` per-patch-id vs shared `transcript-leaves.jsonl` fallback) — cross-referenced from 598/599.

## Verification
- [x] `npx backlog-drift check` — no errors
- [x] IDs 598–600 free (max on main/worktrees/open-PRs was 597)
- [x] Docs-only (`backlog/tasks/**`) — no attestation required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VtN3wGbg8ffee4c1W5Bub