### PR TITLE
chore(backlog): governance hard-rules configurability (AISDLC-601..602)

### DIFF
--- a/backlog/tasks/aisdlc-601 - governance hard-rules driven from agent-role yaml render into session and subagent hooks.md
+++ b/backlog/tasks/aisdlc-601 - governance hard-rules driven from agent-role yaml render into session and subagent hooks.md
@@ -1,0 +1,95 @@
+---
+id: AISDLC-601
+title: >-
+  Governance hard-rules: single per-repo source of truth in agent-role.yaml, rendered into session-start + subagent-start (defaults strict)
+status: To Do
+assignee: []
+created_date: '2026-09-07'
+labels:
+  - plugin
+  - governance
+  - agent-role
+  - adopter
+  - hooks
+dependencies: []
+references:
+  - ai-sdlc-plugin/hooks/session-start.js
+  - ai-sdlc-plugin/hooks/subagent-start.js
+  - ai-sdlc-plugin/hooks/enforce-blocked-actions.js
+  - .ai-sdlc/agent-role.yaml
+priority: high
+dispatchable: true
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+**Triage 2026-09-07 (local-trades adopter, plugin 0.19.0).** The plugin injects a
+FIXED set of governance hard rules ("NEVER merge PRs. Only humans merge.", "NEVER
+force push.", "NEVER close issues or PRs.", …) into every session
+(`session-start.js`) and every subagent (`subagent-start.js`), verbatim, regardless
+of the consumer repo's own policy. An adopter cannot change these without patching
+the framework — which the framework itself tells adopters not to do — so the
+injected rule can directly contradict a policy the repo's operator deliberately
+chose.
+
+**The mechanism already half-exists:** `.ai-sdlc/agent-role.yaml` already carries
+per-repo `spec.blockedActions` / `spec.blockedPaths`, and all three hooks
+(`session-start.js`, `subagent-start.js`, `enforce-blocked-actions.js`) already read
+it. But the injected hard-rule *prose* is hard-coded string constants that don't
+derive from that policy — so the narration and the enforcement have drifted apart
+(e.g. the prose says "never merge PRs" while `blockedActions: git merge*` doesn't
+even match `gh pr merge`).
+
+**Chosen fix direction (operator, 2026-09-07): Option 1 — one per-repo policy source
+of truth, rendered into every governance surface, defaults strict.** This task owns
+the source-of-truth schema + resolver + the two HOOK render surfaces. AISDLC-602
+owns the execute-command render surfaces + reconciling `enforce-blocked-actions.js`.
+
+## Scope
+- Extend `.ai-sdlc/agent-role.yaml` schema with a `spec.governance` (or `hardRules`)
+  section enumerating the canonical hard rules (merge / force-push / close-pr-issue /
+  branch-delete / git-reset-hard / ci-skip-tokens / edit-.ai-sdlc) with STRICT
+  defaults. Absent/omitted section ⇒ current strict behavior (existing adopters
+  unchanged, byte-for-byte where practical).
+- Add a small resolver (shared, testable) that merges the repo's declared governance
+  with the strict defaults into a resolved policy object.
+- Render the injected hard-rule text in BOTH `session-start.js` and
+  `subagent-start.js` FROM the resolved policy, not string constants. A repo that
+  sets e.g. `governance.allowMerge: onGreenClean` (or removes the merge rule) sees
+  the softened/removed rule in the injected banner; a repo that sets nothing sees the
+  current strict text.
+- **Trust/authorization constraint (load-bearing):** the governance policy is only
+  honored from the repo's own trusted `.ai-sdlc/agent-role.yaml` on the base branch —
+  NEVER from PR-modified config supplied by an untrusted contributor (RFC-0043
+  sandbox path). A relaxation must not be settable by the party being governed. Verify
+  how the hooks resolve the config path and preserve this boundary (default to
+  base-branch/operator-filesystem config; do not read PR-tree overrides for
+  untrusted PRs).
+- Hermetic tests: strict-by-default banner when section absent; softened banner when
+  a rule is relaxed; rule-removed case; malformed governance section fails closed to
+  strict.
+
+## Acceptance Criteria
+- [ ] `agent-role.yaml` supports a `governance`/`hardRules` section with strict
+  defaults; omitting it reproduces today's injected hard-rule text.
+- [ ] `session-start.js` and `subagent-start.js` render the hard-rule block from the
+  resolved policy (no hard-coded rule strings for the configurable rules).
+- [ ] A repo that opts into `allowMerge: onGreenClean` (or removes the merge rule)
+  sees that reflected in BOTH injected banners; a repo with no governance section is
+  unchanged.
+- [ ] Untrusted-source config cannot relax a hard rule (policy resolved only from the
+  trusted base-branch/operator config, never PR-modified config).
+- [ ] Malformed/unknown governance keys fail CLOSED to strict.
+- [ ] `pnpm build && pnpm test && pnpm lint && pnpm format:check` pass (hooks use
+  `node --test`).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Notes
+Composes with [[AISDLC-602]] (execute-command render + `enforce-blocked-actions.js`
+reconciliation). Guardrail the fix must preserve: merge-on-green must still be
+expressible as "green + CLEAN" gated on the repo's actual CI checks (verify-attestation,
+migration-mutation-gate, etc.) — configurable, not unguarded. NOTE: this touches the
+trust-chain guardrails (never-merge/never-force-push are load-bearing); if the operator
+prefers, the design (schema shape, trust boundary, preset layer) can be resolved via an
+RFC/OQ walkthrough before implementation rather than settled in-task.

--- a/backlog/tasks/aisdlc-602 - render governance policy into execute hard-rules and reconcile enforce-blocked-actions.md
+++ b/backlog/tasks/aisdlc-602 - render governance policy into execute hard-rules and reconcile enforce-blocked-actions.md
@@ -1,0 +1,85 @@
+---
+id: AISDLC-602
+title: >-
+  Governance hard-rules: render resolved policy into execute/execute-parallel hard-rules + reconcile enforce-blocked-actions (fix gh-pr-merge drift)
+status: To Do
+assignee: []
+created_date: '2026-09-07'
+labels:
+  - plugin
+  - governance
+  - agent-role
+  - execute
+  - adopter
+dependencies:
+  - AISDLC-601
+references:
+  - ai-sdlc-plugin/commands/execute.md
+  - ai-sdlc-plugin/commands/execute-parallel.md
+  - ai-sdlc-plugin/hooks/enforce-blocked-actions.js
+priority: high
+dispatchable: true
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+**Triage 2026-09-07 (local-trades adopter, plugin 0.19.0).** Second half of the
+governance-configurability fix (Option 1). AISDLC-601 established the per-repo
+governance source of truth in `agent-role.yaml` + the resolver + rendering into the
+two hooks. This task makes the remaining governance surfaces agree with that same
+resolved policy and fixes the narration/enforcement drift.
+
+**Two surfaces still hard-code the rules:**
+- `ai-sdlc-plugin/commands/execute.md` + `execute-parallel.md` — the "Hard rules
+  (NEVER violate)" block (Never merge any PR / Never force-push / Never close / Never
+  delete branches / Never `git reset --hard` / …) is literal prose in the command
+  body.
+- `enforce-blocked-actions.js` — enforces `blockedActions` patterns against Bash
+  commands, but the injected prose asserts "NEVER merge PRs" while
+  `blockedActions: git merge*` only matches a LOCAL `git merge`, NOT `gh pr merge`.
+  So the rule the prose asserts most loudly isn't actually enforced by the hook.
+
+## Scope
+- Render the execute / execute-parallel "Hard rules" block FROM the resolved
+  governance policy (AISDLC-601's resolver), so a repo that opts into
+  `allowMerge: onGreenClean` (or removes the merge rule) gets a consistent hard-rule
+  block, and a repo with no governance section is unchanged (strict).
+- Reconcile `enforce-blocked-actions.js` so the merge rule is actually ENFORCED
+  consistently with the narration: when the resolved policy forbids agent merge, the
+  hook must block `gh pr merge` (and `gh pr merge --auto` vs. the arming case — note
+  arming `--auto` is NOT merging and must stay allowed under strict, per current
+  CLAUDE.md); when the policy permits merge-on-green, the hook allows it. Fix the
+  existing `git merge*`-doesn't-cover-`gh pr merge` gap either way.
+- **Preserve the green+CLEAN guardrail:** the merge-on-green policy must be
+  expressible/enforced as "all required CI checks green AND mergeStateStatus CLEAN"
+  (including the repo's real gates: verify-attestation, migration-mutation-gate,
+  workflow-secret-scope-gate, ci), so opting into agent-merge removes only the
+  "human must click" step, not any safety gate. Decide + document where the
+  green+CLEAN check lives (command-body precondition vs. a helper) so it can't be
+  skipped.
+- Keep defaults STRICT: with no governance section, execute's hard rules + the hook
+  behave exactly as today (never-merge/never-force-push/never-close/etc.).
+- Hermetic coverage: strict default (merge blocked incl. `gh pr merge`); opted-in
+  merge-on-green (merge allowed only when green+CLEAN, blocked otherwise); arming
+  `--auto` stays allowed under strict.
+
+## Acceptance Criteria
+- [ ] execute.md + execute-parallel.md hard-rule blocks render from the resolved
+  governance policy; no governance section ⇒ current strict text unchanged.
+- [ ] `enforce-blocked-actions.js` enforces the merge rule consistently with the
+  narration — blocks `gh pr merge` under strict (closing the `git merge*` gap),
+  allows it under an opted-in merge-on-green policy, and still allows arming
+  `--auto`.
+- [ ] Merge-on-green is gated on "all required checks green AND CLEAN" (the repo's
+  real gates), documented and un-skippable.
+- [ ] Defaults strict end-to-end across SessionStart banner (601), SubagentStart
+  banner (601), execute hard-rules (this task), and the PreToolUse hook (this task).
+- [ ] `pnpm build && pnpm test && pnpm lint && pnpm format:check` pass.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Notes
+Depends on [[AISDLC-601]] (shares its resolver). Together these fix the existing
+inconsistency where the injected prose and `agent-role.yaml` can already disagree,
+and give an adopter one per-repo policy source of truth rendered into every surface.
+Trust boundary from 601 applies: policy honored only from trusted base-branch config.


### PR DESCRIPTION
## Summary
Triage from local-trades (plugin 0.19.0): the plugin injects a **fixed** set of governance hard-rules ("NEVER merge PRs. Only humans merge.", "NEVER force push.", "NEVER close…") into every session (`session-start.js`), subagent (`subagent-start.js`), and `execute`/`execute-parallel` command — verbatim, regardless of the repo's own policy. An adopter can't change them without forking the framework (which the framework tells adopters not to do). Meanwhile the enforcement substrate (`agent-role.yaml` `blockedActions`) is **already** per-repo, so narration and enforcement have drifted: the prose asserts "never merge PRs" while `blockedActions: git merge*` doesn't even match `gh pr merge`.

**Operator chose Option 1:** one per-repo policy source of truth in `agent-role.yaml`, rendered into every governance surface, **defaults strict** (existing adopters unchanged).

## Tasks filed
| ID | Scope |
|----|-------|
| **AISDLC-601** | `agent-role.yaml` `governance`/`hardRules` section + resolver + strict defaults; render the injected hard-rule text in `session-start.js` + `subagent-start.js` from the resolved policy. Trust boundary: policy honored only from trusted base-branch config, never PR-modified config. |
| **AISDLC-602** (dep 601) | Render the same policy into `execute`/`execute-parallel` hard-rule blocks + reconcile `enforce-blocked-actions.js` so the merge rule is actually enforced (block `gh pr merge` under strict — closing the `git merge*` gap — allow under opted-in merge-on-green). |

## Guardrails baked in
- **Defaults strict** — no governance section ⇒ today's behavior, byte-for-byte where practical.
- **green+CLEAN** — merge-on-green must stay gated on the repo's real CI checks (verify-attestation, migration-mutation-gate, workflow-secret-scope-gate, ci) + `mergeStateStatus == CLEAN`; opting in removes only the "human clicks merge" step, not any safety gate.
- **Trust boundary** — a relaxation must not be settable by the party being governed (untrusted contributor PRs); resolve policy from trusted base-branch/operator config only.

## Note for the operator
This touches the **trust-chain guardrails** (never-merge/never-force-push are load-bearing). Both tasks are dispatchable as filed, but if you'd prefer the design (schema shape, trust boundary, preset layer, exact green+CLEAN enforcement point) resolved via an **RFC/OQ walkthrough** before implementation, say so and I'll mint the RFC instead of driving the tasks directly.

## Verification
- [x] `npx backlog-drift check` — no errors
- [x] IDs 601–602 free (max on main/worktrees/open-PRs was 600)
- [x] Docs-only (`backlog/tasks/**`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VtN3wGbg8ffee4c1W5Bub